### PR TITLE
fill meetings with next day if none left for current day

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .svn
 .sass-cache
 node_modules
+.idea

--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -81,7 +81,13 @@ class TSML_Widget_Upcoming extends WP_Widget
         }
         echo $table;
         $link = get_post_type_archive_link('tsml_meeting');
-        $link .= ((strpos($link, '?') === false) ? '?' : '&') . 'tsml-time=upcoming';
+        $upcoming_meetings = tsml_get_meetings(array('day' => intval(current_time('w')), 'time' => 'upcoming'));
+        $next_day = date('w', strtotime('+1 day', current_time('timestamp')));
+        if (count($upcoming_meetings) == 0) {
+            $link .= ((strpos($link, '?') === false) ? '?' : '&') . 'tsml-day=' . $next_day;
+        } else {
+            $link .= ((strpos($link, '?') === false) ? '?' : '&') . 'tsml-time=upcoming';
+        }
         echo '<p><a href="' . $link . '">' . __('View More…', '12-step-meeting-list') . '</a></p>';
         echo $args['after_widget'];
     }


### PR DESCRIPTION
this will resolve #51, however it won't add to `?tsml-time=upcoming` endpoint. and it won't fill to total count set in the widget args. I'm not sure that is necessary.  would like to hear what other opinions are. because of the way the current_time wordpress function (function :)) using strtotime in conjunction with built in wp function seemed best option to get next day integer.