### PR TITLE
Prevent issues with ACF time picker

### DIFF
--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -18,11 +18,15 @@ function tsml_move_author_meta_box() {
     add_meta_box('authordiv', __('Editor', '12-step-meeting-list'), 'post_author_meta_box', 'tsml_meeting', 'side', 'default');
 }
 
+// Hook tsml_assets where we can check $post_type
+add_action( 'admin_print_scripts-post.php', 'tsml_assets' );
+add_action( 'admin_print_scripts-post-new.php', 'tsml_assets' );
+
 //edit page
 add_action('admin_init', 'tsml_admin_init');
 function tsml_admin_init() {
 
-    tsml_assets();
+//    tsml_assets();
 
     add_meta_box('info', __('Meeting Information', '12-step-meeting-list'), 'tsml_meeting_box', 'tsml_meeting', 'normal', 'low');
 

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -61,7 +61,7 @@ if (!function_exists('tsml_ajax_groups')) {
 				'contact_3_phone'	=> @$group_custom['contact_3_phone'][0],
 				'last_contact'		=> @$group_custom['last_contact'][0],
 				'notes'				=> $group->post_content,
-				'tokens'			=> tsml_string_tokens($title),
+				'tokens'			=> tsml_string_tokens($group->post_title),
 				'type'				=> 'group',
 			);
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -28,8 +28,12 @@ function tsml_alert($message, $type='success') {
 //function: enqueue assets for public or admin page
 //used: in templates and on admin_edit.php
 function tsml_assets() {
-	global $tsml_street_only, $tsml_programs, $tsml_strings, $tsml_program, $tsml_google_maps_key, $tsml_mapbox_key, $tsml_google_overrides, $tsml_distance_units, $tsml_defaults, $tsml_language, $tsml_columns, $tsml_nonce;
+	global $post_type, $tsml_street_only, $tsml_programs, $tsml_strings, $tsml_program, $tsml_google_maps_key, $tsml_mapbox_key, $tsml_google_overrides, $tsml_distance_units, $tsml_defaults, $tsml_language, $tsml_columns, $tsml_nonce;
 
+	// TODO: verify this doesn't cause any other issues
+	if ( 'tsml_meeting' !== $post_type ) {
+		return;
+	}
 	//google maps api
 	if ($tsml_google_maps_key) {
 		wp_enqueue_script('google_maps_api', '//maps.googleapis.com/maps/api/js?key=' . $tsml_google_maps_key);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -31,7 +31,7 @@ function tsml_assets() {
 	global $post_type, $tsml_street_only, $tsml_programs, $tsml_strings, $tsml_program, $tsml_google_maps_key, $tsml_mapbox_key, $tsml_google_overrides, $tsml_distance_units, $tsml_defaults, $tsml_language, $tsml_columns, $tsml_nonce;
 
 	// TODO: verify this doesn't cause any other issues
-	if ( 'tsml_meeting' !== $post_type ) {
+	if ( isset( $post_type ) && 'tsml_meeting' !== $post_type ) {
 		return;
 	}
 	//google maps api

--- a/templates/archive-meetings.php
+++ b/templates/archive-meetings.php
@@ -542,7 +542,11 @@ if (($day === null) && !empty($meeting['time'])) {
 									<?php
 break;
 
-            case 'distance': ?>
+            case 'distance':
+            	if ( ! isset( $meeting['distance'] ) ) {
+            		break;
+				}
+            	?>
 									<td class="distance" data-sort="<?php echo $meeting['distance'] ?>"><?php echo $meeting['distance'] ?></td>
 									<?php
 break;

--- a/templates/archive-meetings.php
+++ b/templates/archive-meetings.php
@@ -542,12 +542,8 @@ if (($day === null) && !empty($meeting['time'])) {
 									<?php
 break;
 
-            case 'distance':
-            	if ( ! isset( $meeting['distance'] ) ) {
-            		break;
-				}
-            	?>
-									<td class="distance" data-sort="<?php echo $meeting['distance'] ?>"><?php echo $meeting['distance'] ?></td>
+            case 'distance': ?>
+									<td class="distance" data-sort="<?php echo @$meeting['distance'] ?>"><?php echo $meeting['distance'] ?></td>
 									<?php
 break;
 


### PR DESCRIPTION
Hooking tsml_assets() to admin_print_scripts allows us to check $post_type and only enqueue tsml assets for tsml_meeting post type.  Appears to not negatively affect other calls to tsml_assets().

Also:
Prevent PHP undefined index notice.
Use $group->post_title instead of undefined $title for ajax tokens.