### PR TITLE
prepare 3.14.9

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -4,7 +4,7 @@
  * Plugin Name: 12 Step Meeting List
  * Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
  * Description: Manage a list of recovery meetings
- * Version: 3.14.8
+ * Version: 3.14.9
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -20,7 +20,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 
 define('TSML_PATH', plugin_dir_path(__FILE__));
 
-define('TSML_VERSION', '3.14.8');
+define('TSML_VERSION', '3.14.9');
 
 //defining externally-defined constant + function for php intelephense
 if (false) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Code for Recovery
 Requires at least: 3.2
 Requires PHP: 5.6
 Tested up to: 6.0
-Stable tag: 3.14.8
+Stable tag: 3.14.9
 
 This plugin helps twelve step recovery programs list their meetings. It standardizes addresses, and displays results in a searchable list and map.
 
@@ -262,6 +262,11 @@ Yes, you can use the following filter to change the with_front configuration fro
 1. Edit location
 
 == Changelog ==
+
+= 3.14.9 =
+* Fix bug in 3.14.8 causing Regions and Districts to not be editable - [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1016)
+* Fix warning when type_descriptions are not set for program - [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1006)
+* When using TSML UI, remove Online and Location Temporarily Closed as default flags - [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1008)
 
 = 3.14.8 =
 * Remove deprecated "BETA" geocoding option


### PR DESCRIPTION
this PR prepares `3.14.9` for release, which does three things:

* fixes #1016  the stupid bug that makes it not possible to edit Districts or Regions
* fixes a warning if you are using a program like DA that doesn't have type_descriptions specified (and are using TSML UI)
* makes the default TSML UI not show Online and Location Temporary Closed as "flags" (little gray text next to the meeting name)