### PR TITLE
Updating TSML UI URL

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -102,7 +102,7 @@ add_shortcode('tsml_types_list', function () {
 function tsml_ui()
 {
 	global $tsml_mapbox_key, $tsml_nonce, $tsml_conference_providers, $tsml_language, $tsml_programs, $tsml_program, $tsml_ui_config, $tsml_feedback_addresses;
-	$js = defined('TSML_UI_PATH') ? TSML_UI_PATH : 'https://react.meetingguide.org/app.js';
+	$js = defined('TSML_UI_PATH') ? TSML_UI_PATH : 'https://tsml-ui.code4recovery.org/app.js';
 	wp_enqueue_script('tsml_ui', $js);
 	wp_localize_script('tsml_ui', 'tsml_react_config', array_merge(
 		[


### PR DESCRIPTION
TSML UI has moved from react.meetingguide.org (domain controlled by GSO) to tsml-ui.code4recovery.org (domain controlled by C4R).

Making this change will have no user impact but it will enable me to save considerably on my annual hosting bill. Thanks!