### PR TITLE
add custom descriptions function

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -227,6 +227,14 @@ function tsml_custom_addresses($custom_overrides)
 	$tsml_google_overrides = array_merge($tsml_google_overrides, $custom_overrides);
 }
 
+//fuction:	define custom type descriptions
+//used:		theme's functions.php
+function tsml_custom_descriptions($descriptions)
+{
+	global $tsml_programs, $tsml_program;
+	$tsml_programs[$tsml_program]['type_descriptions'] = $descriptions;
+}
+
 //fuction:	define custom flags (/men, /women) for your area
 //used:		theme's functions.php
 function tsml_custom_flags($flags)

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,17 @@ Note you can add multiple entries to the array below.
 		));
 	}
 
+= Can I update the type descriptions? = 
+
+Yes, you can add, update, or remove these descriptions. Adapt this example as needed and add it to your theme's functions.php. Using an empty string `''` will unset the type.
+
+	if (function_exists('tsml_custom_descriptions')) {
+		tsml_custom_descriptions([
+			'C' => 'Special closed type description',
+			'O' => '', //this type has been removed
+		]);
+	}
+
 = What is Change Detection? =
 Change Detection augments our data import utility by periodically polling your data sources and generating email notifications to Change Notification Email recipients who you registered on the Settings page.
 


### PR DESCRIPTION
the plugin doesn't have a helper function to change the type descriptions, like it does for types, addresses, and flags

closes #1083

