### PR TITLE
Set default meeting location in tsml_next_meetings shortcode

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -37,7 +37,11 @@ function tsml_next_meetings($arguments)
 			$classes .= ' notes';
 		}
 
-		$meeting_location = $meeting['location'];
+		$meeting_location = '';
+		if (!empty($meeting['location'])) {
+			$meeting_location = $meeting['location'];
+		}
+
 		if ($meeting['attendance_option'] == 'online' || $meeting['attendance_option'] == 'inactive') {
 			$meeting_location = !empty($meeting['group']) ? $meeting['group'] : '';
 		}


### PR DESCRIPTION
Set default meeting location in tsml_next_meetings shortcode to prevent PHP warnings when a meeting has no location
Fixes issue https://github.com/code4recovery/12-step-meeting-list/issues/1301