### PR TITLE
Csv import

### DIFF
--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -482,7 +482,7 @@ if (!function_exists('function_name')) {
 			}
 
 			//add custom meeting fields if available
-			foreach (array('types', 'data_source', 'attendance_option', 'conference_url', 'conference_url_notes', 'conference_phone', 'conference_phone_notes') as $key) {
+			foreach (array('types', 'data_source', 'conference_url', 'conference_url_notes', 'conference_phone', 'conference_phone_notes') as $key) {
 				if (!empty($meeting[$key])) add_post_meta($meeting_id, $key, $meeting[$key]);
 			}
 

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -202,7 +202,6 @@ if (!function_exists('tsml_ajax_csv')) {
 			'contact_3_email' =>		'Contact 3 Email',
 			'contact_3_phone' =>		'Contact 3 Phone',
 			'last_contact' => 			'Last Contact',
-			'attendance_option' =>	'Attendance Option',
 			'conference_url' => 		'Conference URL',
 			'conference_url_notes' => 	'Conference URL Notes',
 			'conference_phone' => 		'Conference Phone',


### PR DESCRIPTION
This PR fixes the Bug described in Issue #434, where attendance options are imported from a data source, instead of calculated by the plugin. Importing can cause inconsistent meeting information, such as "online" meetings without a URL or Phone number entered. 

Doing it this way allows the Plugin to calculate the correct values after the meetings are imported.