### PR TITLE
Cache buster for Feed URL in tsml_ui shortcode - issue 783

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -118,7 +118,7 @@ function tsml_ui()
 	));
 
 	// use meetings.json if it's writable, otherwise use the admin-ajax URL to the feed
-	$data = $tsml_cache_writable && file_exists(WP_CONTENT_DIR . $tsml_cache) && defined('ABSPATH') ? get_site_url() . str_replace(ABSPATH, '/', WP_CONTENT_DIR) . $tsml_cache : admin_url('admin-ajax.php') . '?action=meetings&nonce=' . wp_create_nonce($tsml_nonce);
+	$data = $tsml_cache_writable && file_exists(WP_CONTENT_DIR . $tsml_cache) && defined('ABSPATH') ? get_site_url() . str_replace(ABSPATH, '/', WP_CONTENT_DIR) . $tsml_cache  . '?' . filemtime(WP_CONTENT_DIR . $tsml_cache) : admin_url('admin-ajax.php') . '?action=meetings&nonce=' . wp_create_nonce($tsml_nonce);
 	return '<div id="tsml-ui"
 					data-src="' . $data . '"
 					data-timezone="' . get_option('timezone_string', 'America/New_York') . '"


### PR DESCRIPTION
Add the modified time to the feed URL in the tsml_ui shortcode.

Closes #783 