### PR TITLE
Catching random post meta

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1044,11 +1044,18 @@ function tsml_get_meeting($meeting_id = false)
     if (empty($meeting->approximate)) $meeting->approximate = 'no';
 
     //escape meeting values
+    $meeting->types = [];
     foreach ($custom as $key => $value) {
-        $meeting->{$key} = ($key == 'types') ? $value[0] : htmlentities($value[0], ENT_QUOTES);
+        if (is_array($value)) {
+            $value = count($value) ? $value[0] : '';
+        }
+        if ('types' === $key) {
+            $value = (array) maybe_unserialize($value);
+        } else {
+            $value = htmlentities(strval($value), ENT_QUOTES);
+        }
+        $meeting->{$key} = $value;
     }
-    if (empty($meeting->types)) $meeting->types = [];
-    if (!is_array($meeting->types)) $meeting->types = unserialize($meeting->types);
     $meeting->post_title = htmlentities($meeting->post_title, ENT_QUOTES);
     $meeting->notes = esc_html($meeting->post_content);
 

--- a/includes/save.php
+++ b/includes/save.php
@@ -46,13 +46,17 @@ add_action('save_post', function ($post_id, $post, $update) {
     //sanitize strings (website, website_2, paypal are not included)
     $strings = ['post_title', 'location', 'formatted_address', 'mailing_address', 'venmo', 'square', 'post_status', 'group', 'last_contact', 'conference_url_notes', 'conference_phone', 'conference_phone_notes'];
     foreach ($strings as $string) {
-        $_POST[$string] = stripslashes(sanitize_text_field($_POST[$string]));
+        if (isset($_POST[$string])) {
+            $_POST[$string] = stripslashes(sanitize_text_field($_POST[$string]));
+        }
     }
 
     //sanitize textareas
     $textareas = ['post_content', 'location_notes', 'group_notes'];
     foreach ($textareas as $textarea) {
-        $_POST[$textarea] = stripslashes(tsml_sanitize_text_area($_POST[$textarea]));
+        if (isset($_POST[$textarea])) {
+            $_POST[$textarea] = stripslashes(tsml_sanitize_text_area($_POST[$textarea]));
+        }
     }
 
     //get current meeting state to compare against


### PR DESCRIPTION
Issue #1399, you really can't trust what shows up on post_meta. In the user's case, it was something that resolved to a non-string, and then PHP warning'd in the `htmlentities()` step. So adding a few more lines to handle oddball data in post_meta.

Also saw a PHP warning on save, so added a check there. Sorry for more lines of code, functions.php is getting kinda beefy.