### PR TITLE
fix: omit regions array from JSON feed when empty

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -4,7 +4,7 @@
  * Plugin Name: 12 Step Meeting List
  * Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
  * Description: Manage a list of recovery meetings
- * Version: 3.14.21
+ * Version: 3.14.22
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -20,7 +20,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 
 define('TSML_PATH', plugin_dir_path(__FILE__));
 
-define('TSML_VERSION', '3.14.21');
+define('TSML_VERSION', '3.14.22');
 
 //defining externally-defined constant + function for php intelephense
 if (false) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -950,11 +950,20 @@ function tsml_get_locations()
 			'region_id' => $region_id,
 			'region' => $region,
 			'sub_region' => $sub_region,
-			'regions' => array_reverse(array_map(function ($region_id) {
-				$term = get_term($region_id, 'tsml_region');
-				return !empty($term->name) ? $term->name : null;
-			}, array_merge([$region_id], get_ancestors($region_id, 'tsml_region')))),
 		];
+
+		// regions array eg ['Midwest', 'Illinois', 'Chicago', 'North Side']
+		$regions_array = array_filter(array_map(function ($region_id) {
+			$term = get_term($region_id, 'tsml_region');
+			return !empty($term->name) ? $term->name : null;
+		}, array_merge([$region_id], get_ancestors($region_id, 'tsml_region'))), function ($region) {
+			return !empty($region);
+		});
+
+		// omit key if empty
+		if (count($regions_array)) {
+			$locations[$post->ID]['regions'] = array_reverse($regions_array);
+		}
 	}
 
 	return $locations;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Code for Recovery
 Requires at least: 3.2
 Requires PHP: 5.6
 Tested up to: 6.3
-Stable tag: 3.14.21
+Stable tag: 3.14.22
 
 This plugin helps twelve step recovery programs list their meetings. It standardizes addresses, and displays results in a searchable list and map.
 
@@ -286,6 +286,9 @@ Yes, add the following to your theme's functions.php. Make sure you've enabled t
 1. Edit location
 
 == Changelog ==
+
+= 3.14.22 =
+* Omit JSON regions array when empty [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1210)
 
 = 3.14.21 =
 * Fix map javascript errors [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1202)


### PR DESCRIPTION
fixes #1210 

when there are no regions, don't add the key `"regions": [ null ],` to the JSON feed