### PR TITLE
Show timezone error message in TSML UI

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -4,7 +4,7 @@
  * Plugin Name: 12 Step Meeting List
  * Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
  * Description: Manage a list of recovery meetings
- * Version: 3.14.23
+ * Version: 3.14.24
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -20,7 +20,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 
 define('TSML_PATH', plugin_dir_path(__FILE__));
 
-define('TSML_VERSION', '3.14.23');
+define('TSML_VERSION', '3.14.24');
 
 //defining externally-defined constant + function for php intelephense
 if (false) {

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -144,17 +144,9 @@ function tsml_ui()
 	$url = parse_url($data);
 	$data = $url['path'] . '?' . $url['query'];
 
-	$timezone = wp_timezone()->getName();
-
-	if (substr($timezone, 0, 1) === '+') {
-		return '<div style="background-color: pink; padding: 1rem; color: black; margin: 1rem; ">' .
-			sprintf(__('TSML UI cannot display with a GMT offset timezone. Your timezone is set to <code>%s</code>. Please set your timezone to use a city name in WordPress Settings > General > Timezone.', '12-step-meeting-list'), $timezone) .
-			'</div>';
-	}
-
 	return '<div id="tsml-ui"
 					data-src="' . $data . '"
-					data-timezone="' . $timezone . '"
+					data-timezone="' . wp_timezone_string() . '"
 					data-mapbox="' . $tsml_mapbox_key . '"></div>';
 }
 add_shortcode('tsml_react', 'tsml_ui');

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -144,9 +144,17 @@ function tsml_ui()
 	$url = parse_url($data);
 	$data = $url['path'] . '?' . $url['query'];
 
+	$timezone = wp_timezone()->getName();
+
+	if (substr($timezone, 0, 1) === '+') {
+		return '<div style="background-color: pink; padding: 1rem; color: black; margin: 1rem; ">' .
+			sprintf(__('TSML UI cannot display with a GMT offset timezone. Your timezone is set to <code>%s</code>. Please set your timezone to use a city name in WordPress Settings > General > Timezone.', '12-step-meeting-list'), $timezone) .
+			'</div>';
+	}
+
 	return '<div id="tsml-ui"
 					data-src="' . $data . '"
-					data-timezone="' . get_option('timezone_string', 'America/New_York') . '"
+					data-timezone="' . $timezone . '"
 					data-mapbox="' . $tsml_mapbox_key . '"></div>';
 }
 add_shortcode('tsml_react', 'tsml_ui');

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Code for Recovery
 Requires at least: 3.2
 Requires PHP: 5.6
-Tested up to: 6.3
-Stable tag: 3.14.23
+Tested up to: 6.4
+Stable tag: 3.14.24
 
 This plugin helps twelve step recovery programs list their meetings. It standardizes addresses, and displays results in a searchable list and map.
 
@@ -286,6 +286,9 @@ Yes, add the following to your theme's functions.php. Make sure you've enabled t
 1. Edit location
 
 == Changelog ==
+
+= 3.14.24 =
+* Show error in TSML UI when time zone is not valid [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1241#discussioncomment-7408442)
 
 = 3.14.23 =
 * Fix compatibility with Advanced Custom Fields [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1239?converting=1#discussioncomment-7351769)


### PR DESCRIPTION
`get_option('timezone_string', 'America/New_York')` only passes through named timezones, and is empty if the timezone is something invalid, like `+1000` - this means the user won't see an "invalid time zone" message (just added to TSML UI)

this should help in situations like this: https://github.com/code4recovery/12-step-meeting-list/discussions/1241#discussioncomment-7408442

also updates "tested up to" `6.4` to close #1246 

![Screenshot 2023-10-29 at 9 46 40 AM](https://github.com/code4recovery/12-step-meeting-list/assets/1551689/e11595e0-5b95-4923-a86e-b1367f4abab4)