### PR TITLE
cleaning up geocoding logic

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -3,7 +3,7 @@
 Plugin Name: 12 Step Meeting List
 Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
 Description: Manage a list of recovery meetings
-Version: 3.4.21
+Version: 3.4.22
 Author: AA Web Servant
 Author URI: https://github.com/code4recovery/12-step-meeting-list
 Text Domain: 12-step-meeting-list
@@ -23,7 +23,7 @@ if (!defined('TSML_PATH')) {
 }
 
 if (!defined('TSML_VERSION')) {
-    define('TSML_VERSION', '3.4.21');
+    define('TSML_VERSION', '3.4.22');
 }
 
 //include these files first

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: aasanjose
 Requires at least: 3.2
 Tested up to: 5.3
-Stable tag: 3.4.21
+Stable tag: 3.4.22
 
 This plugin helps twelve step recovery programs list their meetings. It standardizes addresses, and displays results in a searchable list and map.
 
@@ -419,6 +419,9 @@ To apply these changes, you must go to Settings > Permalinks and click "Save Cha
 1. Edit location
 
 == Changelog ==
+
+= 3.4.22 =
+* Fixing bug in geocode caching (Ogden)
 
 = 3.4.21 =
 * Updating how PDF displays groups (hmbrecords)


### PR DESCRIPTION
this PR filters out any empty geocodes in the cache, and cleans up some faulty logic for #47 

in particular, there was one bug that would have caused an empty result if the API was over the query limit (and would have persisted that empty result)