### PR TITLE
964 update registration of tslm_meeting post type with with_front filter

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -300,7 +300,7 @@ function tsml_custom_post_types()
 			'show_ui' => true,
 			'has_archive' => $is_public,
 			'menu_icon' => 'dashicons-groups',
-			'rewrite' => ['slug' => $tsml_slug],
+			'rewrite' => ['slug' => $tsml_slug, 'with_front' => apply_filters('tslm_meeting_with_front', true)],
 		]
 	);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -300,7 +300,7 @@ function tsml_custom_post_types()
 			'show_ui' => true,
 			'has_archive' => $is_public,
 			'menu_icon' => 'dashicons-groups',
-			'rewrite' => ['slug' => $tsml_slug, 'with_front' => apply_filters('tslm_meeting_with_front', true)],
+			'rewrite' => ['slug' => $tsml_slug, 'with_front' => apply_filters('tsml_meeting_with_front', true)],
 		]
 	);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -300,7 +300,7 @@ function tsml_custom_post_types()
 			'show_ui' => true,
 			'has_archive' => $is_public,
 			'menu_icon' => 'dashicons-groups',
-            'rewrite' => ['slug' => $tsml_slug, 'with_front' => apply_filters('tsml_meeting_with_front', true)],
+			'rewrite' => ['slug' => $tsml_slug, 'with_front' => apply_filters('tslm_meeting_with_front', true)],
 		]
 	);
 
@@ -1725,7 +1725,7 @@ function tsml_import_reformat_googlesheet($data)
 
 	foreach ($data['values'] as $row) {
 
-		//creates a meeting array with elements corresponding to each column header of the Google Sheet; updated for Google Sheets v4 API
+		//creates a meeting array with elements corresponding to each column header of the Google Sheet; updated for Google Sheets v4 API 
 		$meeting = [];
 		for ($j = 0; $j < $header_count; $j++) {
 			if (isset($row[$j])) {
@@ -2070,7 +2070,7 @@ function tsml_import_changes($feed_meetings, $data_source_url, $data_source_last
 		__('Saturday', '12-step-meeting-list'),
 	];
 
-	// get local meetings
+	// get local meetings 
 	$all_db_meetings = tsml_get_meetings();
 	$ds_ids = tsml_get_data_source_ids($data_source_url);
 	sort($ds_ids);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -300,7 +300,7 @@ function tsml_custom_post_types()
 			'show_ui' => true,
 			'has_archive' => $is_public,
 			'menu_icon' => 'dashicons-groups',
-			'rewrite' => ['slug' => $tsml_slug, 'with_front' => apply_filters('tslm_meeting_with_front', true)],
+            'rewrite' => ['slug' => $tsml_slug, 'with_front' => apply_filters('tsml_meeting_with_front', true)],
 		]
 	);
 
@@ -1725,7 +1725,7 @@ function tsml_import_reformat_googlesheet($data)
 
 	foreach ($data['values'] as $row) {
 
-		//creates a meeting array with elements corresponding to each column header of the Google Sheet; updated for Google Sheets v4 API 
+		//creates a meeting array with elements corresponding to each column header of the Google Sheet; updated for Google Sheets v4 API
 		$meeting = [];
 		for ($j = 0; $j < $header_count; $j++) {
 			if (isset($row[$j])) {
@@ -2070,7 +2070,7 @@ function tsml_import_changes($feed_meetings, $data_source_url, $data_source_last
 		__('Saturday', '12-step-meeting-list'),
 	];
 
-	// get local meetings 
+	// get local meetings
 	$all_db_meetings = tsml_get_meetings();
 	$ds_ids = tsml_get_data_source_ids($data_source_url);
 	sort($ds_ids);

--- a/readme.txt
+++ b/readme.txt
@@ -249,6 +249,11 @@ You may set it to false to hide the public meeting finder altogether.
 
 To apply these changes, you must go to Settings > Permalinks and click "Save Changes"
 
+= Can I change the with_front configuration of the tsml meeting post type
+Yes, you can use the following filter to change the with_front configuration from true to false
+
+	add_filter( 'tslm_meeting_with_front', '__return_false');
+
 == Screenshots ==
 
 1. Meeting list page

--- a/readme.txt
+++ b/readme.txt
@@ -249,10 +249,10 @@ You may set it to false to hide the public meeting finder altogether.
 
 To apply these changes, you must go to Settings > Permalinks and click "Save Changes"
 
-= Can I update the $tsml_slug to be appended after the site url instead of the blog url identified in permalinks structure
+= Can I change the with_front configuration of the tsml meeting post type
 Yes, you can use the following filter to change the with_front configuration from true to false
 
-	add_filter( 'tsml_meeting_with_front', '__return_false');
+	add_filter( 'tslm_meeting_with_front', '__return_false');
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -249,10 +249,10 @@ You may set it to false to hide the public meeting finder altogether.
 
 To apply these changes, you must go to Settings > Permalinks and click "Save Changes"
 
-= Can I change the with_front configuration of the tsml meeting post type
+= Can I update the $tsml_slug to be appended after the site url instead of the blog url identified in permalinks structure
 Yes, you can use the following filter to change the with_front configuration from true to false
 
-	add_filter( 'tslm_meeting_with_front', '__return_false');
+	add_filter( 'tsml_meeting_with_front', '__return_false');
 
 == Screenshots ==
 


### PR DESCRIPTION
Added filter to allow altering the `with_front` configuration of the `tsml_meeting` post type. Also updated documentation with instructions on how to apply the filter.