### PR TITLE
overriding theme files when using TSML UI

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -13,15 +13,14 @@ add_action('init', function () {
         global $tsml_user_interface;
 
         if (is_post_type_archive('tsml_meeting')) {
-            $user_theme_file = get_stylesheet_directory() . '/archive-meetings.php';
-            if (file_exists($user_theme_file)) {
-                return $user_theme_file;
-            }
-
             // when UI switch set to tsml_ui we use special template
             if ($tsml_user_interface == 'tsml_ui') {
                 return dirname(__FILE__) . '/../templates/archive-tsml-ui.php';
             } else { // legacy_ui
+                $user_theme_file = get_stylesheet_directory() . '/archive-meetings.php';
+                if (file_exists($user_theme_file)) {
+                    return $user_theme_file;
+                }
                 return dirname(__FILE__) . '/../templates/archive-meetings.php';
             }
         }

--- a/readme.txt
+++ b/readme.txt
@@ -162,7 +162,9 @@ By default this plugin uses the Streets theme, v9. To change this, add this to y
 *Please note* the version of the Mapbox script we use doesn't support all the themes displayed on the Mapbox site. The themes which have been tested and are known to work are: mapbox://styles/mapbox/streets-v9, mapbox://styles/mapbox/outdoors-v9, mapbox://styles/mapbox/light-v9, mapbox://styles/mapbox/dark-v9, mapbox://styles/mapbox/satellite-v9, and mapbox://styles/mapbox/satellite-streets-v9.
 
 = How can I override the meeting list or detail pages? =
-Copy the files from the plugin's templates directory into your theme's root directory. If you're using a theme from the Theme Directory, you may be better off creating a [Child Theme](https://codex.wordpress.org/Child_Themes). Now, you may override those pages. The archive-meetings.php file controls the meeting list page, single-meetings.php controls the meetings detail, and single-locations.php controls the location detail.
+If you are using the "Legacy UI" appearance, copy the files from the plugin's templates directory into your theme's root directory. If you're using a theme from the Theme Directory, you may be better off creating a [Child Theme](https://codex.wordpress.org/Child_Themes). Now, you may override those pages. The archive-meetings.php file controls the meeting list page, single-meetings.php controls the meetings detail, and single-locations.php controls the location detail.
+
+If you are using TSML UI, then adding local CSS is the best way to customize the appearance of the meeting finder.
 
 *Please note* these pages will evolve over time. If you override, you will someday experience website errors after an update. If that happens, please update your theme's copy of the plugin pages.
 


### PR DESCRIPTION
for #990 
closes #991

currently if you are using TSML UI and want to override the page (and follow instructions) this forces Legacy UI

this update make it so if you are using TSML UI then copying template files to your theme has no effect

context: allowing users to customize theme files causes support headaches - we should not go down this road with TSML UI. 

also it's not possible to make the same types of changes to TSML UI (example removing a column) since those are generated with javascript. better to steer people to making CSS updates