### PR TITLE
fix: Hot-fix to reduce invalid geocoding calls (errors)

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -688,7 +688,7 @@ function tsml_geocode($address) {
 //function: Ensure location->approximate set through geocoding and updated
 //used: single-meetings.php, single-locations.php
 function tsml_ensure_location_approximate_set($meeting_location_info) {
-  if (empty($meeting_location_info->approximate)) {
+  if (empty($meeting_location_info->approximate) && !empty($meeting_location_info->formatted_address)) {
     $geocoded = tsml_geocode($meeting_location_info->formatted_address);
     $meeting_location_info->approximate = $geocoded['approximate'];
     update_post_meta($meeting_location_info->location_id, 'approximate', $geocoded['approximate']);
@@ -976,8 +976,9 @@ function tsml_get_meeting($meeting_id=false) {
 			$meeting->types_expanded[] = $tsml_programs[$tsml_program]['types'][$type];
 		}
 	}
-	sort($meeting->types_expanded);
-  $meeting = tsml_ensure_location_approximate_set($meeting); // Can eventually remove this when <3.9 TSMLs no longer used.
+  sort($meeting->types_expanded);
+  
+  if (!empty($meeting->post_title)) $meeting = tsml_ensure_location_approximate_set($meeting); // Can eventually remove this when <3.9 TSMLs no longer used.
 
 	return $meeting;
 }


### PR DESCRIPTION
The `tsml_get_meeting` was called each time a user started
a new meeting even when address values were empty. Because there were no
checks to see if fields were empty, Google was called with an empty address.

A search was made to see if other blocks of code were unexpectedly calling
`tsml_get_meeting`, but none were found.

This commit should help with the issue documented in #255, but only to the
extend that the extra geocodes caused when a meeting is manually being
entered are avoided.