### PR TITLE
dont try to localize slug

### DIFF
--- a/includes/variables.php
+++ b/includes/variables.php
@@ -586,10 +586,10 @@ $tsml_ui_config = [];
 $tsml_days = $tsml_days_order = $tsml_programs = $tsml_types_in_use = $tsml_strings = [];
 
 //string url for the meeting finder, or false for no automatic archive page
-if (!isset($tsml_slug)) $tsml_slug = null;
+if (empty($tsml_slug)) $tsml_slug = 'meetings';
 
 add_action('plugins_loaded', function () {
-	global $tsml_days, $tsml_days_order, $tsml_programs, $tsml_slug, $tsml_strings, $tsml_user_interface, $tsml_types_in_use;
+	global $tsml_days, $tsml_days_order, $tsml_programs, $tsml_strings, $tsml_user_interface, $tsml_types_in_use;
 
 	//load internationalization
 	load_plugin_textdomain('12-step-meeting-list', false, '12-step-meeting-list/languages');
@@ -1323,11 +1323,6 @@ add_action('plugins_loaded', function () {
 		foreach ($tsml_programs as $key => $value) {
 			$tsml_programs[$key]['flags'] = array_diff($value['flags'], ['TC', 'ONL']);
 		}
-	}
-
-	//the location where the list will show up, eg https://intergroup.org/meetings
-	if ($tsml_slug === null) {
-		$tsml_slug = sanitize_title(__('meetings', '12-step-meeting-list'));
 	}
 
 	//strings that must be synced between the javascript and the PHP


### PR DESCRIPTION
fixes #1106 

to recreate this problem locally, set the website language to russian, and save permalinks. you will start seeing 404s on your meetings page. 

then pull this PR down, you will start seeing the page showing up again at `/meetings` (after resaving permalinks)

users can still customize the slug to something else with the normal method of setting `$tsml_slug` in their functions.php - this change will just stop it trying to localize it for them.