### PR TITLE
fix for wp managed hosting

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -131,6 +131,10 @@ function tsml_ui()
 		? get_site_url() . str_replace(ABSPATH, '/', WP_CONTENT_DIR) . $tsml_cache  . '?' . filemtime(WP_CONTENT_DIR . $tsml_cache)
 		: admin_url('admin-ajax.php') . '?action=meetings&nonce=' . wp_create_nonce($tsml_nonce);
 
+	// remove URL domain to fix CORS issues caused by GoDaddy Managed WP
+	$url = parse_url($data);
+	$data = $url['path'] . '?' . $url['query'];
+
 	return '<div id="tsml-ui"
 					data-src="' . $data . '"
 					data-timezone="' . get_option('timezone_string', 'America/New_York') . '"


### PR DESCRIPTION
<img width="824" alt="Screen Shot 2022-10-20 at 6 12 18 PM" src="https://user-images.githubusercontent.com/1551689/197088223-8dbc5d52-7af6-42a1-b7b4-fab3d6c375bf.png">

removes domain from TSML UI JSON URL to fix issue caused by GoDaddy Manged WP hosting