### PR TITLE
208 223 fix approximate locations

### DIFF
--- a/includes/database_updates.php
+++ b/includes/database_updates.php
@@ -30,11 +30,10 @@ if (!function_exists('db_update_tsml_locations_approximate_location')) {
     // dd($locations);
     foreach ($locations_posts as $location_post) {
       $location_custom = get_post_meta($location_post->ID);
-      if (!array_key_exists('is_approximate_location', $location_custom)) {
-        $is_location_approximate = decide_if_location_approximate($location_custom['formatted_address'][0]);
-        if ($is_location_approximate) 
-          add_post_meta($location_post->ID, 'is_approximate_location', $is_location_approximate);				
-      };
+      // if (!array_key_exists('is_approximate_location', $location_custom)) {
+      $is_location_approximate = decide_if_location_approximate($location_custom['formatted_address'][0]);
+      update_post_meta($location_post->ID, 'is_approximate_location', $is_location_approximate);				
+      // };
     }
   };
 };

--- a/includes/database_updates.php
+++ b/includes/database_updates.php
@@ -2,7 +2,10 @@
 
 if(!function_exists('decide_if_location_approximate')) {
   function decide_if_location_approximate($formatted_address) {
-    return (substr_count($formatted_address, ",") <= 2);
+    if (substr_compare($formatted_address, 'Australia', -9, $case_insensitivity = TRUE) === 0) {
+      $location_approximate = substr_count($formatted_address, ",") <= 1;
+    } else $location_approximate = substr_count($formatted_address, ",") <= 2;
+    return $location_approximate;
   }
 }
 
@@ -27,13 +30,10 @@ if (!function_exists('db_update_addresses_cache_approximate_location')) {
 if (!function_exists('db_update_tsml_locations_approximate_location')) {
   function db_update_tsml_locations_approximate_location() {
     $locations_posts = tsml_get_all_locations();
-    // dd($locations);
     foreach ($locations_posts as $location_post) {
       $location_custom = get_post_meta($location_post->ID);
-      // if (!array_key_exists('is_approximate_location', $location_custom)) {
       $is_location_approximate = decide_if_location_approximate($location_custom['formatted_address'][0]);
       update_post_meta($location_post->ID, 'is_approximate_location', $is_location_approximate);				
-      // };
     }
   };
 };

--- a/includes/save.php
+++ b/includes/save.php
@@ -244,7 +244,7 @@ function tsml_save_post($post_id, $post, $update) {
 			//set latitude, longitude, approximate_location and region
 			add_post_meta($location_id, 'latitude', floatval($_POST['latitude']));
 			add_post_meta($location_id, 'longitude', floatval($_POST['longitude']));
-			add_post_meta($location_id, 'is_approximate_location', $_POST['is_approximate_location']);
+			update_post_meta($location_id, 'is_approximate_location', $_POST['is_approximate_location']);
 			wp_set_object_terms($location_id, intval($_POST['region']), 'tsml_region');
 		}
 	

--- a/includes/save.php
+++ b/includes/save.php
@@ -244,7 +244,7 @@ function tsml_save_post($post_id, $post, $update) {
 			//set latitude, longitude, approximate_location and region
 			add_post_meta($location_id, 'latitude', floatval($_POST['latitude']));
 			add_post_meta($location_id, 'longitude', floatval($_POST['longitude']));
-			update_post_meta($location_id, 'is_approximate_location', $_POST['is_approximate_location']);
+			update_post_meta($location_id, 'is_approximate_location', json_decode($_POST['is_approximate_location']));
 			wp_set_object_terms($location_id, intval($_POST['region']), 'tsml_region');
 		}
 	


### PR DESCRIPTION
I believe I now have this. I think the problems we were having were three-fold:

1. The original boolean from geocoding was done in JS, and this didn't translate correctly to PHP. This PR adds `json_decode` in `save.php` which seems to ensure either a 1 or 0/blank is written to the database (instead of true or false) when a user enters a new address.
1. The use of `add_post_meta` may be generating multiple `is_approximate_location` keys in the post meta, or it may not. No way to tell for sure, but based on documentation, `update_post_meta` *should* be safer for our uses.
1. Australian addresses don't use as many commas as does the US. I still don't know if other countries have this issue, but this PR should correct Australia's situation.

In the current form, this PR will update the database every time the admin meeting page is executed. I left this way for testing, but will change it to execute only once for the `v3.9.4-rc` that will be pushed to the beta testers. 

closes #208 and #223.