### PR TITLE
persist options when you navigate to meeting and back

### DIFF
--- a/assets/src/public.js
+++ b/assets/src/public.js
@@ -663,12 +663,7 @@ jQuery(function($) {
 										'-' +
 										sort_time +
 										'">' +
-										//formatLink(obj.url, obj.name, 'post_type') +
-										'<a href="' +
-										obj.url +
-										'">' +
-										obj.name +
-										'</a>';
+										formatLink(obj.url, obj.name, 'post_type');
 									if (typeList.length > 0) {
 										row += ' <small>' + typeList.join(', ') + '</small>';
 									}

--- a/templates/archive-meetings.php
+++ b/templates/archive-meetings.php
@@ -536,7 +536,7 @@ foreach ($meetings as $meeting) {
         $meeting['types'] = array();
     }
 
-    $meeting['link'] = tsml_link($meeting['url'], tsml_format_name($meeting['name'], $meeting['types']), 'post_type');
+    //$meeting['link'] = tsml_link($meeting['url'], tsml_format_name($meeting['name'], $meeting['types']), 'post_type');
 
     if (!isset($locations[$meeting['location_id']])) {
         $locations[$meeting['location_id']] = array(
@@ -589,7 +589,7 @@ break;
 
             case 'name': ?>
 									<td class="name" data-sort="<?php echo tsml_sanitize_data_sort($meeting['name']) . '-' . $sort_time ?>">
-                                        <a href="<?php echo $meeting['url']?>"><?php echo $meeting['name']?></a>
+                                        <?php echo tsml_link($meeting['url'], $meeting['name']); ?>
                                         <?php
                                             $meeting_types = tsml_format_types($meeting['types']);
                                             if (!empty($meeting_types)) {

--- a/templates/single-locations.php
+++ b/templates/single-locations.php
@@ -80,7 +80,7 @@ get_header();
 									$type_classes = tsml_to_css_classes($meeting['types']);
 
 									$meeting_link = '<li class="meeting attendance-' . $meeting['attendance_option']. '"><span>' . $meeting['time_formatted'] . '</span> ';
-									$meeting_link .= '<a href="' . $meeting['url'] . '">' . $meeting['name'] . '</a>';
+									$meeting_link .= tsml_link($meeting['url'], $meeting['name']);
 									$meeting_types = tsml_format_types($meeting['types']);
 									if (!empty($meeting_types)) {
 										$meeting_link .= '<div class="meeting_types"><small>(' . __($meeting_types, "12-step-meeting-list") . ')</small></div>';


### PR DESCRIPTION
Fixed the meeting links, so the search options should persist when you navigate to a meetings details page, then click the "Back to meetings" link. This, hopefully will finish addressing Issue #424 

This PR does change the file assets/src/public.js, however, I did not include `npm run prod` in the PR, because I think @tech2serve is changing CSS, and I didn't want to create any merge conflicts. However, `npm run prod` should be run when the PR is accepted.