### PR TITLE
Explicitly send `false` for tsml_address ajax function

### DIFF
--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -122,7 +122,7 @@ if (!function_exists('tsml_admin_ajax_address')) {
 			'numberposts'	=> 1,
 			'meta_key'		=> 'formatted_address',
 			'meta_value'	=> sanitize_text_field($_GET['formatted_address']),
-		))) wp_send_json("");
+		))) wp_send_json(false);
 
 		$region = array_values(get_the_terms($posts[0]->ID, 'tsml_region'));
 

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -122,7 +122,7 @@ if (!function_exists('tsml_admin_ajax_address')) {
 			'numberposts'	=> 1,
 			'meta_key'		=> 'formatted_address',
 			'meta_value'	=> sanitize_text_field($_GET['formatted_address']),
-		))) return array();
+		))) wp_send_json("");
 
 		$region = array_values(get_the_terms($posts[0]->ID, 'tsml_region'));
 


### PR DESCRIPTION
This is consistent with all other functions in ajax.php. It uses `wp_send_json` to explicitly send a value, which is falsey, which `admin.js` will use to determine whether a location was found

Addresses #208