### PR TITLE
Added ability to pass an offset value to adjust time filter

### DIFF
--- a/includes/filter_meetings.php
+++ b/includes/filter_meetings.php
@@ -76,7 +76,13 @@ class tsml_filter_meetings
         if (!empty($arguments['time'])) {
             $this->time = is_array($arguments['time']) ? array_map('sanitize_title', $arguments['time']) : array(sanitize_title($arguments['time']));
             if (in_array('upcoming', $this->time)) {
-                $this->now = current_time('H:i');
+                if (!empty($arguments['offset'])) {
+                    $timestamp = current_time('timestamp');
+                    $secondsToAdd = $arguments['offset'] * 60;
+                    $this->now =  date("H:i", $timestamp + $secondsToAdd);
+                } else {
+                   $this->now = current_time('H:i');
+                }
             }
         }
 
@@ -237,7 +243,7 @@ class tsml_filter_meetings
         if (!isset($meeting['time'])) {
             return false;
         }
-
+        
         foreach ($this->time as $time) {
             if ($time == 'morning') {
                 return (strcmp('04:00', $meeting['time']) <= 0 && strcmp('11:59', $meeting['time']) >= 0);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1088,7 +1088,7 @@ function tsml_get_meetings($arguments=array(), $from_cache=true) {
 	}
 
 	//check if we are filtering
-	$allowed = array('mode', 'day', 'time', 'region', 'district', 'type', 'query', 'group_id', 'location_id', 'latitude', 'longitude', 'distance_units', 'distance');
+	$allowed = array('mode', 'day', 'time', 'region', 'district', 'type', 'query', 'group_id', 'location_id', 'latitude', 'longitude', 'distance_units', 'distance', 'offset');
 	if ($arguments = array_intersect_key($arguments, array_flip($allowed))) {
 		$filter = new tsml_filter_meetings($arguments);
 		$meetings = $filter->apply($meetings);

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -11,8 +11,10 @@ if (!function_exists('tsml_next_meetings')) {
 	function tsml_next_meetings($arguments)
 	{
 		global $tsml_program, $tsml_programs;
-		$arguments = shortcode_atts(array('count' => 5, 'message' => ''), $arguments, 'tsml_next_meetings');
-		$meetings = tsml_get_meetings(array('day' => intval(current_time('w')), 'time' => 'upcoming'));
+
+		$arguments = shortcode_atts(array('count' => 5, 'message' => '', 'time' => 'upcoming', 'offset' => 0), $arguments, 'tsml_next_meetings');
+		$meetings = tsml_get_meetings(array('day' => intval(current_time('w')), 'time' => $arguments['time'], 'offset' => $arguments['offset']));
+
 		if (!count($meetings) && empty($arguments['message'])) {
 			return false;
 		}


### PR DESCRIPTION
The timestamp used to filter a meeting from the meeting list is based on the current_time. When a meetings start time has passed this timestamp it no longer appears. Users have reported that they would like the meeting to continue to display for a period of time longer (i.e. Until after the meeting has ended) than the start of the meeting. This new offset attribute allows a user to adjust the time used in comparison.

[tsml_next_meetings offset="-60"] would allow a meeting to display for an additional 60 minutes beyond current time.
