### PR TITLE
add regions key to json

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -943,6 +943,9 @@ function tsml_get_locations()
 			'region_id' => $region_id,
 			'region' => $region,
 			'sub_region' => $sub_region,
+			'regions' => array_reverse(array_map(function ($region_id) {
+				return get_term($region_id, 'tsml_region')->name;
+			}, array_merge([$region_id], get_ancestors($region_id, 'tsml_region')))),
 		];
 	}
 


### PR DESCRIPTION
this fixes #846 by adding a `regions` key to the json, for example:

```
  'regions' => ['New York', 'Manhattan', 'Downtown', 'East Village'],
  'regions' => ['Germany', 'Berlin', 'Kreuzberg'],
```

this will enable TSML UI to support more than two levels of hierarchy in the region menu