### PR TITLE
enable exporting custom fields

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -4,7 +4,7 @@
  * Plugin Name: 12 Step Meeting List
  * Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
  * Description: Manage a list of recovery meetings
- * Version: 3.14.28
+ * Version: 3.14.29
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -20,7 +20,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 
 define('TSML_PATH', plugin_dir_path(__FILE__));
 
-define('TSML_VERSION', '3.14.28');
+define('TSML_VERSION', '3.14.29');
 
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 

--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -14,8 +14,6 @@
 //define constants
 define('TSML_GROUP_CONTACT_COUNT', 3);
 
-define('TSML_CONTACT_EMAIL', 'tsml@code4recovery.org');
-
 define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 
 define('TSML_PATH', plugin_dir_path(__FILE__));

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -185,7 +185,7 @@ add_action('wp_ajax_contacts', function () {
 add_action('wp_ajax_csv', function () {
 
     //going to need this later
-    global $tsml_days, $tsml_programs, $tsml_program, $tsml_sharing, $tsml_export_columns;
+    global $tsml_days, $tsml_programs, $tsml_program, $tsml_sharing, $tsml_export_columns, $tsml_custom_meeting_fields;
 
     //security
     if (($tsml_sharing != 'open') && !is_user_logged_in()) {
@@ -198,6 +198,11 @@ add_action('wp_ajax_csv', function () {
     //helper vars
     $delimiter = ',';
     $escape = '"';
+
+    // allow user-defined fields to be exported
+    if (!empty($tsml_custom_meeting_fields)) {
+        $tsml_export_columns = array_merge($tsml_export_columns, $tsml_custom_meeting_fields);
+    }
 
     //do header
     $return = implode($delimiter, array_values($tsml_export_columns)) . PHP_EOL;

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -188,9 +188,7 @@ add_action('wp_ajax_csv', function () {
     global $tsml_days, $tsml_programs, $tsml_program, $tsml_sharing, $tsml_export_columns, $tsml_custom_meeting_fields;
 
     //security
-    if (($tsml_sharing != 'open') && !is_user_logged_in()) {
-        tsml_ajax_unauthorized();
-    }
+    tsml_require_meetings_permission();
 
     //get data source
     $meetings = tsml_get_meetings([], false, true);

--- a/includes/save.php
+++ b/includes/save.php
@@ -61,7 +61,9 @@ add_action('save_post', function ($post_id, $post, $update) {
         $old_meeting = tsml_get_meeting($post_id);
         $decode_keys = array('post_title', 'post_content', 'location', 'location_notes', 'group', 'group_notes');
         foreach ($decode_keys as $key) {
-            $old_meeting->{$key} = html_entity_decode($old_meeting->{$key});
+            if (!empty($old_meeting->{$key})) {
+                $old_meeting->{$key} = html_entity_decode($old_meeting->{$key});
+            }
         }
     }
 
@@ -116,7 +118,7 @@ add_action('save_post', function ($post_id, $post, $update) {
     }
 
     //video conferencing info
-    if (!$update || strcmp($old_meeting->conference_url, $valid_conference_url) !== 0) {
+    if ($valid_conference_url && (!$update || strcmp($old_meeting->conference_url, $valid_conference_url) !== 0)) {
         $changes[] = 'conference_url';
         if (empty($valid_conference_url)) {
             delete_post_meta($post->ID, 'conference_url');
@@ -390,7 +392,7 @@ add_action('save_post', function ($post_id, $post, $update) {
         $_POST['square'] = null;
     }
     if (!empty($_POST['paypal']) && strpos($_POST['paypal'], '/') !== false) {
-        $_POST['paypal'] = array_pop(explode('/', $_POST['paypal']));
+        $_POST['paypal'] = strtok($_POST['paypal'], '/');
     }
 
     //loop through and validate each field

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Code for Recovery
 Requires at least: 3.2
 Requires PHP: 5.6
 Tested up to: 6.4
-Stable tag: 3.14.28
+Stable tag: 3.14.29
 
 This plugin helps twelve step recovery programs list their meetings. It standardizes addresses, and displays results in a searchable list and map.
 
@@ -282,6 +282,15 @@ Yes, add the following to your theme's functions.php. Make sure you've enabled t
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage, and
 handle security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/12-step-meeting-list)
 
+= Can I include custom fields in the CSV export?
+
+Yes, you will need to know the key name of the field. Then include an array in your theme's function.php file:
+
+	$tsml_custom_meeting_fields = [
+		'my_custom_field_key' => 'My Custom Field',
+	];
+
+
 
 == Screenshots ==
 
@@ -292,6 +301,9 @@ handle security vulnerabilities. [Report a security vulnerability.](https://patc
 1. Edit location
 
 == Changelog ==
+
+= 3.14.29 =
+* Add ability to export custom field types [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1334)
 
 = 3.14.28 =
 * Remove capability to make public CSV download links, since it looks like a security gap to researchers [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1329)

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Code for Recovery
 Requires at least: 3.2
 Requires PHP: 5.6
-Tested up to: 6.4
+Tested up to: 6.4.3
 Stable tag: 3.14.29
 
 This plugin helps twelve step recovery programs list their meetings. It standardizes addresses, and displays results in a searchable list and map.
@@ -304,6 +304,7 @@ Yes, you will need to know the key name of the field. Then include an array in y
 
 = 3.14.29 =
 * Add ability to export custom field types [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1334)
+* Limit CSV-downloading to editors and above
 
 = 3.14.28 =
 * Remove capability to make public CSV download links, since it looks like a security gap to researchers [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1329)


### PR DESCRIPTION
for https://github.com/code4recovery/12-step-meeting-list/discussions/1334

add the field to ACF
<img width="874" alt="Screenshot 2024-02-02 at 8 17 45 AM" src="https://github.com/code4recovery/12-step-meeting-list/assets/1551689/2895973e-494e-4ade-9f8c-a3147d27276c">

add a value to a meeting
<img width="634" alt="Screenshot 2024-02-02 at 8 17 27 AM" src="https://github.com/code4recovery/12-step-meeting-list/assets/1551689/45f7c110-e402-4016-899e-deb623b70a81">

add an array to your theme
```
$tsml_custom_meeting_fields = [
	'test' => 'Test',
];
```

click 'export csv'
you should see your custom fields appended as columns at the end of the CSV ✨ 


(i also noticed a few warnings when saving a meeting, so i added some conditionals to save.php to suppress them)

additionally i've added a more stringent check on CSV permissions
