### PR TITLE
Fixes #132

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -692,7 +692,15 @@ function tsml_get_all_groups($status='any') {
 //function: get all locations in the system
 //used:		tsml_location_count(), tsml_import(), and admin_import.php
 function tsml_get_all_locations($status='any') {
-	return get_posts('post_type=tsml_location&post_status=' . $status . '&numberposts=-1&orderby=name&order=asc');
+
+	$args = array(
+		'post_type'   => 'tsml_location',
+		'post_status' => $status,
+		'numberposts' => - 1,
+		'orderby'     => 'name',
+		'order'       => 'ASC',
+	);
+	return get_posts( $args );
 }
 
 //function: get all meetings in the system
@@ -1679,7 +1687,7 @@ function tsml_to_css_classes($types, $prefix = 'type-') {
 
 /**
  * Sanitizes a string for sorting purposes.  Similar to sanitize_title(), but uses Unicode regular expressions to support multiple languages.
- * 
+ *
  * NOTE: Requires PHP 5.1.0 or later.  More details here:
  *   https://www.php.net/manual/en/regexp.reference.unicode.php
  *

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -686,27 +686,40 @@ function tsml_geocode($address) {
 //function: get all locations in the system
 //used:		tsml_group_count()
 function tsml_get_all_groups($status='any') {
-	return get_posts('post_type=tsml_group&post_status=' . $status . '&numberposts=-1&orderby=name&order=asc');
+
+	return get_posts( array(
+		'post_type'   => 'tsml_group',
+		'post_status' => $status,
+		'numberposts' => - 1,
+		'orderby'     => 'name',
+		'order'       => 'ASC',
+	) );
 }
 
 //function: get all locations in the system
 //used:		tsml_location_count(), tsml_import(), and admin_import.php
 function tsml_get_all_locations($status='any') {
 
-	$args = array(
+	return get_posts( array(
 		'post_type'   => 'tsml_location',
 		'post_status' => $status,
 		'numberposts' => - 1,
 		'orderby'     => 'name',
 		'order'       => 'ASC',
-	);
-	return get_posts( $args );
+	) );
 }
 
 //function: get all meetings in the system
 //used:		tsml_meeting_count(), tsml_import(), and admin_import.php
 function tsml_get_all_meetings($status='any') {
-	return get_posts('post_type=tsml_meeting&post_status=' . $status . '&numberposts=-1&orderby=name&order=asc');
+
+	return get_posts( array(
+		'post_type'   => 'tsml_meeting',
+		'post_status' => $status,
+		'numberposts' => - 1,
+		'orderby'     => 'name',
+		'order'       => 'ASC',
+	) );
 }
 
 //function: get all regions in the system

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -831,7 +831,7 @@ function tsml_get_locations() {
 	}
 
 	# Get all locations
-	$posts = tsml_get_all_locations('publish');
+	$posts = tsml_get_all_locations( array( 'publish', 'draft' ) );
 
 	# Much faster than doing get_post_meta() over and over
 	$location_meta = tsml_get_meta('tsml_location');


### PR DESCRIPTION
I noticed that setting all meetings that share a location to draft status via bulk actions did not change the related location status.  The location status only changed to draft when I changed each meeting individually via the post edit screen.  Not sure if this indicates further investigation being necessary.

Include `draft` in array when calling `tsml_get_all_locations()` in `tsml_get_locations()`.

Switch args from string to array when calling `get_posts()` in `tsml_get_all_locations()` so we can accept the status array mentioned above.

This also changes args used when calling `get_posts()` from string to array in other locations in `functions.php`.

Tested locally with no issues.  

This was based off `develop` (3.9.0-rc) and merged into current `master` (3.9.3) locally with no issues.

There was talk of not using short array syntax for backward compatibility.  Short array syntax was introduced in PHP 5.4 and I believe WordPress 5.2 bumped the required PHP version up to 5.6.2.  I did _not_ use short array syntax in these changes in order to match the existing code.