### PR TITLE
Issue425

### DIFF
--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -36,6 +36,14 @@ add_action('admin_init', function () {
 		// Delete the attendance_option metadata tag, don't need it
 		delete_metadata('post', 0, 'attendance_option', false, true);
 
+		// Remove old cache info
+		if ($tmpstr = get_option('tsml_cache')) {
+			if (file_exists(WP_CONTENT_DIR . $tmpstr)) {
+				unlink(WP_CONTENT_DIR . $tmpstr);
+			}
+			delete_option('tsml_cache');
+		}
+
 		//Rebuild the meeting cache
 		tsml_cache_rebuild();
 

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -224,13 +224,13 @@ function tsml_ajax_csv()
 			} elseif ($column == 'day') {
 				$line[] = $tsml_days[$meeting[$column]];
 			} elseif ($column == 'types') {
-				$types = $meeting[$column];
+				$types = !empty($meeting[$column]) ? $meeting[$column] : [];
 				if (!is_array($types)) $types = [];
 				foreach ($types as &$type) $type = $tsml_programs[$tsml_program]['types'][trim($type)];
 				sort($types);
 				$line[] = $escape . implode(', ', $types) . $escape;
 			} elseif (strstr($column, 'notes')) {
-				$line[] = $escape . strip_tags(str_replace($escape, str_repeat($escape, 2), $meeting[$column])) . $escape;
+				$line[] = $escape . strip_tags(str_replace($escape, str_repeat($escape, 2), !empty($meeting[$column]) ? $meeting[$column] : '')) . $escape;
 			} elseif (array_key_exists($column, $meeting)) {
 				$line[] = $escape . str_replace($escape, '', $meeting[$column]) . $escape;
 			} else {

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -158,7 +158,7 @@ function tsml_ajax_csv()
 	}
 
 	//get data source
-	$meetings = tsml_get_meetings();
+	$meetings = tsml_get_meetings([], false, true);
 
 	//define columns to output, always in English for portability (per Poland NA)
 	$columns = [
@@ -201,6 +201,7 @@ function tsml_ajax_csv()
 		'conference_phone_notes' => 'Conference Phone Notes',
 		'author' => 				'Author',
 		'slug' => 					'Slug',
+		'data_source' =>			'Data Source',
 		'updated' =>				'Updated',
 	];
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1392,7 +1392,9 @@ function tsml_import_buffer_set($meetings, $data_source_url = null, $data_source
 	$count_meetings = count($meetings);
 	for ($i = 0; $i < $count_meetings; $i++) {
 
-		$meetings[$i]['data_source'] = $data_source_url;
+		if (empty($meetings[$i]['data_source'])) {
+			$meetings[$i]['data_source'] = $data_source_url;
+		}
 		$meetings[$i]['data_source_parent_region_id'] = $data_source_parent_region_id;
 
 		//do wordpress sanitization

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -116,7 +116,7 @@ function tsml_ui()
 		],
 		$tsml_ui_config
 	));
-	$data = admin_url('admin-ajax.php') . '?action=meetings&nonce=' . wp_create_nonce($tsml_nonce);
+	$data = content_url('meetings.json');
 	return '<div id="tsml-ui" 
 					data-src="' . $data . '" 
 					data-timezone="' . get_option('timezone_string', 'America/New_York') . '" 

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -9,10 +9,7 @@ if you need to customize your site, please follow the instructions on our FAQ:
 $tsml_bounds = get_option('tsml_bounds');
 
 //get the secret cache location
-if (!$tsml_cache = get_option('tsml_cache')) {
-	$tsml_cache = '/tsml-cache-' . substr(str_shuffle(md5(microtime())), 0, 10) . '.json';
-	update_option('tsml_cache', $tsml_cache);
-}
+$tsml_cache = '/meetings.json';
 
 // Define attendance options
 $tsml_meeting_attendance_options = [


### PR DESCRIPTION
This PR addresses the feed issues from Issue #425.

These include:
- Making the cache file of meetings follow the directive from the "Meeting/Group Contacts Are" (Private/Public) field
- Moving the cache file to /wp-content/meetings.json
- CSV Exports/Imports include all fields, including Meeting/Group contacts, and whether the meeting is from a data_source (feed). This makes it a more complete backup/restore of meetings
- Change the data src URL in the [tsml_ui] short code to use meetings.json

It also fixes a couple of PHP warnings when exporting CSV file when some of the optional fields are empty.

A future PR will address how to handle the "Authorized Apps" section of the settings page. We'll need to have some future discussions about that, and how to deprecate the existing admin-ajax feeds. For now, this PR is a good first step, and can stand on it's own.