### PR TITLE
fix: Filter out inactive meetings in upcoming meetings widget

### DIFF
--- a/includes/filter_meetings.php
+++ b/includes/filter_meetings.php
@@ -93,6 +93,7 @@ class tsml_filter_meetings
                 $this->attendance_option[] = 'hybrid';
             }
             if (!empty(array_intersect($this->attendance_option, Array('active')))) {
+                $this->attendance_option = [];
                 $this->attendance_option[] = 'hybrid';
                 $this->attendance_option[] = 'in_person';
                 $this->attendance_option[] = 'online';

--- a/includes/filter_meetings.php
+++ b/includes/filter_meetings.php
@@ -92,11 +92,8 @@ class tsml_filter_meetings
             if (!empty(array_intersect($this->attendance_option, Array('online', 'in_person')))) {
                 $this->attendance_option[] = 'hybrid';
             }
-            if (!empty(array_intersect($this->attendance_option, Array('active')))) {
-                $this->attendance_option = array();
-                $this->attendance_option[] = 'hybrid';
-                $this->attendance_option[] = 'in_person';
-                $this->attendance_option[] = 'online';
+            if (in_array('active', $this->attendance_option)) {
+                $this->attendance_option = array('hybrid', 'in_person', 'online');
             }
             $this->attendance_option = array_unique($this->attendance_option);
         }

--- a/includes/filter_meetings.php
+++ b/includes/filter_meetings.php
@@ -93,7 +93,7 @@ class tsml_filter_meetings
                 $this->attendance_option[] = 'hybrid';
             }
             if (!empty(array_intersect($this->attendance_option, Array('active')))) {
-                $this->attendance_option = [];
+                $this->attendance_option = array();
                 $this->attendance_option[] = 'hybrid';
                 $this->attendance_option[] = 'in_person';
                 $this->attendance_option[] = 'online';

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -12,10 +12,11 @@ if (!function_exists('tsml_next_meetings')) {
 	{
 		global $tsml_program, $tsml_programs, $tsml_meeting_attendance_options;
 		$arguments = shortcode_atts(array('count' => 5, 'message' => ''), $arguments, 'tsml_next_meetings');
-		$meetings = tsml_get_meetings(array('day' => intval(current_time('w')), 'time' => 'upcoming'));
-    $filter_arguments['attendance_option'] = 'active';
-    $filter = new tsml_filter_meetings($filter_arguments);
-		$meetings = $filter->apply($meetings);
+		$meetings = tsml_get_meetings(array(
+			'day' => intval(current_time('w')), 
+			'time' => 'upcoming',
+			'attendance_option' => 'active',
+		));
 		if (!count($meetings) && empty($arguments['message'])) {
 			return false;
 		}

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -13,6 +13,9 @@ if (!function_exists('tsml_next_meetings')) {
 		global $tsml_program, $tsml_programs, $tsml_meeting_attendance_options;
 		$arguments = shortcode_atts(array('count' => 5, 'message' => ''), $arguments, 'tsml_next_meetings');
 		$meetings = tsml_get_meetings(array('day' => intval(current_time('w')), 'time' => 'upcoming'));
+    $filter_arguments['attendance_option'] = 'active';
+    $filter = new tsml_filter_meetings($filter_arguments);
+		$meetings = $filter->apply($meetings);
 		if (!count($meetings) && empty($arguments['message'])) {
 			return false;
 		}


### PR DESCRIPTION
Logically, inactive meetings shouldn't be shown in the widget that
is specifically designed to show the user the near term meetings available
for them to attend.

closes #398
answers #422