### PR TITLE
partly revert slug change

### DIFF
--- a/includes/variables.php
+++ b/includes/variables.php
@@ -586,10 +586,10 @@ $tsml_ui_config = [];
 $tsml_days = $tsml_days_order = $tsml_programs = $tsml_types_in_use = $tsml_strings = [];
 
 //string url for the meeting finder, or false for no automatic archive page
-if (empty($tsml_slug)) $tsml_slug = 'meetings';
+if (!isset($tsml_slug)) $tsml_slug = null;
 
 add_action('plugins_loaded', function () {
-	global $tsml_days, $tsml_days_order, $tsml_programs, $tsml_strings, $tsml_user_interface, $tsml_types_in_use;
+	global $tsml_days, $tsml_days_order, $tsml_programs, $tsml_slug, $tsml_strings, $tsml_user_interface, $tsml_types_in_use;
 
 	//load internationalization
 	load_plugin_textdomain('12-step-meeting-list', false, '12-step-meeting-list/languages');
@@ -1324,6 +1324,11 @@ add_action('plugins_loaded', function () {
 		foreach ($tsml_programs as $key => $value) {
 			$tsml_programs[$key]['flags'] = array_diff($value['flags'], ['TC', 'ONL']);
 		}
+	}
+
+	//the location where the list will show up, eg https://intergroup.org/meetings
+	if ($tsml_slug === null) {
+		$tsml_slug = 'meetings';
 	}
 
 	//strings that must be synced between the javascript and the PHP


### PR DESCRIPTION
this change should still prevent the slug localization problems while going back to the 'old' way of defaulting to 'meetings' when `$tsml_slug` is not specified locally