### PR TITLE
fix warnings and allow removing conference url

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -4,7 +4,7 @@
  * Plugin Name: 12 Step Meeting List
  * Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
  * Description: Manage a list of recovery meetings
- * Version: 3.14.31
+ * Version: 3.14.32
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -18,7 +18,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 
 define('TSML_PATH', plugin_dir_path(__FILE__));
 
-define('TSML_VERSION', '3.14.31');
+define('TSML_VERSION', '3.14.32');
 
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 

--- a/includes/save.php
+++ b/includes/save.php
@@ -118,7 +118,7 @@ add_action('save_post', function ($post_id, $post, $update) {
     }
 
     //video conferencing info
-    if ($valid_conference_url && (!$update || strcmp($old_meeting->conference_url, $valid_conference_url) !== 0)) {
+    if (!$update || @strcmp($old_meeting->conference_url, $valid_conference_url) !== 0) {
         $changes[] = 'conference_url';
         if (empty($valid_conference_url)) {
             delete_post_meta($post->ID, 'conference_url');
@@ -403,7 +403,7 @@ add_action('save_post', function ($post_id, $post, $update) {
 
     //loop through and validate each field
     foreach ($tsml_contact_fields as $field => $type) {
-        if (!$update || strcmp($old_meeting->{$field}, $_POST[$field]) !== 0) {
+        if (!$update || @strcmp($old_meeting->{$field}, $_POST[$field]) !== 0) {
             $changes[] = $field;
         }
         if (empty($_POST[$field])) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Code for Recovery
 Requires at least: 3.2
 Requires PHP: 5.6
 Tested up to: 6.4.3
-Stable tag: 3.14.31
+Stable tag: 3.14.32
 
 This plugin helps twelve step recovery programs list their meetings. It standardizes addresses, and displays results in a searchable list and map.
 
@@ -302,6 +302,9 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.14.32 =
+* Fix bug preventing removal of online meeting URLs [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1354)
 
 = 3.14.31 =
 * Improve page appearance with block themes [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1260)


### PR DESCRIPTION
fix #1354 bug preventing people from removing conference URLs

i notice that i do have to click the Update button twice, not sure if that's new