### PR TITLE
Just ensure the option returns an array

### DIFF
--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -19,9 +19,14 @@ function tsml_ajax_info()
 
     $theme = wp_get_theme();
 
+    $tsml_log = get_option('tsml_log', []);
+    if (!is_array($tsml_log)) {
+        $tsml_log = array();
+    }
+
     wp_send_json([
         'language' => get_bloginfo('language'),
-        'log' => array_slice(get_option('tsml_log', []), 0, 25), //limit to 25 events
+        'log' => array_slice($tsml_log, 0, 25), //limit to 25 events
         'plugins' => array_map(function ($key) {
             return explode('/', $key)[0];
         }, array_keys(get_plugins())),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1868,6 +1868,9 @@ function tsml_log($type, $info = null, $input = null)
 {
     //load
     $tsml_log = get_option('tsml_log', []);
+    if (!is_array($tsml_log)) {
+        $tsml_log = array();
+    }
 
     //default variables
     $entry = [


### PR DESCRIPTION
For issue #1366, maybe simplistic, but not being able to be certain the `tsml_log` options is always an array, this is just one more step.