### PR TITLE
Performance Fixes

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -3,7 +3,7 @@
 Plugin Name: 12 Step Meeting List
 Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
 Description: Manage a list of recovery meetings
-Version: 3.11.2
+Version: 3.11.3
 Author: Code4Recovery
 Author URI: https://github.com/code4recovery/12-step-meeting-list
 Text Domain: 12-step-meeting-list
@@ -19,7 +19,7 @@ if (!defined('TSML_CONTACT_EMAIL')) {
 }
 
 if (!defined('MEETING_GUIDE_APP_NOTIFY')) {
-  define('MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
+    define('MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 }
 
 if (!defined('TSML_PATH')) {
@@ -27,7 +27,7 @@ if (!defined('TSML_PATH')) {
 }
 
 if (!defined('TSML_VERSION')) {
-    define('TSML_VERSION', '3.11.2');
+    define('TSML_VERSION', '3.11.3');
 }
 
 //include these files first

--- a/includes/admin_lists.php
+++ b/includes/admin_lists.php
@@ -266,12 +266,14 @@ function tsml_bulk_action_handler($redirect, $doaction, $object_ids)
 
             if (empty($meeting->formatted_address) || tsml_geocode($meeting->formatted_address)['approximate'] != 'no') continue;
 
+            /* No longer writing attendance_option to the database...
             if (!empty($meeting->conference_url) || !empty($meeting->conference_phone)) {
                 $meeting->attendance_option = 'hybrid';
             } else {
                 $meeting->attendance_option = 'in_person';
             }
             update_post_meta($post_id, 'attendance_option', $meeting->attendance_option);
+            */
 
             // For each select post, remove TC if it's selected in "types"
             $types = get_post_meta($post_id, 'types', false)[0];

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -30,10 +30,11 @@ function tsml_admin_init() {
 	// Compares versions and updates databases as needed for upgrades
 	$tsml_version = get_option('tsml_version');
 	if (version_compare($tsml_version, TSML_VERSION, '<')) {
-    db_update_remove_all_approximate_location_cache();
-    db_update_remove_all_is_approximate_location_meta();
+		db_update_remove_all_approximate_location_cache();
+		db_update_remove_all_is_approximate_location_meta();
 		// db_update_addresses_cache_approximate_location();
 		// db_update_tsml_locations_approximate_location();
+		tsml_db_set_address_approximate();
 		update_option('tsml_version', TSML_VERSION);
 		flush_rewrite_rules();
 	};

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -39,6 +39,9 @@ function tsml_admin_init() {
 		// Delete the attendance_option metadata tag, don't need it
 		delete_metadata( 'post', 0, 'attendance_option', false, true );
 
+		//Rebuild the meeting cache
+		tsml_cache_rebuild();
+
 		update_option('tsml_version', TSML_VERSION);
 		flush_rewrite_rules();
 	};

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -35,6 +35,10 @@ function tsml_admin_init() {
 		// db_update_addresses_cache_approximate_location();
 		// db_update_tsml_locations_approximate_location();
 		tsml_db_set_address_approximate();
+
+		// Delete the attendance_option metadata tag, don't need it
+		delete_metadata( 'post', 0, 'attendance_option', false, true );
+
 		update_option('tsml_version', TSML_VERSION);
 		flush_rewrite_rules();
 	};

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -34,7 +34,7 @@ function tsml_admin_init() {
 		db_update_remove_all_is_approximate_location_meta();
 		// db_update_addresses_cache_approximate_location();
 		// db_update_tsml_locations_approximate_location();
-		tsml_db_set_address_approximate();
+		tsml_db_set_location_approximate();
 
 		// Delete the attendance_option metadata tag, don't need it
 		delete_metadata( 'post', 0, 'attendance_option', false, true );

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -231,6 +231,7 @@ if (!function_exists('tsml_ajax_csv')) {
 					$line[] = $tsml_days[$meeting[$column]];
 				} elseif ($column == 'types') {
 					$types = $meeting[$column];
+					if (!is_array($types)) $types = array();
 					foreach ($types as &$type) $type = $tsml_programs[$tsml_program]['types'][trim($type)];
 					sort($types);
 					$line[] = $escape . implode(', ', $types) . $escape;

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -457,6 +457,7 @@ if (!function_exists('function_name')) {
 				add_post_meta($location_id, 'formatted_address',	$geocoded['formatted_address']);
 				add_post_meta($location_id, 'latitude',				$geocoded['latitude']);
 				add_post_meta($location_id, 'longitude',			$geocoded['longitude']);
+				add_post_meta($location_id, 'approximate',			$geocoded['approximate']);
 				wp_set_object_terms($location_id, $region_id, 'tsml_region');
 			}
 

--- a/includes/database_updates.php
+++ b/includes/database_updates.php
@@ -79,13 +79,13 @@ if (!function_exists('tsml_db_set_address_approximate')) {
 
     foreach ($locations as $location) {
       // if location doesn't have the approximate tag
-      if (empty($location['approximate'])) {
-        $location_address = $location['formatted_address'];
+      if (empty($location['address_approximate'])) {
+        $tmp_address = $location['formatted_address'];
 
         // if the cached address has the approximate tag
-        if (!empty($addresses_cache[$location_address]['approximate'])) {
+        if (!empty($addresses_cache[$tmp_address]['approximate'])) {
           // Location in Database doesn't have approximate, and it's in the address cache, so write it to the database
-          update_post_meta($location['location_id'], 'approximate', $addresses_cache[$location_address]['approximate']);
+          update_post_meta($location['location_id'], 'approximate', $addresses_cache[$tmp_address]['approximate']);
         }
       }
     }

--- a/includes/database_updates.php
+++ b/includes/database_updates.php
@@ -72,14 +72,14 @@ if (!function_exists('db_update_remove_all_is_approximate_location_meta')) {
 
 // Function: Add approximate value to locations when we can do so without doing a new geocode
 // May want do a geocode sometime in a later version of the plugin
-if (!function_exists('tsml_db_set_address_approximate')) {
-  function tsml_db_set_address_approximate() {
+if (!function_exists('tsml_db_set_location_approximate')) {
+  function tsml_db_set_location_approximate() {
     $locations = tsml_get_locations();
     $addresses_cache = get_option('tsml_addresses');
 
     foreach ($locations as $location) {
       // if location doesn't have the approximate tag
-      if (empty($location['address_approximate'])) {
+      if (empty($location['approximate'])) {
         $tmp_address = $location['formatted_address'];
 
         // if the cached address has the approximate tag

--- a/includes/database_updates.php
+++ b/includes/database_updates.php
@@ -76,6 +76,16 @@ if (!function_exists('tsml_db_set_location_approximate')) {
   function tsml_db_set_location_approximate() {
     $locations = tsml_get_locations();
     $addresses_cache = get_option('tsml_addresses');
+    $tmp_cache = array();
+
+    // Remove addresses from cache if approximate is not set
+    foreach ($addresses_cache as $key => $address) {
+      if (!empty($address['approximate'])) {
+        $tmp_cache[$key] = $address;
+      }
+    }
+    $addresses_cache = $tmp_cache;
+    update_option('tsml_addresses', $addresses_cache);
 
     foreach ($locations as $location) {
       // if location doesn't have the approximate tag

--- a/includes/database_updates.php
+++ b/includes/database_updates.php
@@ -68,3 +68,26 @@ if (!function_exists('db_update_remove_all_is_approximate_location_meta')) {
     };
   };
 };
+
+
+// Function: Add approximate value to locations when we can do so without doing a new geocode
+// May want do a geocode sometime in a later version of the plugin
+if (!function_exists('tsml_db_set_address_approximate')) {
+  function tsml_db_set_address_approximate() {
+    $locations = tsml_get_locations();
+    $addresses_cache = get_option('tsml_addresses');
+
+    foreach ($locations as $location) {
+      // if location doesn't have the approximate tag
+      if (empty($location['approximate'])) {
+        $location_address = $location['formatted_address'];
+
+        // if the cached address has the approximate tag
+        if (!empty($addresses_cache[$location_address]['approximate'])) {
+          // Location in Database doesn't have approximate, and it's in the address cache, so write it to the database
+          update_post_meta($location['location_id'], 'approximate', $addresses_cache[$location_address]['approximate']);
+        }
+      }
+    }
+  }
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -938,6 +938,7 @@ function tsml_get_locations() {
 			'location_notes' => $post->post_content,
 			'location_url' => get_permalink($post->ID),
 			'formatted_address' => empty($location_meta[$post->ID]['formatted_address']) ? null : $location_meta[$post->ID]['formatted_address'],
+			'approximate' => empty($location_meta[$post->ID]['approximate']) ? null : $location_meta[$post->ID]['approximate'],
 			'latitude' => empty($location_meta[$post->ID]['latitude']) ? null : $location_meta[$post->ID]['latitude'],
 			'longitude' => empty($location_meta[$post->ID]['longitude']) ? null : $location_meta[$post->ID]['longitude'],
 			'region_id' => $region_id,
@@ -1191,7 +1192,7 @@ function tsml_get_meta($type, $id=null) {
 	//contact info still available on an individual meeting basis via tsml_get_meeting()
 	$keys = array(
 		'tsml_group' => '"website", "website_2", "email", "phone", "mailing_address", "venmo", "square", "paypal", "last_contact"' . (current_user_can('edit_posts') ? ', "contact_1_name", "contact_1_email", "contact_1_phone", "contact_2_name", "contact_2_email", "contact_2_phone", "contact_3_name", "contact_3_email", "contact_3_phone"' : ''),
-		'tsml_location' => '"formatted_address", "latitude", "longitude"',
+		'tsml_location' => '"formatted_address", "latitude", "longitude", "approximate"',
 		'tsml_meeting' => '"day", "time", "end_time", "types", "group_id", "website", "website_2", "email", "phone", "mailing_address", "venmo", "square", "paypal", "last_contact", "attendance_option", "conference_url", "conference_url_notes", "conference_phone", "conference_phone_notes"' . (current_user_can('edit_posts') ? ', "contact_1_name", "contact_1_email", "contact_1_phone", "contact_2_name", "contact_2_email", "contact_2_phone", "contact_3_name", "contact_3_email", "contact_3_phone"' : ''),
 	);
 	if (!array_key_exists($type, $keys)) return trigger_error('tsml_get_meta for unexpected type ' . $type);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1093,7 +1093,6 @@ function tsml_get_meetings($arguments=array(), $from_cache=true) {
 				'time'				=> @$meeting_meta[$post->ID]['time'],
 				'end_time'			=> @$meeting_meta[$post->ID]['end_time'],
 				'time_formatted'	=> tsml_format_time(@$meeting_meta[$post->ID]['time']),
-				'attendance_option'	=> @$meeting_meta[$post->ID]['attendance_option'],
 				'conference_url'	=> @$meeting_meta[$post->ID]['conference_url'],
 				'conference_url_notes'	=> @$meeting_meta[$post->ID]['conference_url_notes'],
 				'conference_phone'	=> @$meeting_meta[$post->ID]['conference_phone'],
@@ -1122,7 +1121,6 @@ function tsml_get_meetings($arguments=array(), $from_cache=true) {
 	for ($i=0; $i < count($meetings); $i++) {
 		if (empty($meetings[$i]['attendance_option'])) {
 			$meetings[$i]['attendance_option'] = tsml_calculate_attendance_option(empty($meetings[$i]['types']) ? array() : $meetings[$i]['types'], $meetings[$i]['formatted_address']);
-			update_post_meta($meetings[$i]['id'], 'attendance_option', $meetings[$i]['attendance_option']);
 			$rebuild_cache = true;
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -713,6 +713,9 @@ function tsml_geocode_google($address, $tsml_map_key) {
 	//check our overrides array again in case google is wrong
 	if (array_key_exists($data->results[0]->formatted_address, $tsml_google_overrides)) {
 		$response = $tsml_google_overrides[$data->results[0]->formatted_address];
+		if (empty($response['approximate'])) {
+			$response['approximate'] = 'no';
+		}
 	} else {
 		//start building response
 		// $myfile = fopen("./newfile.txt", "a") or die("Unable to open file!");

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -941,7 +941,7 @@ function tsml_get_locations() {
 			'location_notes' => $post->post_content,
 			'location_url' => get_permalink($post->ID),
 			'formatted_address' => empty($location_meta[$post->ID]['formatted_address']) ? null : $location_meta[$post->ID]['formatted_address'],
-			'address_approximate' => empty($location_meta[$post->ID]['approximate']) ? null : $location_meta[$post->ID]['approximate'],
+			'approximate' => empty($location_meta[$post->ID]['approximate']) ? null : $location_meta[$post->ID]['approximate'],
 			'latitude' => empty($location_meta[$post->ID]['latitude']) ? null : $location_meta[$post->ID]['latitude'],
 			'longitude' => empty($location_meta[$post->ID]['longitude']) ? null : $location_meta[$post->ID]['longitude'],
 			'region_id' => $region_id,
@@ -984,10 +984,10 @@ function tsml_get_meeting($meeting_id=false) {
 			'saddr' => 'Current Location',
 			'q' => $meeting->location,
 		));
-		$meeting->address_approximate = $location->approximate;
+		$meeting->approximate = $location->approximate;
 	}
 
-	if (empty($meeting->address_approximate)) $meeting->address_approximate = 'no';
+	if (empty($meeting->approximate)) $meeting->approximate = 'no';
 
 	//escape meeting values
 	foreach ($custom as $key=>$value) {
@@ -1026,10 +1026,10 @@ function tsml_get_meeting($meeting_id=false) {
 		$meeting->group = null;
 	}
 
-	$meeting->attendance_option = tsml_calculate_attendance_option($meeting->types, $meeting->address_approximate);
+	$meeting->attendance_option = tsml_calculate_attendance_option($meeting->types, $meeting->approximate);
 
 	// Remove TC when online only meeting has approximate address
-	if (!empty($meeting->types) && $meeting->attendance_option == 'online' && $meeting->address_approximate == 'yes') {
+	if (!empty($meeting->types) && $meeting->attendance_option == 'online' && $meeting->approximate == 'yes') {
 		$meeting->types = array_values(array_diff($meeting->types, array('TC')));
 	}
 
@@ -1119,15 +1119,15 @@ function tsml_get_meetings($arguments=array(), $from_cache=true) {
 			}
 
 			// Ensure each meeting has an address approximate value
-			if (empty($meeting['address_approximate'])) {
-				$meeting['address_approximate'] = 'no';
+			if (empty($meeting['approximate'])) {
+				$meeting['approximate'] = 'no';
 			}
 
 			// Calculate the attendance option
-			$meeting['attendance_option'] = tsml_calculate_attendance_option($meeting['types'], $meeting['address_approximate']);
+			$meeting['attendance_option'] = tsml_calculate_attendance_option($meeting['types'], $meeting['approximate']);
 
 			// Remove TC when online only meeting has approximate address
-			if (!empty($meeting['types']) && $meeting['attendance_option'] == 'online' && $meeting['address_approximate'] == 'yes') {
+			if (!empty($meeting['types']) && $meeting['attendance_option'] == 'online' && $meeting['approximate'] == 'yes') {
 				$meeting['types'] = array_values(array_diff($meeting['types'], array('TC')));
 			}
 
@@ -1154,8 +1154,7 @@ function tsml_get_meetings($arguments=array(), $from_cache=true) {
 
 //function: calculate attendance option given types and address
 // called in tsml_get_meetings()
-function tsml_calculate_attendance_option($types, $address_approximate) {
-	$approximate = $address_approximate == 'yes';
+function tsml_calculate_attendance_option($types, $approximate) {
 	$attendance_option = '';
 
 	// Handle when the types list is empty, this prevents PHP warnings
@@ -1170,13 +1169,13 @@ function tsml_calculate_attendance_option($types, $address_approximate) {
 	} elseif (in_array('ONL', $types)) {
 		// Types has Online, but not Temp closed, which means it's a hybrid (or online)
 		$attendance_option = 'hybrid';
-		if ($approximate) {
+		if ($approximate == 'yes') {
 			$attendance_option = 'online';
 		}
 	} else {
 		// Neither Online or Temp Closed, which means it's in person (or inactive)
 		$attendance_option = 'in_person';
-		if ($approximate) {
+		if ($approximate == 'yes') {
 			$attendance_option = 'inactive';
 		}
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -938,7 +938,7 @@ function tsml_get_locations() {
 			'location_notes' => $post->post_content,
 			'location_url' => get_permalink($post->ID),
 			'formatted_address' => empty($location_meta[$post->ID]['formatted_address']) ? null : $location_meta[$post->ID]['formatted_address'],
-			'approximate' => empty($location_meta[$post->ID]['approximate']) ? null : $location_meta[$post->ID]['approximate'],
+			'address_approximate' => empty($location_meta[$post->ID]['approximate']) ? null : $location_meta[$post->ID]['approximate'],
 			'latitude' => empty($location_meta[$post->ID]['latitude']) ? null : $location_meta[$post->ID]['latitude'],
 			'longitude' => empty($location_meta[$post->ID]['longitude']) ? null : $location_meta[$post->ID]['longitude'],
 			'region_id' => $region_id,

--- a/includes/save.php
+++ b/includes/save.php
@@ -104,7 +104,6 @@ function tsml_save_post($post_id, $post, $update) {
 		$attendance_option = $meeting_is_online ? 'online' : 'inactive';
 		array_push($_POST['types'], 'TC');
 	}
-	update_post_meta($post->ID, 'attendance_option', $attendance_option);
 
 	//video conferencing info
 	if (!$update || strcmp($old_meeting->conference_url, $valid_conference_url) !== 0) {

--- a/readme.txt
+++ b/readme.txt
@@ -62,6 +62,7 @@ Note you can add multiple entries to the array below.
 				'city' => 'Paris',
 				'latitude' => 48.858372,
 				'longitude' => 2.294481,
+				'approximate' => 'no',
 			),
 		));
 	}

--- a/templates/archive-meetings.php
+++ b/templates/archive-meetings.php
@@ -583,7 +583,7 @@ if (($day === null) && !empty($meeting['time'])) {
 break;
 
             case 'distance': ?>
-									<td class="distance" data-sort="<?php echo @$meeting['distance'] ?>"><?php echo @$meeting['distance'] ?></td>
+									<td class="distance" data-sort="<?php if (isset($meeting['distance'])) echo $meeting['distance'] ?>"><?php if (isset($meeting['distance'])) echo $meeting['distance'] ?></td>
 									<?php
 break;
 


### PR DESCRIPTION
Version 3.11.0 introduced a couple pretty major performance issues, especially when the site has a lot of meetings. These were caused because the geocoding method was called for each meeting returned by the tsml_get_meeting and tsml_get_meetings. This cause a lot of unnecessary database calls, which broke sites with a lot of meetings, like Boston.

With this PR, we now store whether an address is approximate (or specific) in the "location" metadata, so we can get that information much more efficiently.

It also fixes an issue when an address is overridden because these address don't include the "approximate" tag. Now, it will assume these addresses are specific addresses because there shouldn't be a need to override an approximate address.