### PR TITLE
Display 'Inactive' rather than 'Temporarily Inactive'

### DIFF
--- a/includes/variables.php
+++ b/includes/variables.php
@@ -16,7 +16,7 @@ $tsml_meeting_attendance_options = [
 	'in_person' => __('In-person', '12-step-meeting-list'),
 	'hybrid' => __('In-person and Online', '12-step-meeting-list'),
 	'online' => __('Online', '12-step-meeting-list'),
-	'inactive' => __('Temporarily Inactive', '12-step-meeting-list'),
+	'inactive' => __('Inactive', '12-step-meeting-list'),
 ];
 
 //load the set of columns that should be present in the list (not sure why this shouldn't go after plugins_loaded below)

--- a/templates/single-meetings.php
+++ b/templates/single-meetings.php
@@ -94,8 +94,8 @@ get_header();
 													<path fill-rule="evenodd" d="M10.97 4.97a.75.75 0 0 1 1.071 1.05l-3.992 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.236.236 0 0 1 .02-.022z"/>
 												</svg>';
 										if ($meeting->attendance_option === 'hybrid') {
-											echo '<li>' . $li_marker . __('In-person', '12-step-meeting-list') . '</li>' . PHP_EOL;
-											echo '<li>' . $li_marker . __('Online', '12-step-meeting-list') . '</li>' . PHP_EOL;
+											echo '<li>' . $li_marker . $tsml_meeting_attendance_options['in_person'] . '</li>' . PHP_EOL;
+											echo '<li>' . $li_marker . $tsml_meeting_attendance_options['online'] . '</li>' . PHP_EOL;
 										} else {
 											echo '<li>' . $li_marker . $tsml_meeting_attendance_options[$meeting->attendance_option] . '</li>' . PHP_EOL;
 										}

--- a/templates/single-meetings.php
+++ b/templates/single-meetings.php
@@ -105,7 +105,7 @@ get_header();
 												echo '<li>' . $li_marker . __('Online', '12-step-meeting-list') . '</li>' . PHP_EOL;
 												break;
 											case 'inactive':
-												echo '<li>' . $li_marker . __('Temporarily Inactive', '12-step-meeting-list') . '</li>' . PHP_EOL;
+												echo '<li>' . $li_marker . __('Inactive', '12-step-meeting-list') . '</li>' . PHP_EOL;
 												break;
 											default:
 												break;

--- a/templates/single-meetings.php
+++ b/templates/single-meetings.php
@@ -93,22 +93,11 @@ get_header();
 										$li_marker = '<svg class="icon" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
 													<path fill-rule="evenodd" d="M10.97 4.97a.75.75 0 0 1 1.071 1.05l-3.992 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.236.236 0 0 1 .02-.022z"/>
 												</svg>';
-										switch ($meeting->attendance_option) {
-											case 'in_person':
-												echo '<li>' . $li_marker . __('In person', '12-step-meeting-list') . '</li>' . PHP_EOL;
-												break;
-											case 'hybrid':
-												echo '<li>' . $li_marker . __('In person', '12-step-meeting-list') . '</li>' . PHP_EOL;
-												echo '<li>' . $li_marker . __('Online', '12-step-meeting-list') . '</li>' . PHP_EOL;
-												break;
-											case 'online':
-												echo '<li>' . $li_marker . __('Online', '12-step-meeting-list') . '</li>' . PHP_EOL;
-												break;
-											case 'inactive':
-												echo '<li>' . $li_marker . __('Inactive', '12-step-meeting-list') . '</li>' . PHP_EOL;
-												break;
-											default:
-												break;
+										if ($meeting->attendance_option === 'hybrid') {
+											echo '<li>' . $li_marker . __('In-person', '12-step-meeting-list') . '</li>' . PHP_EOL;
+											echo '<li>' . $li_marker . __('Online', '12-step-meeting-list') . '</li>' . PHP_EOL;
+										} else {
+											echo '<li>' . $li_marker . $tsml_meeting_attendance_options[$meeting->attendance_option] . '</li>' . PHP_EOL;
 										}
 										?>
 										<li>


### PR DESCRIPTION
This PR displays the word "Inactive" rather than "Temporarily Inactive". This was requested in discussion item #701, which became issue #719