### PR TITLE
[Issue 1342]: Uninstall fix

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -5,6 +5,8 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
     exit();
 }
 
+require_once trailingslashit(__DIR__) . '12-step-meeting-list.php';
+
 tsml_delete('everything');
 
 //flush rewrite once more for good measure


### PR DESCRIPTION
Addressing issue #1342 :  Apparently when you choose to delete the plugin, the `uninstall.php` is included in isolation, before plugin load. So just adding a require_once to the primary plugin file, to ensure all expected functions are available.

The plugin load happens during ajax request to uninstall. After the request finishes, the files are gone.
