### PR TITLE
Block theme template improvements

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -4,7 +4,7 @@
  * Plugin Name: 12 Step Meeting List
  * Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
  * Description: Manage a list of recovery meetings
- * Version: 3.14.30
+ * Version: 3.14.31
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -18,7 +18,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 
 define('TSML_PATH', plugin_dir_path(__FILE__));
 
-define('TSML_VERSION', '3.14.30');
+define('TSML_VERSION', '3.14.31');
 
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Code for Recovery
 Requires at least: 3.2
 Requires PHP: 5.6
 Tested up to: 6.4.3
-Stable tag: 3.14.30
+Stable tag: 3.14.31
 
 This plugin helps twelve step recovery programs list their meetings. It standardizes addresses, and displays results in a searchable list and map.
 
@@ -302,6 +302,9 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.14.31 =
+* Improve page appearance with block themes [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1260)
 
 = 3.14.30 =
 * Add SECURITY.md [more info](https://github.com/code4recovery/12-step-meeting-list/pull/1332)

--- a/templates/archive-tsml-ui.php
+++ b/templates/archive-tsml-ui.php
@@ -1,7 +1,5 @@
-<!-- USING TSML UI IN A CLASSIC THEME -->
 <?php
-tsml_assets();
-get_header();
+tsml_header();
 
 if (is_active_sidebar('tsml_meetings_top')) { ?>
     <div class="widgets meetings-widgets meetings-widgets-top" role="complementary">
@@ -19,5 +17,4 @@ if (is_active_sidebar('tsml_meetings_top')) { ?>
     </div>
 <?php }
 
-get_footer();
-
+tsml_footer();

--- a/templates/archive-tsml-ui.php
+++ b/templates/archive-tsml-ui.php
@@ -5,13 +5,11 @@ if (is_active_sidebar('tsml_meetings_top')) { ?>
     <div class="widgets meetings-widgets meetings-widgets-top" role="complementary">
         <?php dynamic_sidebar('tsml_meetings_top') ?>
     </div>
-<?php } ?>
+<?php }
 
-<div class="wp-site-blocks">
-    <?php echo tsml_ui(); ?>
-</div>
+echo tsml_ui();
 
-<?php if (is_active_sidebar('tsml_meetings_bottom')) { ?>
+if (is_active_sidebar('tsml_meetings_bottom')) { ?>
     <div class="widgets meetings-widgets meetings-widgets-bottom" role="complementary">
         <?php dynamic_sidebar('tsml_meetings_bottom') ?>
     </div>

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -1,7 +1,6 @@
-<?php
-block_footer_area();
-wp_footer();
-?>
+<?php block_footer_area(); ?>
+</div>
+<?php wp_footer(); ?>
 </body>
 
 </html>

--- a/templates/header.php
+++ b/templates/header.php
@@ -4,8 +4,13 @@
 <head>
     <meta charset="<?php bloginfo('charset'); ?>" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <?php wp_head(); ?>
+    <?php
+    // must be before wp_head() to render CSS
+    $header = do_blocks('<!-- wp:template-part {"slug":"header"} /-->');
+    wp_head();
+    ?>
 </head>
 
 <body <?php body_class(); ?>>
-    <?php block_header_area();
+    <?php wp_body_open(); ?>
+    <?php echo $header; ?>

--- a/templates/header.php
+++ b/templates/header.php
@@ -13,4 +13,5 @@
 
 <body <?php body_class(); ?>>
     <?php wp_body_open(); ?>
-    <?php echo $header; ?>
+    <div class="wp-site-blocks">
+        <?php echo $header; ?>


### PR DESCRIPTION
fixes TSML UI appearance to work with block themes

makes block theme header CSS output properly

TSML UI before
![tsml-ui-before](https://github.com/code4recovery/12-step-meeting-list/assets/1551689/a6dc9356-4701-4dd2-aede-f66c50e8d3bb)

TSML UI after
![tsml-ui-after](https://github.com/code4recovery/12-step-meeting-list/assets/1551689/64ce96fa-01b2-4a59-9aa0-fae4b5b6c336)

Legacy before
![legacy-before](https://github.com/code4recovery/12-step-meeting-list/assets/1551689/e2d40892-da62-4a30-8d50-6f846f2b3e4b)

Legacy after
![legacy-after](https://github.com/code4recovery/12-step-meeting-list/assets/1551689/a1efd846-bed0-4e84-bce2-68f78141da78)
