### PR TITLE
Fix ACF compatibility

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -4,7 +4,7 @@
  * Plugin Name: 12 Step Meeting List
  * Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
  * Description: Manage a list of recovery meetings
- * Version: 3.14.22
+ * Version: 3.14.23
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -20,7 +20,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 
 define('TSML_PATH', plugin_dir_path(__FILE__));
 
-define('TSML_VERSION', '3.14.22');
+define('TSML_VERSION', '3.14.23');
 
 //defining externally-defined constant + function for php intelephense
 if (false) {

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -17,12 +17,13 @@ add_action('do_meta_boxes', function () {
 	add_meta_box('authordiv', __('Editor', '12-step-meeting-list'), 'post_author_meta_box', 'tsml_meeting', 'side', 'default');
 });
 
-
-// Hook tsml_assets where we can check $post_type
-add_action('admin_print_scripts-post.php', 'tsml_assets');
-add_action('admin_print_scripts-post-new.php', 'tsml_assets');
-add_action('admin_print_scripts-tsml_meeting_page_import', 'tsml_assets');
-add_action('admin_print_scripts-tsml_meeting_page_settings', 'tsml_assets');
+// add admin assets to tsml screens only
+add_action('admin_enqueue_scripts', function () {
+	$screen = get_current_screen();
+	if (is_object($screen) && $screen->post_type === 'tsml_meeting') {
+		tsml_assets();
+	}
+});
 
 //edit page
 add_action('admin_init', function () {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Code for Recovery
 Requires at least: 3.2
 Requires PHP: 5.6
 Tested up to: 6.3
-Stable tag: 3.14.22
+Stable tag: 3.14.23
 
 This plugin helps twelve step recovery programs list their meetings. It standardizes addresses, and displays results in a searchable list and map.
 
@@ -286,6 +286,9 @@ Yes, add the following to your theme's functions.php. Make sure you've enabled t
 1. Edit location
 
 == Changelog ==
+
+= 3.14.23 =
+* Fix compatibility with Advanced Custom Fields [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1239?converting=1#discussioncomment-7351769)
 
 = 3.14.22 =
 * Omit JSON regions array when empty [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1210)


### PR DESCRIPTION
check out my comment here: https://github.com/code4recovery/12-step-meeting-list/discussions/1239?converting=1#discussioncomment-7351769

to reproduce the issue:

* install Advanced Custom Fields on a site that has TSML installed.
* now add create a field group
* add a time field to the field group
* say that the field group should only display on posts
* create a new post and click on the the field group, it will look like this if this branch is active
<img width="261" alt="Screenshot 2023-10-22 at 8 56 30 AM" src="https://github.com/code4recovery/12-step-meeting-list/assets/1551689/5053e8ab-8a5c-481c-ab1a-622fd8b8815d">

however `main` looks like this
<img width="148" alt="Screenshot 2023-10-22 at 8 57 04 AM" src="https://github.com/code4recovery/12-step-meeting-list/assets/1551689/02d6a732-c84d-4c96-97fb-be447d6962b5">

hopefully no other issues are observed
