### PR TITLE
Allow user to add feedback_url via themes functions.php. Fixes #598

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1047,6 +1047,25 @@ function tsml_get_meeting($meeting_id = false)
 	return $meeting;
 }
 
+//function: get feedback_url
+//called in tsml_get_meta
+function tsml_feedback_url($post)
+{
+    global $tsml_feedback_url;
+
+    if (isset($tsml_feedback_url)) {
+        $id = $post->ID;
+        $slug = $post->post_name;
+
+        $url = $tsml_feedback_url;
+
+        $url = str_replace('{{id}}', $id, $url);
+        $url = str_replace('{{slug}}', $slug, $url);
+    }
+    return esc_url_raw($url, ['http', 'https', 'mailto', 'tel', 'sms']);
+}
+
+
 //function: get meetings based on unsanitized $arguments
 //$from_cache is only false when calling from tsml_cache_rebuild()
 //used:		tsml_ajax_meetings(), single-locations.php, archive-meetings.php
@@ -1098,6 +1117,7 @@ function tsml_get_meetings($arguments = [], $from_cache = true)
 				'time' => isset($meeting_meta[$post->ID]['time']) ? $meeting_meta[$post->ID]['time'] : null,
 				'end_time' => isset($meeting_meta[$post->ID]['end_time']) ? $meeting_meta[$post->ID]['end_time'] : null,
 				'time_formatted' => isset($meeting_meta[$post->ID]['time']) ? tsml_format_time($meeting_meta[$post->ID]['time']) : null,
+				'feedback_url' => tsml_feedback_url($post),
 				'conference_url' => isset($meeting_meta[$post->ID]['conference_url']) ? $meeting_meta[$post->ID]['conference_url'] : null,
 				'conference_url_notes' => isset($meeting_meta[$post->ID]['conference_url_notes']) ? $meeting_meta[$post->ID]['conference_url_notes'] : null,
 				'conference_phone' => isset($meeting_meta[$post->ID]['conference_phone']) ? $meeting_meta[$post->ID]['conference_phone'] : null,

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1052,6 +1052,7 @@ function tsml_get_meeting($meeting_id = false)
 function tsml_feedback_url($post)
 {
     global $tsml_feedback_url;
+    $url = "";
 
     if (isset($tsml_feedback_url)) {
         $id = $post->ID;
@@ -1062,7 +1063,7 @@ function tsml_feedback_url($post)
         $url = str_replace('{{id}}', $id, $url);
         $url = str_replace('{{slug}}', $slug, $url);
     }
-    return esc_url_raw($url, ['http', 'https', 'mailto', 'tel', 'sms']);
+    return $url;
 }
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,7 @@ Add this to your theme's functions.php.
 
 	$tsml_street_only = false;
 
-= Can I add a feedback_url to each meeting when using tsml_ui? = Add a URL to your themes functions.php.
+= Can I add a feedback_url to each meeting when using TSML UI? = Add a URL to your themes functions.php.
 
 	$tsml_feedback_url = "https://domain.com?meeting={{slug}}";
 	$tsml_feedback_url = "https://domain.com?meeting={{id}}";

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,12 @@ Add this to your theme's functions.php.
 
 	$tsml_street_only = false;
 
+= Can I add a feedback_url to each meeting when using tsml_ui? = Add a URL to your themes functions.php.
+
+	$tsml_feedback_url = "https://domain.com?meeting={{slug}}";
+	$tsml_feedback_url = "https://domain.com?meeting={{id}}";
+	$tsml_feedback_url = "mailto:office@domain.com?subject={{slug}}";
+
 = Can I change the order of the columns on the meeting list page, eg put the Region first? =
 Add this to your theme's functions.php. Feel free to change the order or column names (eg 'Region') but keep the keys the same (eg 'region').
 


### PR DESCRIPTION
For advanced users using tsml_ui. Allows user to build a URL to be included in meetings feed.

$tsml_feedback_url = "https://domain.com?meeting={{slug}}";
$tsml_feedback_url = "https://domain.com?meeting={{id}}";
$tsml_feedback_url = "mailto:office@domain.com?subject={{slug}}";