### PR TITLE
Added missing class property to filter_meetings.php ...

### DIFF
--- a/includes/filter_meetings.php
+++ b/includes/filter_meetings.php
@@ -19,6 +19,7 @@ class tsml_filter_meetings
     public $time;
     public $type;
     public $attendance_option;
+    public $ten_minutes_ago;
 
     //sanitize and save arguments (won't be passed to a database)
     public function __construct($arguments)


### PR DESCRIPTION
Fixes https://github.com/code4recovery/12-step-meeting-list/issues/1308
Added one missing class property to filter_meetings.php ($ten_minutes_ago).  The class worked without this property because PHP historically allows dynamic property setting, but the setting of dynamic properties is deprecated in PHP 8.2.  I scanned all the other PHP files and this is the only file that has this issue, and only for this one property.  
Discovered this while working on https://github.com/code4recovery/12-step-meeting-list/discussions/1300  