### PR TITLE
Updates importing of Google Sheets meeting data to Google Sheets v4 API

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1716,15 +1716,20 @@ function tsml_import_reformat_fnv($rows)
 //used: tsml_import_buffer_set
 function tsml_import_reformat_googlesheet($data)
 {
-$meetings = [];
+	$meetings = [];
 
-	for ($i = 1; $i < count($data['values']); $i++) {
+	$header = array_shift($data['values']);
+	$header = array_map('sanitize_title_with_dashes', $header);
+	$header = str_replace('-', '_', $header);
+	$header_count = count($header);
+
+	foreach ($data['values'] as $row) {
 
 		//creates a meeting array with elements corresponding to each column header of the Google Sheet; updated for Google Sheets v4 API 
 		$meeting = [];
-		for ($j=0; $j < count($data['values'][0]); $j++) {
-			if ( isset($data['values'][$i][$j]) ){			
-				$meeting[$data['values'][0][$j]] = $data['values'][$i][$j];
+		for ($j = 0; $j < $header_count; $j++) {
+			if (isset($row[$j])) {
+				$meeting[$header[$j]] = $row[$j];
 			}
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1328,7 +1328,7 @@ function tsml_import_buffer_set($meetings, $data_source_url = null, $data_source
 {
 	global $tsml_programs, $tsml_program, $tsml_days, $tsml_meeting_attendance_options, $tsml_data_sources;
 
-	if (strpos($data_source_url, "spreadsheets.google.com") !== false) {
+	if (strpos($data_source_url, "sheets.googleapis.com") !== false) {
 		$meetings = tsml_import_reformat_googlesheet($meetings);
 	}
 
@@ -1716,16 +1716,15 @@ function tsml_import_reformat_fnv($rows)
 //used: tsml_import_buffer_set
 function tsml_import_reformat_googlesheet($data)
 {
-	$meetings = [];
+$meetings = [];
 
-	for ($i = 0; $i < count($data['feed']['entry']); $i++) {
+	for ($i = 1; $i < count($data['values']); $i++) {
 
-		//creates a meeting array with elements corresponding to each column header of the Google Sheet
+		//creates a meeting array with elements corresponding to each column header of the Google Sheet; updated for Google Sheets v4 API 
 		$meeting = [];
-		$meetingKeys = array_keys($data['feed']['entry'][$i]);
-		for ($j = 0; $j < count($meetingKeys); $j++) {
-			if (substr($meetingKeys[$j], 0, 4) == "gsx$") {
-				$meeting[substr($meetingKeys[$j], 4)] = $data['feed']['entry'][$i][$meetingKeys[$j]]['$t'];
+		for ($j=0; $j < count($data['values'][0]); $j++) {
+			if ( isset($data['values'][$i][$j]) ){			
+				$meeting[$data['values'][0][$j]] = $data['values'][$i][$j];
 			}
 		}
 


### PR DESCRIPTION
Years ago I did a pull request to add code to allow the 12-Step-Meeting-List to import meeting data from Google Sheets using the Google Sheets v3 API. This was done specifically so that the Area 72 website running the 12-Step-Meeting-List could import meeting data from the Puget Sound Central Service Office meetings Google Sheet.

In August 2021 Google deprecated the Google Sheets v3 API, and thus this pull request updates the 12-Step-Meeting-List to utilize the Google Sheets v4 API and once again allow Area 72 (and any other user of this plugin) to import meeting data from a Google Sheet.

Here is the link to the Puget Sound CSO's meeting feed that you can use for testing:
https://sheets.googleapis.com/v4/spreadsheets/13W4lBuRWKpnHNOC_3wTXI5anLVOkyvMmyn4Wvqx1z3c/values/A1:ZZ?key=AIzaSyAdMoeqxk-EWspUIJDwN7GBSwWSzgL6E5A

