### PR TITLE
don't regenerate cache after every update

### DIFF
--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -28,7 +28,7 @@ add_action('admin_init', function () {
 
 	// Compares versions and updates databases as needed for upgrades
 	$tsml_version = get_option('tsml_version');
-	if (version_compare($tsml_version, TSML_VERSION, '<')) {
+	if (version_compare($tsml_version, '3.14.7', '<')) {
 		tsml_db_update_remove_all_approximate_location_cache();
 		tsml_db_update_remove_all_is_approximate_location_meta();
 		tsml_db_set_location_approximate();


### PR DESCRIPTION
the cache file is getting deleted and regenerated after every update, which is no longer needed. this is (i think) causing the issue viv reported here: https://github.com/code4recovery/12-step-meeting-list/discussions/843

it's hard to reproduce this issue consistently

this (hopefully) closes #972 