### PR TITLE
Bw/draft location

### DIFF
--- a/includes/save.php
+++ b/includes/save.php
@@ -27,12 +27,6 @@ function tsml_save_post($post_id, $post, $update) {
 	//update is always 1, probably because it's actually 'created' when the edit screen first loads (due to autosave)
 	$update = ($post->post_date !== $post->post_modified);
 
-	// Set the meeting's location status to 'publish'
-	// tsml_delete_orphans() will undo this later if necessary
-	if (!empty($post->post_parent)) {
-		wp_update_post(array('ID' => $post->post_parent, 'post_status' => 'publish'));
-	}
-	
 	//sanitize strings (website, website_2, paypal are not included)
 	$strings = array('post_title', 'location', 'formatted_address', 'mailing_address', 'venmo', 'square', 'post_status', 'group', 'last_contact', 'conference_phone');
 	foreach ($strings as $string) {
@@ -200,7 +194,13 @@ function tsml_save_post($post_id, $post, $update) {
 					'post_content'  => $_POST['location_notes'],
 				));
 			}
-	
+
+			// Set the meeting's location status to 'publish'
+			// tsml_delete_orphans() will change it back to draft if necessary
+			if ($locations[0]->post_status != 'publish') {
+				wp_update_post(array('ID' => $location_id, 'post_status' => 'publish'));
+			}
+
 			//latitude longitude only if updated
  			foreach (array('latitude', 'longitude') as $field) {
 				if (!$update || $old_meeting->{$field} != $_POST[$field]) {

--- a/includes/save.php
+++ b/includes/save.php
@@ -195,9 +195,8 @@ function tsml_save_post($post_id, $post, $update) {
 				));
 			}
 
-			// Set the meeting's location status to 'publish'
-			// tsml_delete_orphans() will change it back to draft if necessary
-			if ($locations[0]->post_status != 'publish') {
+			// If the meeting post is published, and the location isn't, then publish the location 
+			if ($_POST['post_status'] == 'publish' && $locations[0]->post_status != 'publish') {
 				wp_update_post(array('ID' => $location_id, 'post_status' => 'publish'));
 			}
 

--- a/includes/save.php
+++ b/includes/save.php
@@ -26,6 +26,12 @@ function tsml_save_post($post_id, $post, $update) {
 	
 	//update is always 1, probably because it's actually 'created' when the edit screen first loads (due to autosave)
 	$update = ($post->post_date !== $post->post_modified);
+
+	// Set the meeting's location status to 'publish'
+	// tsml_delete_orphans() will undo this later if necessary
+	if (!empty($post->post_parent)) {
+		wp_update_post(array('ID' => $post->post_parent, 'post_status' => 'publish'));
+	}
 	
 	//sanitize strings (website, website_2, paypal are not included)
 	$strings = array('post_title', 'location', 'formatted_address', 'mailing_address', 'venmo', 'square', 'post_status', 'group', 'last_contact', 'conference_phone');

--- a/includes/save.php
+++ b/includes/save.php
@@ -190,6 +190,7 @@ function tsml_save_post($post_id, $post, $update) {
 			'order' => 'ASC',
 			'meta_key' => 'formatted_address',
 			'meta_value' => $_POST['formatted_address'],
+			'post_status' => 'any',
 		))) {
 			$location_id = $locations[0]->ID;
 			if ($locations[0]->post_title != $_POST['location'] || $locations[0]->post_content != $_POST['location_notes']) {


### PR DESCRIPTION
This PR is to fix issue #119, where an address can get lost when the last meeting at that location gets set to "draft". This happens because in the save function, it doesn't find the tsml_location post when this post also status of "draft". Therefore, what this PR does is sets the status of the parent post of the meeting, which is the tsml_location, to publish. This way, the function finds the correct location, and uses it, thus preserving the address.

At first, it appeared that the problem was in tsml_delete_orphans() function, however, that function seemed to do the right thing. When all the meetings at a location are set to draft, it sets that location to draft. That seems reasonable. So this PR lets the status of the location be draft until the meeting is being saved.