### PR TITLE
updating type descriptions to use official language

### DIFF
--- a/includes/variables.php
+++ b/includes/variables.php
@@ -581,10 +581,8 @@ function tsml_define_strings() {
 			'flags' => array('M', 'W', 'TC', 'ONL'), //for /men and /women at end of meeting name (used in tsml_format_name())
 			'name' => __('Alcoholics Anonymous', '12-step-meeting-list'),
 			'type_descriptions' => array(
-				'C' => __('This meeting is closed; only those who have a desire to stop drinking may attend.', '12-step-meeting-list'),
-				'O' => __('This meeting is open and anyone may attend.', '12-step-meeting-list'),
-				//'TC' => __('This meeting is temporarily not meeting in-person.', '12-step-meeting-list'),
-				//'ONL' => __('Online meeting. Details below.', '12-step-meeting-list')
+				'C' => __('Closed meetings are for A.A. members only, or for those who have a drinking problem and “have a desire to stop drinking.”', '12-step-meeting-list'),
+				'O' => __('Open meetings are available to anyone interested in Alcoholics Anonymous’ program of recovery from alcoholism. Nonalcoholics may attend open meetings as observers.', '12-step-meeting-list'),
 			),
 			'types' => array(
 				'11' => __('11th Step Meditation', '12-step-meeting-list'),


### PR DESCRIPTION
i'm not such a fan of these descriptions, but they wore me down. i made this change in the meeting guide app last year and TSML UI last month, so it makes sense to do it here too.

to fix #330 

![closed](https://user-images.githubusercontent.com/1551689/124339103-ca299c00-db60-11eb-9c00-b4fc28deb40d.png)
![open](https://user-images.githubusercontent.com/1551689/124339104-cac23280-db60-11eb-9fb6-d2ac782bbbce.png)
