### PR TITLE
Mostly Documentation Changes

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
 Description: Manage a list of recovery meetings
 Version: 3.4.20
 Author: AA Web Servant
-Author URI: https://github.com/meeting-guide/12-step-meeting-list
+Author URI: https://github.com/code4recovery/12-step-meeting-list
 Text Domain: 12-step-meeting-list
  */
 

--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -765,6 +765,12 @@ function tmsl_import_page() {
 										<input type="submit" class="button" value="<?php _e('Add', '12-step-meeting-list')?>">
 									</div>
 								</form>
+							<?php } else {?>
+								<details>
+									<summary><strong><?php _e('Public Feed', '12-step-meeting-list')?></strong></summary>
+									<p><?php _e('The following feed contains your publicly available meeting information.')?></p>
+								</details>
+								<?php printf(__('<a class="public_feed" href="%s" target="_blank">Public Data Source</a>.', '12-step-meeting-list'), admin_url('admin-ajax.php?action=meetings'))?>
 							<?php }?>
 
 							<details>

--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -716,7 +716,7 @@ function tmsl_import_page() {
 							<form method="post" action="<?php echo $_SERVER['REQUEST_URI']?>">
 								<details>
 									<summary><strong><?php _e('Sharing', '12-step-meeting-list')?></strong></summary>
-									<p><?php printf(__('You can share your meeting information with other websites and apps via your <a href="%s" target="_blank">meetings feed</a>.', '12-step-meeting-list'), admin_url('admin-ajax.php?action=meetings'))?></p>
+									<p><?php printf(__('Open means your feeds are available publicly. Restricted means people need a key or to be logged in to get the feed.'))?></p>
 								</details>
 								<?php wp_nonce_field($tsml_nonce, 'tsml_nonce', false)?>
 								<select name="tsml_sharing" onchange="this.form.submit()">
@@ -770,7 +770,7 @@ function tmsl_import_page() {
 									<summary><strong><?php _e('Public Feed', '12-step-meeting-list')?></strong></summary>
 									<p><?php _e('The following feed contains your publicly available meeting information.')?></p>
 								</details>
-								<?php printf(__('<a class="public_feed" href="%s" target="_blank">Public Data Source</a>.', '12-step-meeting-list'), admin_url('admin-ajax.php?action=meetings'))?>
+								<?php printf(__('<a class="public_feed" href="%s" target="_blank">Public Data Source</a>', '12-step-meeting-list'), admin_url('admin-ajax.php?action=meetings'))?>
 							<?php }?>
 
 							<details>

--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -716,7 +716,7 @@ function tmsl_import_page() {
 							<form method="post" action="<?php echo $_SERVER['REQUEST_URI']?>">
 								<details>
 									<summary><strong><?php _e('Sharing', '12-step-meeting-list')?></strong></summary>
-									<p><?php printf(__('Open means your feeds are available publicly. Restricted means people need a key or to be logged in to get the feed.'))?></p>
+									<p><?php printf(__('Open means your feeds are available publicly. Restricted means people need a key or to be logged in to get the feed.', '12-step-meeting-list'))?></p>
 								</details>
 								<?php wp_nonce_field($tsml_nonce, 'tsml_nonce', false)?>
 								<select name="tsml_sharing" onchange="this.form.submit()">
@@ -733,7 +733,7 @@ function tmsl_import_page() {
 							<?php if ($tsml_sharing == 'restricted') {?>
 								<details>
 									<summary><strong><?php _e('Authorized Apps', '12-step-meeting-list')?></strong></summary>
-									<p><?php _e('You may allow access to your meeting data for specific purposes, such as the <a target="_blank" href="https://meetingguide.org/">Meeting Guide App</a>.')?></p>
+									<p><?php _e('You may allow access to your meeting data for specific purposes, such as the <a target="_blank" href="https://meetingguide.org/">Meeting Guide App</a>.', '12-step-meeting-list')?></p>
 								</details>
 								<?php if (count($tsml_sharing_keys)) {?>
 									<table class="tsml_sharing_list">
@@ -759,7 +759,7 @@ function tmsl_import_page() {
 								<form class="columns" method="post" action="<?php echo $_SERVER['REQUEST_URI']?>">
 									<?php wp_nonce_field($tsml_nonce, 'tsml_nonce', false)?>
 									<div class="input">
-										<input type="text" name="tsml_add_sharing_key" placeholder="<?php _e('Meeting Guide')?>">
+										<input type="text" name="tsml_add_sharing_key" placeholder="<?php _e('Meeting Guide', '12-step-meeting-list')?>">
 									</div>
 									<div class="btn">
 										<input type="submit" class="button" value="<?php _e('Add', '12-step-meeting-list')?>">

--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -558,7 +558,7 @@ function tmsl_import_page() {
 						<div class="inside">
 							<h3><?php _e('Data Sources', '12-step-meeting-list')?></h3>
 							<p><?php printf(__('Data sources are JSON feeds that contain a website\'s public meeting data. They can be used to aggregate meetings from different sites into a single master list. 
-								The data source for this website is <a href="%s" target="_blank">right here</a>. More information is available at the <a href="%s" target="_blank">Meeting Guide API Specification</a>.', '12-step-meeting-list'), admin_url('admin-ajax.php') . '?action=meetings', 'https://github.com/meeting-guide/spec')?></p>
+								Data sources listed below will pull meeting information into this website. More information is available at the <a href="%s" target="_blank">Meeting Guide API Specification</a>.', '12-step-meeting-list'), 'https://github.com/code4recovery/spec')?></p>
 							<?php if (!empty($tsml_data_sources)) {?>
 							<table>
 								<thead>

--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -733,7 +733,7 @@ function tmsl_import_page() {
 							<?php if ($tsml_sharing == 'restricted') {?>
 								<details>
 									<summary><strong><?php _e('Authorized Apps', '12-step-meeting-list')?></strong></summary>
-									<p><?php _e('You may allow access to your meeting data for specific purposes, such as the <a target="_blank" href="https://meetingguide.org/">Meeting Guide App</a>.')?>
+									<p><?php _e('You may allow access to your meeting data for specific purposes, such as the <a target="_blank" href="https://meetingguide.org/">Meeting Guide App</a>.')?></p>
 								</details>
 								<?php if (count($tsml_sharing_keys)) {?>
 									<table class="tsml_sharing_list">
@@ -744,7 +744,7 @@ function tmsl_import_page() {
 											));
 										?>
 										<tr>
-											<td><a href="<?php echo $address?>" target="_blank"><?php echo $name?></td>
+											<td><a href="<?php echo $address?>" target="_blank"><?php echo $name?></a></td>
 											<td>
 												<form method="post" action="<?php echo $_SERVER['REQUEST_URI']?>">
 													<?php wp_nonce_field($tsml_nonce, 'tsml_nonce', false)?>

--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -768,7 +768,7 @@ function tmsl_import_page() {
 							<?php } else {?>
 								<details>
 									<summary><strong><?php _e('Public Feed', '12-step-meeting-list')?></strong></summary>
-									<p><?php _e('The following feed contains your publicly available meeting information.')?></p>
+									<p><?php _e('The following feed contains your publicly available meeting information.', '12-step-meeting-list')?></p>
 								</details>
 								<?php printf(__('<a class="public_feed" href="%s" target="_blank">Public Data Source</a>', '12-step-meeting-list'), admin_url('admin-ajax.php?action=meetings'))?>
 							<?php }?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -469,7 +469,7 @@ function tsml_format_utf8(&$item, $key) {
 }
 
 //function: display meeting list on home page (must be set to a static page)
-//used:		by themes that want it, such as https://github.com/meeting-guide/one-page-meeting-list
+//used:		by themes that want it, such as https://github.com/code4recovery/one-page-meeting-list
 function tsml_front_page($wp_query){
 	if (is_admin()) return; //don't do this to inside pages
 	if ($wp_query->get('page_id') == get_option('page_on_front')) {

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ cd 12-step-meeting-list
 * Add an upstream feed, so you can pull in changes from the root repository:
 
 ```
-git remote add upstream https://github.com/meeting-guide/12-step-meeting-list.git
+git remote add upstream https://github.com/code4recovery/12-step-meeting-list.git
 ````
 
 * You should update your copy from the upstream repository frequently, especially before starting work on a new feature or issuing a pull request. Here is how:

--- a/readme.txt
+++ b/readme.txt
@@ -322,7 +322,7 @@ Add this to your theme's functions.php. Feel free to change the order or column 
 = Can I change the default sort order on the meeting list page? =
 By default, the plugin sorts by day, then time, then location name. To set your own sort index, add this to your functions.php:
 
-	$tsml_sort_order = 'region'; //options are name, location, address, time, or region
+	$tsml_sort_by = 'region'; //options are name, location, address, time, or region
 
 = How can I override the meeting list or detail pages? =
 Copy the files from the plugin's templates directory into your theme's root directory. If you're using a theme from the Theme Directory, you may be better off creating a [Child Theme](https://codex.wordpress.org/Child_Themes). Now, you may override those pages. The archive-meetings.php file controls the meeting list page, single-meetings.php controls the meetings detail, and single-locations.php controls the location detail.

--- a/readme.txt
+++ b/readme.txt
@@ -395,7 +395,7 @@ Sure. Try adding this code to your theme's functions.php:
 
 	add_action('pre_get_posts', 'tsml_front_page');
 	
-Also check out our [One Page Meeting List](https://github.com/meeting-guide/one-page-meeting-list) theme.
+Also check out our [One Page Meeting List](https://github.com/code4recovery/one-page-meeting-list) theme.
 	
 = Can I use this plugin to list telephone meetings or other meetings without a fixed location? =
 No, there's not a good way to do this at this time. All meetings currently need to have a geographic location.


### PR DESCRIPTION
I changed the wording on some messages on the Import & Settings page, most notably, under "Data Sources" in the left column, and under "Sharing" under Settings in the right column. In addition, I added a "Public Feed" item under Settings when Sharing is set to Open.

I'm hoping these changes will help address the support question [Error Linking Plugin to App](https://wordpress.org/support/topic/error-linking-plugin-to-app/) and this comment on [Support External Database](https://wordpress.org/support/topic/support-external-database/#post-12114917)

It also will address the support question [Change functions.php for default sort](https://wordpress.org/support/topic/change-functions-php-for-default-sort/) by correcting the readme.txt file for tsml_sort_by. I'm hoping this will also change the FAQ's listed on the plugin's pages on WordPress.org.

One last change, this pull requests changes the URL https://github.com/meeting-guide to https://github.com/code4recovery in a few places, wherever I found it. There is 1 itunes link that still has meeting-guide in it, we'll need to look into that later.

Here is a couple of before/after pictures to show what I'm proposing...


<img width="582" alt="Screen Shot 2019-11-16 at 9 17 52 AM" src="https://user-images.githubusercontent.com/55821195/68995339-3e131580-0852-11ea-828e-582967a9831b.png">
<img width="469" alt="Screen Shot 2019-11-16 at 9 19 02 AM" src="https://user-images.githubusercontent.com/55821195/68995340-3e131580-0852-11ea-878e-ed22a2864796.png">
