### PR TITLE
[Issue-1200] Fix rewrite rules after plugin activation / decativation

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -55,5 +55,5 @@ if (is_admin()) {
 }
 
 //these hooks need to be in this file
-register_activation_hook(__FILE__, 'tsml_change_activation_state');
-register_deactivation_hook(__FILE__, 'tsml_change_activation_state');
+register_activation_hook(__FILE__, 'tsml_plugin_activation');
+register_deactivation_hook(__FILE__, 'tsml_plugin_deactivation');

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -156,15 +156,15 @@ function tsml_plugin_activation()
 {
 	tsml_custom_post_types();
 	flush_rewrite_rules();
-    add_option( 'tsml_plugin_new_activation', true );
-    update_option( 'tsml_plugin_new_activation', true );
+	add_option( 'tsml_plugin_new_activation', true );
+	update_option( 'tsml_plugin_new_activation', true );
 }
 
 //called by register_deactivation_hook in 12-step-meeting-list.php
 //hands off to tsml_custom_post_types
 function tsml_plugin_deactivation()
 {
-    tsml_unregister_custom_post_types();
+	tsml_unregister_custom_post_types();
 	flush_rewrite_rules();
 }
 
@@ -348,9 +348,9 @@ function tsml_custom_post_types()
 //used: 	plugin deactivation, before final rewrite flush
 function tsml_unregister_custom_post_types()
 {
-    unregister_taxonomy('tsml_region');
-    unregister_taxonomy('tsml_location');
-    unregister_taxonomy('tsml_district');
+	unregister_taxonomy('tsml_region');
+	unregister_taxonomy('tsml_location');
+	unregister_taxonomy('tsml_district');
 	unregister_post_type('tsml_meeting');
 	unregister_post_type('tsml_location');
 	unregister_post_type('tsml_group');

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -161,10 +161,27 @@ function tsml_plugin_activation()
 }
 
 //called by register_deactivation_hook in 12-step-meeting-list.php
-//hands off to tsml_custom_post_types
+//clean up custom taxonomies / post types and flush rewrite rules
 function tsml_plugin_deactivation()
 {
-	tsml_unregister_custom_post_types();
+	if ( taxonomy_exists('tsml_region') ) {
+        unregister_taxonomy('tsml_region');
+    }
+	if ( taxonomy_exists('tsml_location') ) {
+	    unregister_taxonomy('tsml_location');
+    }
+	if ( taxonomy_exists('tsml_district') ) {
+	    unregister_taxonomy('tsml_district');
+    }
+    if ( post_type_exists('tsml_meeting') ) {
+	    unregister_post_type('tsml_meeting');
+    }
+    if ( post_type_exists('tsml_location') ) {
+	    unregister_post_type('tsml_location');
+    }
+    if ( post_type_exists('tsml_group') ) {
+	    unregister_post_type('tsml_group');
+    }
 	flush_rewrite_rules();
 }
 
@@ -342,18 +359,6 @@ function tsml_custom_post_types()
 			'capabilities' => ['create_posts' => false],
 		]
 	);
-}
-
-//function: unregister custom post types and taxonomies
-//used: 	plugin deactivation, before final rewrite flush
-function tsml_unregister_custom_post_types()
-{
-	unregister_taxonomy('tsml_region');
-	unregister_taxonomy('tsml_location');
-	unregister_taxonomy('tsml_district');
-	unregister_post_type('tsml_meeting');
-	unregister_post_type('tsml_location');
-	unregister_post_type('tsml_group');
 }
 
 //fuction:	define custom meeting types for your area

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -154,34 +154,33 @@ function tsml_calculate_attendance_option($types, $approximate)
 //hands off to tsml_custom_post_types
 function tsml_plugin_activation()
 {
-    tsml_plugin_loaded();
     tsml_custom_post_types();
-	flush_rewrite_rules();
+    flush_rewrite_rules();
 }
 
 //called by register_deactivation_hook in 12-step-meeting-list.php
 //clean up custom taxonomies / post types and flush rewrite rules
 function tsml_plugin_deactivation()
 {
-	if ( taxonomy_exists('tsml_region') ) {
+    if ( taxonomy_exists('tsml_region') ) {
         unregister_taxonomy('tsml_region');
     }
-	if ( taxonomy_exists('tsml_location') ) {
-	    unregister_taxonomy('tsml_location');
+    if ( taxonomy_exists('tsml_location') ) {
+        unregister_taxonomy('tsml_location');
     }
-	if ( taxonomy_exists('tsml_district') ) {
-	    unregister_taxonomy('tsml_district');
+    if ( taxonomy_exists('tsml_district') ) {
+        unregister_taxonomy('tsml_district');
     }
     if ( post_type_exists('tsml_meeting') ) {
-	    unregister_post_type('tsml_meeting');
+        unregister_post_type('tsml_meeting');
     }
     if ( post_type_exists('tsml_location') ) {
-	    unregister_post_type('tsml_location');
+        unregister_post_type('tsml_location');
     }
     if ( post_type_exists('tsml_group') ) {
-	    unregister_post_type('tsml_group');
+        unregister_post_type('tsml_group');
     }
-	flush_rewrite_rules();
+    flush_rewrite_rules();
 }
 
 //validate conference provider and return name

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -154,10 +154,9 @@ function tsml_calculate_attendance_option($types, $approximate)
 //hands off to tsml_custom_post_types
 function tsml_plugin_activation()
 {
-	tsml_custom_post_types();
+    tsml_plugin_loaded();
+    tsml_custom_post_types();
 	flush_rewrite_rules();
-	add_option( 'tsml_plugin_new_activation', true );
-	update_option( 'tsml_plugin_new_activation', true );
 }
 
 //called by register_deactivation_hook in 12-step-meeting-list.php

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -152,9 +152,19 @@ function tsml_calculate_attendance_option($types, $approximate)
 
 //called by register_activation_hook in 12-step-meeting-list.php
 //hands off to tsml_custom_post_types
-function tsml_change_activation_state()
+function tsml_plugin_activation()
 {
 	tsml_custom_post_types();
+	flush_rewrite_rules();
+    add_option( 'tsml_plugin_new_activation', true );
+    update_option( 'tsml_plugin_new_activation', true );
+}
+
+//called by register_deactivation_hook in 12-step-meeting-list.php
+//hands off to tsml_custom_post_types
+function tsml_plugin_deactivation()
+{
+    tsml_unregister_custom_post_types();
 	flush_rewrite_rules();
 }
 
@@ -332,6 +342,18 @@ function tsml_custom_post_types()
 			'capabilities' => ['create_posts' => false],
 		]
 	);
+}
+
+//function: unregister custom post types and taxonomies
+//used: 	plugin deactivation, before final rewrite flush
+function tsml_unregister_custom_post_types()
+{
+    unregister_taxonomy('tsml_region');
+    unregister_taxonomy('tsml_location');
+    unregister_taxonomy('tsml_district');
+	unregister_post_type('tsml_meeting');
+	unregister_post_type('tsml_location');
+	unregister_post_type('tsml_group');
 }
 
 //fuction:	define custom meeting types for your area
@@ -1747,7 +1769,7 @@ function tsml_import_reformat_googlesheet($data)
 
 	foreach ($data['values'] as $row) {
 
-		//creates a meeting array with elements corresponding to each column header of the Google Sheet; updated for Google Sheets v4 API 
+		//creates a meeting array with elements corresponding to each column header of the Google Sheet; updated for Google Sheets v4 API
 		$meeting = [];
 		for ($j = 0; $j < $header_count; $j++) {
 			if (isset($row[$j])) {
@@ -2119,7 +2141,7 @@ function tsml_import_changes($feed_meetings, $data_source_url, $data_source_last
 		__('Saturday', '12-step-meeting-list'),
 	];
 
-	// get local meetings 
+	// get local meetings
 	$all_db_meetings = tsml_get_meetings();
 	$ds_ids = tsml_get_data_source_ids($data_source_url);
 	sort($ds_ids);

--- a/includes/init.php
+++ b/includes/init.php
@@ -6,12 +6,6 @@ add_action('init', function () {
     //register post types and taxonomies
     tsml_custom_post_types();
 
-    //recent activation, flush rewrite rules on first full load (once)
-    if (get_option('tsml_plugin_new_activation')) {
-        flush_rewrite_rules();
-        update_option('tsml_plugin_new_activation', false);
-    }
-
     //meeting list page
     add_filter('archive_template', 'tsml_archive_template');
     function tsml_archive_template($template)

--- a/includes/init.php
+++ b/includes/init.php
@@ -6,11 +6,11 @@ add_action('init', function () {
     //register post types and taxonomies
     tsml_custom_post_types();
 
-    //recent activation, flush rewrite rules on first full load (once)
-    if (get_option('tsml_plugin_new_activation')) {
-        flush_rewrite_rules();
-        update_option('tsml_plugin_new_activation', false);
-    }
+	//recent activation, flush rewrite rules on first full load (once)
+	if (get_option('tsml_plugin_new_activation')) {
+		flush_rewrite_rules();
+		update_option('tsml_plugin_new_activation', false);
+	}
 
     //meeting list page
     add_filter('archive_template', 'tsml_archive_template');

--- a/includes/init.php
+++ b/includes/init.php
@@ -6,11 +6,11 @@ add_action('init', function () {
     //register post types and taxonomies
     tsml_custom_post_types();
 
-	//recent activation, flush rewrite rules on first full load (once)
-	if (get_option('tsml_plugin_new_activation')) {
-		flush_rewrite_rules();
-		update_option('tsml_plugin_new_activation', false);
-	}
+    //recent activation, flush rewrite rules on first full load (once)
+    if (get_option('tsml_plugin_new_activation')) {
+        flush_rewrite_rules();
+        update_option('tsml_plugin_new_activation', false);
+    }
 
     //meeting list page
     add_filter('archive_template', 'tsml_archive_template');

--- a/includes/init.php
+++ b/includes/init.php
@@ -6,6 +6,12 @@ add_action('init', function () {
     //register post types and taxonomies
     tsml_custom_post_types();
 
+    //recent activation, flush rewrite rules on first full load (once)
+    if (get_option('tsml_plugin_new_activation')) {
+        flush_rewrite_rules();
+        update_option('tsml_plugin_new_activation', false);
+    }
+
     //meeting list page
     add_filter('archive_template', 'tsml_archive_template');
     function tsml_archive_template($template)

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -588,8 +588,6 @@ $tsml_days = $tsml_days_order = $tsml_programs = $tsml_types_in_use = $tsml_stri
 //string url for the meeting finder, or false for no automatic archive page
 if (!isset($tsml_slug)) $tsml_slug = null;
 
-add_action('plugins_loaded', 'tsml_load_config');
-
 // set up globals, common variables once plugins are loaded, but before init
 function tsml_load_config () {
 	global $tsml_days, $tsml_days_order, $tsml_programs, $tsml_slug, $tsml_strings, $tsml_user_interface, $tsml_types_in_use;
@@ -1422,3 +1420,9 @@ function tsml_load_config () {
 	$tsml_types_in_use = get_option('tsml_types_in_use', []);
 	if (!is_array($tsml_types_in_use)) $tsml_types_in_use = [];
 };
+
+add_action('plugins_loaded', 'tsml_load_config');
+// load config if we always passed plugins_loaded action
+if ( did_action( 'plugins_loaded' ) ) {
+    tsml_load_config();
+}

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -588,7 +588,10 @@ $tsml_days = $tsml_days_order = $tsml_programs = $tsml_types_in_use = $tsml_stri
 //string url for the meeting finder, or false for no automatic archive page
 if (!isset($tsml_slug)) $tsml_slug = null;
 
-add_action('plugins_loaded', function () {
+add_action('plugins_loaded', 'tsml_load_config');
+
+// set up globals, common variables once plugins are loaded, but before init
+function tsml_load_config () {
 	global $tsml_days, $tsml_days_order, $tsml_programs, $tsml_slug, $tsml_strings, $tsml_user_interface, $tsml_types_in_use;
 
 	//load internationalization
@@ -1306,7 +1309,7 @@ add_action('plugins_loaded', function () {
 		],
 		'sia' => [
 			'abbr' => __('SIA', '12-step-meeting-list'),
-			'flags' => ['M', 'W', 'TC', 'ONL'], 
+			'flags' => ['M', 'W', 'TC', 'ONL'],
 			'name' => __('Survivors of Incest Anonymous', '12-step-meeting-list'),
 			'types' => [
 				'12x12' => __('12 Steps & 12 Traditions', '12-step-meeting-list'),
@@ -1418,4 +1421,4 @@ add_action('plugins_loaded', function () {
 
 	$tsml_types_in_use = get_option('tsml_types_in_use', []);
 	if (!is_array($tsml_types_in_use)) $tsml_types_in_use = [];
-});
+};


### PR DESCRIPTION
## Fix for issue #1200 

Used a `rewrite-rules-inspector` to look at the rewrite rules before and after plugin activation, and noticed

1. After plugin activation as second time (not first time), rules look invalid. 

I don't know exactly why they're bad, we register the post types and taxonomies and flush rewrite rules. I tried flushing rewrite rules later, at shutdown, but no luck. Since it seems fine if you flush rewrite rules on a later load, figure it's something with timing. Activation hook happens maybe too later for rewrite / post_type and taxonomy registration to matter. 

To fix, on activation, I set a `tsml_plugin_new_activation` to `true` (`1`), then init checks if truthy, flushes rewrite, sets false, so basically flush rewrite rules on first full load. Works on my end, but I haven't tested on multi site. _Should_ be good.

2. After plugin deactivation, rewrite rules for our plugin still exist.

Not a huge issue, but "leave no trace", figured better to unregister post types and taxonomies before final flush rewrite. Fixes the remnant rules.
