### PR TITLE
fix: Remove ambiguity associated with `is_approximate_location` in da…

### DIFF
--- a/includes/database_updates.php
+++ b/includes/database_updates.php
@@ -30,11 +30,10 @@ if (!function_exists('db_update_tsml_locations_approximate_location')) {
     // dd($locations);
     foreach ($locations_posts as $location_post) {
       $location_custom = get_post_meta($location_post->ID);
-      if (!array_key_exists('is_approximate_location', $location_custom)) {
-        $is_location_approximate = decide_if_location_approximate($location_custom['formatted_address'][0]);
-        if ($is_location_approximate) 
-          add_post_meta($location_post->ID, 'is_approximate_location', $is_location_approximate);				
-      };
+      // if (!array_key_exists('is_approximate_location', $location_custom)) {
+      $is_location_approximate = decide_if_location_approximate($location_custom['formatted_address'][0]);
+      update_post_meta($location_post->ID, 'is_approximate_location', $is_location_approximate);				
+      // };
     }
   };
 };

--- a/includes/save.php
+++ b/includes/save.php
@@ -244,7 +244,7 @@ function tsml_save_post($post_id, $post, $update) {
 			//set latitude, longitude, approximate_location and region
 			add_post_meta($location_id, 'latitude', floatval($_POST['latitude']));
 			add_post_meta($location_id, 'longitude', floatval($_POST['longitude']));
-			add_post_meta($location_id, 'is_approximate_location', $_POST['is_approximate_location']);
+			update_post_meta($location_id, 'is_approximate_location', $_POST['is_approximate_location']);
 			wp_set_object_terms($location_id, intval($_POST['region']), 'tsml_region');
 		}
 	


### PR DESCRIPTION
…tabase

Accomplished through two changes. First is to write `is_approximate_location` for every
location in the database. Second, changed from `add_post_meta` to `update_post_meta` which should
reduce the likelihood of multiple `is_approximate_location` keys in post meta.

see #208