### PR TITLE
new react project shortcode

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -82,6 +82,20 @@ if (!function_exists('tsml_types_list')) {
 }
 add_shortcode('tsml_types_list', 'tsml_types_list');
 
+//output a react meeting finder widget https://github.com/code4recovery/react
+if (!function_exists('tsml_react')) {
+	function tsml_react() {
+		global $tsml_mapbox_key, $tsml_nonce, $tsml_sharing;
+		$host = 'https://react.' . (tsml_string_ends(get_site_url(), '.test') ? 'test' : 'meetingguide.org');
+		$url = admin_url('admin-ajax.php') . '?action=meetings&nonce=' . wp_create_nonce($tsml_nonce);
+		wp_enqueue_style('tsml_react', $host . '/style.css');
+		wp_enqueue_script('tsml_react', $host . '/app.js');
+		wp_add_inline_script('tsml_react', 'window.config={timezone: "' . get_option('timezone_string') . '"}', 'before');
+		return '<meetings src="' . $url . '" mapbox="' . $tsml_mapbox_key . '"/>';
+	}
+}
+add_shortcode('tsml_react', 'tsml_react');
+
 //output a list of regions with links for AA-DC
 if (!function_exists('tsml_regions_list')) {
 	function tsml_regions_list()


### PR DESCRIPTION
this PR adds a new shortcode `[tsml_react]` that outputs a meeting finder based on the [code4recovery/react](https://github.com/code4recovery/react) project (currently in beta)