### PR TITLE
Fix for #1049 - Problem with Bulk Action remove meetings

### DIFF
--- a/includes/admin_lists.php
+++ b/includes/admin_lists.php
@@ -1,41 +1,46 @@
 <?php
 
-# Adding region dropdown to filter
-add_action('restrict_manage_posts', function () {
+// Rebuild tsml cache when using bulk actions (edit status or trash)
+add_action('transition_post_status', function ($new_status, $old_status, $post) {
+    if ($post->post_type === 'tsml_meeting') {
+        tsml_cache_rebuild();
+    }
+}, 10, 3);
 
-    if (@$_GET['post_type'] != 'tsml_meeting') {
+# Adding region dropdown to filter
+add_action('restrict_manage_posts', function ($post_type) {
+
+    if( $post_type !== 'tsml_meeting' ) {
         return;
     }
 
     wp_dropdown_categories([
         'show_option_all' => 'Region',
         'orderby' => 'tax_name',
-        'hide_empty' => true,
-        'selected' => !empty($_GET['region']) ? $_GET['region'] : null,
+        'selected' => !empty($_GET['region']) ? sanitize_text_field($_GET['region']) : '',
         'hierarchical' => true,
         'name' => 'region',
         'taxonomy' => 'tsml_region',
         'hide_if_empty' => true,
-        'value_field' => 'term_id',
     ]);
-});
+}, 10, 1);
 
 # If filter is set, restrict results
 add_filter(
-    'parse_query',
+    'pre_get_posts',
     function ($query) {
-        global $pagenow, $wpdb;
+        global $post_type, $pagenow, $wpdb;
 
-        if (($pagenow != 'edit.php') || (@$_GET['post_type'] != 'tsml_meeting') || empty($_GET['region'])) {
-            return;
+        if(!empty($_GET['region']) && $pagenow === 'edit.php' && $post_type === 'tsml_meeting' && $query->is_main_query()) {
+            $parent_ids = $wpdb->get_col($wpdb->prepare(
+                "SELECT p.ID FROM $wpdb->posts p 
+	                    JOIN $wpdb->term_relationships r ON r.object_id = p.ID 
+	                    JOIN $wpdb->term_taxonomy x ON x.term_taxonomy_id = r.term_taxonomy_id 
+	                    WHERE x.term_id = %d",
+                    intval(sanitize_text_field($_GET['region']))
+            ));
+            $query->query_vars['post_parent__in'] = empty($parent_ids) ? [0] : $parent_ids;
         }
-
-        $parent_ids = $wpdb->get_col('SELECT p.ID FROM ' . $wpdb->posts . ' p
-            JOIN ' . $wpdb->term_relationships . ' r ON r.object_id = p.ID
-            JOIN ' . $wpdb->term_taxonomy . ' x ON x.term_taxonomy_id = r.term_taxonomy_id
-            WHERE x.term_id = ' . intval($_GET['region']));
-
-        $query->query_vars['post_parent__in'] = empty($parent_ids) ? [0] : $parent_ids;
     }
 );
 

--- a/includes/admin_lists.php
+++ b/includes/admin_lists.php
@@ -1,16 +1,9 @@
 <?php
 
-// Rebuild tsml cache when using bulk actions (edit status or trash)
-add_action('transition_post_status', function ($new_status, $old_status, $post) {
-    if ($post->post_type === 'tsml_meeting') {
-        tsml_cache_rebuild();
-    }
-}, 10, 3);
-
 # Adding region dropdown to filter
 add_action('restrict_manage_posts', function ($post_type) {
 
-    if( $post_type !== 'tsml_meeting' ) {
+    if($post_type !== 'tsml_meeting') {
         return;
     }
 

--- a/includes/init.php
+++ b/includes/init.php
@@ -82,11 +82,12 @@ add_action('init', function () {
 });
 
 if (is_admin()) {
-    // Rebuild tsml cache when using bulk actions (edit status or trash)
+    // Rebuild tsml cache when using bulk actions to edit status.
+    // Uses a transient to keep track the array of post ids that are being processed
     add_action('transition_post_status', function ($new_status, $old_status, $post) {
         global $pagenow;
         if ($post->post_type === 'tsml_meeting' && $new_status === 'publish' && $pagenow !== 'post.php' && $pagenow !== 'admin-ajax.php') {
-            // Look for transient first. Get it from $_GET if it doesn't exist
+            // Try to load transient first or $_GET['post'] if it doesn't exist
             if ($bulk_ids = get_transient('tsml_bulk_process')) {
                 // Remove current post ID from array
                 if (($key = array_search($post->ID, $bulk_ids)) !== false) {

--- a/includes/init.php
+++ b/includes/init.php
@@ -82,6 +82,37 @@ add_action('init', function () {
 });
 
 if (is_admin()) {
+    // Rebuild tsml cache when using bulk actions (edit status or trash)
+    add_action('transition_post_status', function ($new_status, $old_status, $post) {
+        global $pagenow;
+        if ($post->post_type === 'tsml_meeting' && $new_status === 'publish' && $pagenow !== 'post.php' && $pagenow !== 'admin-ajax.php') {
+            // Look for transient first. Get it from $_GET if it doesn't exist
+            if ($bulk_ids = get_transient('tsml_bulk_process')) {
+                // Remove current post ID from array
+                if (($key = array_search($post->ID, $bulk_ids)) !== false) {
+                    unset($bulk_ids[$key]);
+                }
+                // Resave transient
+                set_transient('tsml_bulk_process', $bulk_ids, HOUR_IN_SECONDS);
+                // If the array is empty, we are done. Process now.
+                if (empty($bulk_ids)) {
+                    tsml_update_types_in_use();
+                    tsml_cache_rebuild();
+                    delete_transient('tsml_bulk_process');
+                }
+            } else {
+                if (!empty($_GET['post'])) {
+                    $bulk_ids = $_GET['post'];
+                    // Remove current post ID from array
+                    if (($key = array_search($post->ID, $bulk_ids)) !== false) {
+                        unset($bulk_ids[$key]);
+                    }
+                    // Set transient. Expire in 5 minutes.
+                    set_transient('tsml_bulk_process', $bulk_ids, 5 * MINUTE_IN_SECONDS);
+                }
+            }
+        }
+    }, 10, 3);
     //rebuild cache when trashing or untrashing posts
     add_action('trashed_post', 'tsml_trash_change');
     add_action('untrashed_post', 'tsml_trash_change');


### PR DESCRIPTION
Closing #1049 

The important parts of this fix are:
    1. The addition of the "transition_post_status" action hook, that refrehes the tsml_cache when post statuses are changed (published -> trash, draft -> published, etc.)
    2. The $wpdb->is_main_query() check in the "pre_get_posts" action that prevents the filters form being applied to subsequent queries (this was being applied to the query in the get_meetings() function, causing the tsml_cahce json file to be empty.

Details:
- Added Wordpress "transition_post_status" action that runs tsml_cache_rebuild() anytime meeting post statuses are changed
- "restrict_manage_posts" action - Changed to use built-in $post_type argument - Removed values in wp_dropdown_categories() that were identical to defaults - Sanitize incoming "region" $_GET variable before setting value in dropdown
- "parse_query" action - Changed to "pre_get_posts" (newer and better documented action) - Changed to use global $post_type argument instead of $_GET - Added $query->is_main_query() check before setting filters. - Refectored $parent_ids query to use $wpdb->prepare() to prevent SQL injection - Sanitize incoming "region" $_GET variable before using in $wpdb->get_col()