### PR TITLE
Use the array_filter function instead of array_map

### DIFF
--- a/includes/database_updates.php
+++ b/includes/database_updates.php
@@ -33,9 +33,9 @@ function tsml_db_set_location_approximate()
   $addresses = get_option('tsml_addresses', []);
 
   // Remove addresses from cache if approximate or formatted_address is not set
-  $addresses = array_map(function ($address) {
+  $addresses = array_filter($addresses, function ($address) {
     return !empty($address['approximate']) && !empty($address['formatted_address']);
-  }, $addresses);
+  });
 
   update_option('tsml_addresses', $addresses);
 


### PR DESCRIPTION
This PR addresses the issue where addresses in the cache were being changed from an array, into a boolean. It was using array_map function, when it should have been using the array_filter function