### PR TITLE
Fixes #116 multiple type filters

### DIFF
--- a/includes/filter_meetings.php
+++ b/includes/filter_meetings.php
@@ -81,7 +81,7 @@ class tsml_filter_meetings
         }
 
         if (!empty($arguments['type'])) {
-            $this->type = is_array($arguments['type']) ? array_map('trim', $arguments['type']) : array(trim($arguments['type']));
+            $this->type = is_array($arguments['type']) ? array_map('trim', $arguments['type']) : explode(',',trim($arguments['type']));
         }
 
     }
@@ -259,8 +259,7 @@ class tsml_filter_meetings
         if (!isset($meeting['types'])) {
             return false;
         }
-
-        return array_intersect($meeting['types'], $this->type);
+        return !count(array_diff($this->type, $meeting['types']));
     }
 
     //function to get district id from slug


### PR DESCRIPTION
1. In `tsml_filter_meetings`, changed constructor so types (string) accurately becomes an array.

1. In `filter_types`, changed logic so all requested types are checked for existence in meeting before including in filtered list.

Closes #116