### PR TITLE
Issue425 - use meetings.json as the cache file

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1072,10 +1072,10 @@ function tsml_feedback_url($post)
 //used:		tsml_ajax_meetings(), single-locations.php, archive-meetings.php
 function tsml_get_meetings($arguments = [], $from_cache = true, $full_export = false)
 {
-	global $tsml_cache, $tsml_contact_fields, $tsml_contact_display;
+	global $tsml_cache, $tsml_cache_writable, $tsml_contact_fields, $tsml_contact_display;
 
 	//start by grabbing all meetings
-	if ($from_cache && file_exists(WP_CONTENT_DIR . $tsml_cache) && $meetings = file_get_contents(WP_CONTENT_DIR . $tsml_cache)) {
+	if ($from_cache && $tsml_cache_writable && $meetings = file_get_contents(WP_CONTENT_DIR . $tsml_cache)) {
 		$meetings = json_decode($meetings, true);
 	} else {
 		//from database

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1181,8 +1181,14 @@ function tsml_get_meetings($arguments = [], $from_cache = true, $full_export = f
 
 		//write array to cache
 		if (!$full_export) {
-			$filesize = file_put_contents(WP_CONTENT_DIR . $tsml_cache, json_encode($meetings));
-			update_option('tsml_cache_writable', $filesize === false ? 0 : 1);
+			$filepath = WP_CONTENT_DIR . $tsml_cache;
+			// Check if the file is writable, and if so, write it
+			if (is_writable($filepath) || (!file_exists($filepath) && is_writable(WP_CONTENT_DIR))) {
+				$filesize = file_put_contents($filepath, json_encode($meetings));
+				update_option('tsml_cache_writable', $filesize === false ? 0 : 1);
+			} else {
+				update_option('tsml_cache_writable', 0);
+			}
 		}
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1181,7 +1181,8 @@ function tsml_get_meetings($arguments = [], $from_cache = true, $full_export = f
 
 		//write array to cache
 		if (!$full_export) {
-			file_put_contents(WP_CONTENT_DIR . $tsml_cache, json_encode($meetings));
+			$filesize = file_put_contents(WP_CONTENT_DIR . $tsml_cache, json_encode($meetings));
+			update_option('tsml_cache_writable', $filesize === false ? 0 : 1);
 		}
 	}
 

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -118,7 +118,7 @@ function tsml_ui()
 	));
 
 	// use meetings.json if it's writable, otherwise use the admin-ajax URL to the feed
-	$data = $tsml_cache_writable ? content_url('meetings.json') : $data = admin_url('admin-ajax.php') . '?action=meetings&nonce=' . wp_create_nonce($tsml_nonce);
+	$data = $tsml_cache_writable ? content_url('meetings.json') : admin_url('admin-ajax.php') . '?action=meetings&nonce=' . wp_create_nonce($tsml_nonce);
 	return '<div id="tsml-ui"
 					data-src="' . $data . '"
 					data-timezone="' . get_option('timezone_string', 'America/New_York') . '"

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -101,7 +101,7 @@ add_shortcode('tsml_types_list', function () {
 //output a react meeting finder widget https://github.com/code4recovery/tsml-ui
 function tsml_ui()
 {
-	global $tsml_mapbox_key, $tsml_nonce, $tsml_conference_providers, $tsml_language, $tsml_programs, $tsml_program, $tsml_ui_config, $tsml_feedback_addresses;
+	global $tsml_mapbox_key, $tsml_nonce, $tsml_conference_providers, $tsml_language, $tsml_programs, $tsml_program, $tsml_ui_config, $tsml_feedback_addresses, $tsml_cache_writable;
 	$js = defined('TSML_UI_PATH') ? TSML_UI_PATH : 'https://tsml-ui.code4recovery.org/app.js';
 	wp_enqueue_script('tsml_ui', $js, [], false, true);
 	wp_localize_script('tsml_ui', 'tsml_react_config', array_merge(
@@ -116,10 +116,12 @@ function tsml_ui()
 		],
 		$tsml_ui_config
 	));
-	$data = content_url('meetings.json');
-	return '<div id="tsml-ui" 
-					data-src="' . $data . '" 
-					data-timezone="' . get_option('timezone_string', 'America/New_York') . '" 
+
+	// use meetings.json if it's writable, otherwise use the admin-ajax URL to the feed
+	$data = $tsml_cache_writable ? content_url('meetings.json') : $data = admin_url('admin-ajax.php') . '?action=meetings&nonce=' . wp_create_nonce($tsml_nonce);
+	return '<div id="tsml-ui"
+					data-src="' . $data . '"
+					data-timezone="' . get_option('timezone_string', 'America/New_York') . '"
 					data-mapbox="' . $tsml_mapbox_key . '"></div>';
 }
 add_shortcode('tsml_react', 'tsml_ui');

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -101,7 +101,7 @@ add_shortcode('tsml_types_list', function () {
 //output a react meeting finder widget https://github.com/code4recovery/tsml-ui
 function tsml_ui()
 {
-	global $tsml_mapbox_key, $tsml_nonce, $tsml_conference_providers, $tsml_language, $tsml_programs, $tsml_program, $tsml_ui_config, $tsml_feedback_addresses, $tsml_cache_writable;
+	global $tsml_mapbox_key, $tsml_nonce, $tsml_conference_providers, $tsml_language, $tsml_programs, $tsml_program, $tsml_ui_config, $tsml_feedback_addresses, $tsml_cache, $tsml_cache_writable;
 	$js = defined('TSML_UI_PATH') ? TSML_UI_PATH : 'https://tsml-ui.code4recovery.org/app.js';
 	wp_enqueue_script('tsml_ui', $js, [], false, true);
 	wp_localize_script('tsml_ui', 'tsml_react_config', array_merge(
@@ -118,7 +118,7 @@ function tsml_ui()
 	));
 
 	// use meetings.json if it's writable, otherwise use the admin-ajax URL to the feed
-	$data = $tsml_cache_writable ? content_url('meetings.json') : admin_url('admin-ajax.php') . '?action=meetings&nonce=' . wp_create_nonce($tsml_nonce);
+	$data = $tsml_cache_writable && file_exists(WP_CONTENT_DIR . $tsml_cache) ? content_url('meetings.json') : admin_url('admin-ajax.php') . '?action=meetings&nonce=' . wp_create_nonce($tsml_nonce);
 	return '<div id="tsml-ui"
 					data-src="' . $data . '"
 					data-timezone="' . get_option('timezone_string', 'America/New_York') . '"

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -10,6 +10,7 @@ $tsml_bounds = get_option('tsml_bounds');
 
 //get the secret cache location
 $tsml_cache = '/meetings.json';
+$tsml_cache_writable = file_exists(WP_CONTENT_DIR . $tsml_cache) && is_writable(WP_CONTENT_DIR . $tsml_cache);
 
 // Define attendance options
 $tsml_meeting_attendance_options = [

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -10,7 +10,7 @@ $tsml_bounds = get_option('tsml_bounds');
 
 //get the secret cache location
 $tsml_cache = '/meetings.json';
-$tsml_cache_writable = file_exists(WP_CONTENT_DIR . $tsml_cache) && is_writable(WP_CONTENT_DIR . $tsml_cache);
+$tsml_cache_writable = boolval(get_option('tsml_cache_writable', 0));
 
 // Define attendance options
 $tsml_meeting_attendance_options = [


### PR DESCRIPTION
This PR is a follow up to PR #718, addressing issue #425. It addresses the case where the cache file isn't actually written when the plugin tries to write it.

When the cache file wasn't written, this PR bypasses the cache file, reading from the database directly. This helps ensure current information is being used. For example, then the cache file was written, TSML UI can use it as the data source, but if the file wasn't written, then the data source is the admin-ajax URL, which will read from the database if necessary.