### PR TITLE
Fix URLs in [tsml_types_list] & [tsml_regions_list] shortcodes

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -85,16 +85,21 @@ function tsml_next_meetings($arguments)
 add_shortcode('tsml_next_meetings', 'tsml_next_meetings');
 
 //output a list of types with links for AA-DC
-
 add_shortcode('tsml_types_list', function () {
-	global $tsml_types_in_use, $tsml_programs, $tsml_program;
-	$types = [];
-	$base = get_post_type_archive_link('tsml_meeting') . '?tsml-day=any&tsml-type=';
-	foreach ($tsml_types_in_use as $type) {
-		$types[$tsml_programs[$tsml_program]['types'][$type]] = '<li><a href="' . $base . $type . '">' . $tsml_programs[$tsml_program]['types'][$type] . '</a></li>';
-	}
-	ksort($types);
-	return '<h3>Types</h3><ul>' . implode($types) . '</ul>';
+    global $tsml_types_in_use, $tsml_programs, $tsml_program, $tsml_user_interface;
+    $types = [];
+    foreach ($tsml_types_in_use as $type) {
+        if ($tsml_user_interface === 'tsml_ui') {
+            $filter_url = tsml_meetings_url([
+                'type' => str_replace(' ', '-', strtolower($tsml_programs[$tsml_program]['types'][$type]))
+            ]);
+        } else {
+            $filter_url = tsml_meetings_url(['tsml-day' => 'any', 'tsml-type' => $type]);
+        }
+        $types[$tsml_programs[$tsml_program]['types'][$type]] = '<li><a href="' . $filter_url . '">' . $tsml_programs[$tsml_program]['types'][$type] . '</a></li>';
+    }
+    ksort($types);
+    return '<h3>Types</h3><ul>' . implode($types) . '</ul>';
 });
 
 //output a react meeting finder widget https://github.com/code4recovery/tsml-ui
@@ -149,21 +154,28 @@ add_shortcode('tsml_ui', 'tsml_ui');
 
 //output a list of regions with links for AA-DC
 add_shortcode('tsml_regions_list', function () {
-	//run function recursively
-	function get_regions($parent = 0)
-	{
-		$taxonomy = 'tsml_region';
-		$terms = get_terms(compact('taxonomy', 'parent'));
-		if (!count($terms)) {
-			return;
-		}
+    //run function recursively
+    function get_regions($parent = 0)
+    {
+        global $tsml_user_interface;
+        $taxonomy = 'tsml_region';
+        $terms    = get_terms(compact('taxonomy', 'parent'));
+        if (!count($terms)) {
+            return;
+        }
 
-		$base = get_post_type_archive_link('tsml_meeting') . '?tsml-day=any&tsml-region=';
-		foreach ($terms as &$term) {
-			$term = '<li><a href="' . $base . $term->term_id . '">' . $term->name . '</a>' . get_regions($term->term_id) . '</li>';
-		}
-		return '<ul>' . implode($terms) . '</ul>';
-	}
+        foreach ($terms as &$term) {
+            if ($tsml_user_interface === 'tsml_ui') {
+                $filter_url = tsml_meetings_url(['region' => $term->slug]);
+            } else {
+                $filter_url = tsml_meetings_url(
+                    ['tsml-day' => 'any', 'tsml-region' => $term->slug]
+                );
+            }
+            $term = '<li><a href="' . $filter_url . '">' . $term->name . '</a>' . get_regions($term->term_id) . '</li>';
+        }
+        return '<ul>' . implode($terms) . '</ul>';
+    }
 
-	return '<h3>Regions</h3>' . get_regions();
+    return '<h3>Regions</h3>' . get_regions();
 });


### PR DESCRIPTION
Conditionally changes the URL's on both shortcodes, so both TSML_UI and LEGACY_UI work with them.

I used the tsml_meetings_url() function to generate the URL's instead of setting manually with $base.

I didn't save the entire file as PSR-12, just the 2 functions I edited. I assume all those tabs are from my last commit? 

closes #1091 