### PR TITLE
Update to Meeting Schedule PDF

### DIFF
--- a/includes/pdf.php
+++ b/includes/pdf.php
@@ -129,7 +129,7 @@ if (!class_exists('TSMLPDF')) {
                 //line two
                 $this->Cell($day_width, .1, '', 0, 0);
                 $this->Cell($time_width, .1, $types);
-                $this->MultiCell($right_width, .1, $location . ' ' . tsml_format_address(@$meeting['formatted_address'], false), 0, 'L');
+                $this->MultiCell($right_width, .1, $location . ', ' . @$meeting['formatted_address'], 0, 'L');
                 $this->Ln(.1);
 
             }

--- a/includes/pdf.php
+++ b/includes/pdf.php
@@ -88,9 +88,6 @@ if (!class_exists('TSMLPDF')) {
 
                 //format meeting name and group
                 $meeting_name = strtoupper($meeting['name']);
-                if (!empty($meeting['group'])) {
-                    $meeting_name .= ' ' . $meeting['group'];
-                }
 
                 //format types
                 $types = '';
@@ -132,7 +129,7 @@ if (!class_exists('TSMLPDF')) {
                 //line two
                 $this->Cell($day_width, .1, '', 0, 0);
                 $this->Cell($time_width, .1, $types);
-                $this->MultiCell($right_width, .1, $location . ' ' . tsml_format_address(@$meeting['formatted_address'], true), 0, 'L');
+                $this->MultiCell($right_width, .1, $location . ' ' . tsml_format_address(@$meeting['formatted_address'] . ', ' . @$meeting['city'], true), 0, 'L');
                 $this->Ln(.1);
 
             }

--- a/includes/pdf.php
+++ b/includes/pdf.php
@@ -88,6 +88,9 @@ if (!class_exists('TSMLPDF')) {
 
                 //format meeting name and group
                 $meeting_name = strtoupper($meeting['name']);
+                if (!empty($meeting['group']) && $meeting['name'] != $meeting['group']) {
+                    $meeting_name .= ' ' . $meeting['group'];
+                }
 
                 //format types
                 $types = '';

--- a/includes/pdf.php
+++ b/includes/pdf.php
@@ -129,7 +129,7 @@ if (!class_exists('TSMLPDF')) {
                 //line two
                 $this->Cell($day_width, .1, '', 0, 0);
                 $this->Cell($time_width, .1, $types);
-                $this->MultiCell($right_width, .1, $location . ' ' . tsml_format_address(@$meeting['formatted_address'] . ', ' . @$meeting['city'], true), 0, 'L');
+                $this->MultiCell($right_width, .1, $location . ' ' . tsml_format_address(@$meeting['formatted_address'], false), 0, 'L');
                 $this->Ln(.1);
 
             }


### PR DESCRIPTION
I've updated the meeting schedule PDF generator to only include group name if necessary and to include the full address of the meeting location.  This helps reduce unnecessary usage of space and allows people to find meetings in counties where there are multiple towns with the same street name within a county.