### PR TITLE
add flag settings to TSML UI configuration

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -114,8 +114,8 @@ function tsml_ui()
 			'columns' => array_keys($tsml_columns),
 			'conference_providers' => $tsml_conference_providers,
 			'distance_unit' => $tsml_distance_units,
-			'flags' => $tsml_programs[$tsml_program]['flags'],
 			'feedback_emails' => array_values($tsml_feedback_addresses),
+			'flags' => $tsml_programs[$tsml_program]['flags'],
 			'strings' => [
 				$tsml_language => array_merge($tsml_columns, [
 					'types' => $tsml_programs[$tsml_program]['types'],

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -114,6 +114,7 @@ function tsml_ui()
 			'columns' => array_keys($tsml_columns),
 			'conference_providers' => $tsml_conference_providers,
 			'distance_unit' => $tsml_distance_units,
+			'flags' => $tsml_programs[$tsml_program]['flags'],
 			'feedback_emails' => array_values($tsml_feedback_addresses),
 			'strings' => [
 				$tsml_language => array_merge($tsml_columns, [


### PR DESCRIPTION
closes #905
from #904 

this PR passes local website flag settings to TSML UI, allowing sites to customize which flags are showing, rather than displaying the default (`Men`, `Women`).

there is a side effect of implementing this PR: websites sites that upgrade (and do not customize) will have `Location Temporarily Closed` added to their flags automatically, because this is a default setting in TSML (but not TSML UI).

default
![Screenshot 2022-09-07 at 08-12-39 Meetings](https://user-images.githubusercontent.com/1551689/188914653-e65f63b2-98b5-449a-aeb3-4b9c0cd4e789.png)

customized
![Screenshot 2022-09-07 at 08-14-56 Meetings](https://user-images.githubusercontent.com/1551689/188915398-b7ba7b2e-8fb6-4855-95bb-d08b1f521fe9.png)
