### PR TITLE
Feeds import puts 12x12 meetings in notes

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1532,8 +1532,8 @@ function tsml_import_buffer_set($meetings, $data_source_url = null, $data_source
 		$meetings[$i]['types'] = $unused_types = [];
 		foreach ($types as $type) {
 			$upper_type = trim(strtoupper($type));
-			if (array_key_exists($upper_type, $upper_types)) {
-				$meetings[$i]['types'][] = $upper_type;
+			if (in_array($upper_type, array_map('strtoupper', array_keys($upper_types)))) {
+				$meetings[$i]['types'][] = $type;
 			} elseif (in_array($upper_type, array_values($upper_types))) {
 				$meetings[$i]['types'][] = array_search($upper_type, $upper_types);
 			} else {


### PR DESCRIPTION
When importing meetings from a remote feed, the "12x12" meeting type is inserted into the meeting notes field, instead of importing into the "types" meta key.

This PR fixes this by changing the condition that checks the incoming feed types against the known types on the target website.

**Original code**
Previously, the check (inside the tsml_import_buffer_set() function, line 1535) converted types from the origin feed to uppercase and checked against the keys of known types on the target site, which is not uppercase for "12x12" meetings, according to the TSML spec.

**The update fixes this by:**
1. Comparing the same uppercase types from the origin feed against an array of uppercase keys of known types, converting "12x12" to "12X12", thereby passing the check, and...
2. Setting the type key that is eventually saved to the incoming type (12x12) instead of the uppercased type (12X12), preserving the correct key, according to the TSML Spec.

closes code4recovery/12-step-meeting-list#1073