### PR TITLE
Add Timezone Field

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -4,7 +4,7 @@
  * Plugin Name: 12 Step Meeting List
  * Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
  * Description: Manage a list of recovery meetings
- * Version: 3.14.34
+ * Version: 3.14.35
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -18,7 +18,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 
 define('TSML_PATH', plugin_dir_path(__FILE__));
 
-define('TSML_VERSION', '3.14.34');
+define('TSML_VERSION', '3.14.35');
 
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 
@@ -35,6 +35,7 @@ if (false) {
 //include these files first
 include TSML_PATH . '/includes/filter_meetings.php';
 include TSML_PATH . '/includes/functions.php';
+include TSML_PATH . '/includes/functions_timezone.php';
 include TSML_PATH . '/includes/variables.php';
 
 //include public files

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -87,9 +87,7 @@ add_action('admin_init', function () {
                     class="checkboxes<?php if (!empty($tsml_types_in_use) && count($tsml_types_in_use) !== count($tsml_programs[$tsml_program]['types'])) { ?> has_more<?php } ?>">
                     <?php
                     foreach ($tsml_programs[$tsml_program]['types'] as $key => $type) {
-                        if ($key == 'ONL' || $key == 'TC') {
-                            continue;
-                        } //hide "Online Meeting" since it's not manually settable, neither is location Temporarily Closed
+                        if ($key == 'ONL' || $key == 'TC') continue; //hide "Online Meeting" since it's not manually settable, neither is location Temporarily Closed
                         ?>
                         <label <?php if (!empty($tsml_types_in_use) && !in_array($key, $tsml_types_in_use)) {
                             echo ' class="not_in_use"';
@@ -264,6 +262,18 @@ add_action('admin_init', function () {
         <?php } ?>
 
         <div class="meta_form_row">
+            <label>
+                <?php _e('Map', '12-step-meeting-list') ?>
+            </label>
+            <div id="map">
+                <?php if (empty($tsml_mapbox_key) && empty($tsml_google_maps_key)) { ?>
+                    <p>Enable maps on the <a href="<?php echo admin_url('edit.php?post_type=tsml_meeting&page=import') ?>">Import &
+                            Settings</a> page.</p>
+                <?php } ?>
+            </div>
+        </div>
+
+        <div class="meta_form_row">
             <label for="timezone">
                 <?php _e('Timezone', '12-step-meeting-list') ?>
             </label>
@@ -279,18 +289,6 @@ add_action('admin_init', function () {
                     </option>
                 <?php } ?>
             </select>
-        </div>
-
-        <div class="meta_form_row">
-            <label>
-                <?php _e('Map', '12-step-meeting-list') ?>
-            </label>
-            <div id="map">
-                <?php if (empty($tsml_mapbox_key) && empty($tsml_google_maps_key)) { ?>
-                    <p>Enable maps on the <a href="<?php echo admin_url('edit.php?post_type=tsml_meeting&page=import') ?>">Import &
-                            Settings</a> page.</p>
-                <?php } ?>
-            </div>
         </div>
 
         <?php if (count($meetings) > 1) { ?>

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -269,9 +269,9 @@ add_action('admin_init', function () {
 			</label>
 
 				<?php
-					$selected_timezone = isset($meeting->timezone) ? $meeting->timezone : ''; // Allow null tz for backwards compatibility
-					$timezones = DateTimeZone::listIdentifiers();
-				?>
+                    $selected_timezone = isset($meeting->timezone) ? $meeting->timezone : ''; // Allow null tz for backwards compatibility
+            $timezones = DateTimeZone::listIdentifiers();
+            ?>
             <select name="timezone" id="timezone">
 				<?php foreach ($timezones as $timezone) : ?>
 				<option value="<?echo esc_attr($timezone);?>" <?php selected($timezone, $selected_timezone);?>>

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -87,7 +87,9 @@ add_action('admin_init', function () {
                     class="checkboxes<?php if (!empty($tsml_types_in_use) && count($tsml_types_in_use) !== count($tsml_programs[$tsml_program]['types'])) { ?> has_more<?php } ?>">
                     <?php
                     foreach ($tsml_programs[$tsml_program]['types'] as $key => $type) {
-                        if ($key == 'ONL' || $key == 'TC') continue; //hide "Online Meeting" since it's not manually settable, neither is location Temporarily Closed
+                        if ($key == 'ONL' || $key == 'TC') {
+                            continue;
+                        } //hide "Online Meeting" since it's not manually settable, neither is location Temporarily Closed
                         ?>
                         <label <?php if (!empty($tsml_types_in_use) && !in_array($key, $tsml_types_in_use)) {
                             echo ' class="not_in_use"';
@@ -244,20 +246,20 @@ add_action('admin_init', function () {
                 </label>
             </div>
         <?php }
-            if (wp_count_terms('tsml_region')) { ?>
+        if (wp_count_terms('tsml_region')) { ?>
             <div class="meta_form_row">
                 <label for="region">
                     <?php _e('Region', '12-step-meeting-list') ?>
                 </label>
                 <?php wp_dropdown_categories([
-                        'name' => 'region',
-                        'taxonomy' => 'tsml_region',
-                        'hierarchical' => true,
-                        'hide_empty' => false,
-                        'orderby' => 'name',
-                        'selected' => empty($location->region_id) ? null : $location->region_id,
-                        'show_option_none' => __('Region', '12-step-meeting-list'),
-                    ]) ?>
+                    'name' => 'region',
+                    'taxonomy' => 'tsml_region',
+                    'hierarchical' => true,
+                    'hide_empty' => false,
+                    'orderby' => 'name',
+                    'selected' => empty($location->region_id) ? null : $location->region_id,
+                    'show_option_none' => __('Region', '12-step-meeting-list'),
+                ]) ?>
             </div>
         <?php } ?>
 
@@ -266,18 +268,16 @@ add_action('admin_init', function () {
 				 <?php _e('Timezone', '12-step-meeting-list') ?>
 			</label>
 
-            <select name="timezone" id="timezone">
 				<?php
-				$selected_timezone = isset($meeting->timezone) ? $meeting->timezone : ''; // Allow null tz for backwards compatibility
-				$timezones = DateTimeZone::listIdentifiers(); 
-				foreach ($timezones as $timezone) {
-        echo '<option value="' . htmlspecialchars($timezone) . '"';
-        if ($timezone === $selected_timezone) {
-            echo ' selected';
-        }
-        echo '>' . htmlspecialchars($timezone) . '</option>';
-    }
+					$selected_timezone = isset($meeting->timezone) ? $meeting->timezone : ''; // Allow null tz for backwards compatibility
+					$timezones = DateTimeZone::listIdentifiers();
 				?>
+            <select name="timezone" id="timezone">
+				<?php foreach ($timezones as $timezone) : ?>
+				<option value="<?echo esc_attr($timezone);?>" <?php selected($timezone, $selected_timezone);?>>
+						<?php echo esc_html($timezone); ?>
+					</option>
+				<?php endforeach; ?>
             </select>
 		</div>
 
@@ -300,10 +300,10 @@ add_action('admin_init', function () {
                 </label>
                 <ol>
                     <?php foreach ($meetings as $m) {
-                            if ($m['id'] != $meeting->ID) {
-                                $m['name'] = '<a href="' . get_edit_post_link($m['id']) . '">' . $m['name'] . '</a>';
-                            }
-                            ?>
+                        if ($m['id'] != $meeting->ID) {
+                            $m['name'] = '<a href="' . get_edit_post_link($m['id']) . '">' . $m['name'] . '</a>';
+                        }
+                        ?>
                         <li>
                             <span>
                                 <?php echo tsml_format_day_and_time(@$m['day'], @$m['time'], ' ', true) ?>

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -263,23 +263,23 @@ add_action('admin_init', function () {
             </div>
         <?php } ?>
 
-		<div class="meta_form_row">
-			<label for="timezone">
-				 <?php _e('Timezone', '12-step-meeting-list') ?>
-			</label>
+        <div class="meta_form_row">
+            <label for="timezone">
+                <?php _e('Timezone', '12-step-meeting-list') ?>
+            </label>
 
-				<?php
-                    $selected_timezone = isset($meeting->timezone) ? $meeting->timezone : ''; // Allow null tz for backwards compatibility
+            <?php
             $timezones = DateTimeZone::listIdentifiers();
+            array_unshift($timezones, '');
             ?>
             <select name="timezone" id="timezone">
-				<?php foreach ($timezones as $timezone) : ?>
-				<option value="<?echo esc_attr($timezone);?>" <?php selected($timezone, $selected_timezone);?>>
-						<?php echo esc_html($timezone); ?>
-					</option>
-				<?php endforeach; ?>
+                <?php foreach ($timezones as $timezone) { ?>
+                    <option value="<?php echo esc_attr($timezone); ?>" <?php selected($timezone, $meeting->timezone); ?>>
+                        <?php echo esc_html($timezone); ?>
+                    </option>
+                <?php } ?>
             </select>
-		</div>
+        </div>
 
         <div class="meta_form_row">
             <label>

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -261,6 +261,26 @@ add_action('admin_init', function () {
             </div>
         <?php } ?>
 
+		<div class="meta_form_row">
+			<label for="timezone">
+				 <?php _e('Timezone', '12-step-meeting-list') ?>
+			</label>
+
+            <select name="timezone" id="timezone">
+				<?php
+				$selected_timezone = isset($meeting->timezone) ? $meeting->timezone : ''; // Allow null tz for backwards compatibility
+				$timezones = DateTimeZone::listIdentifiers(); 
+				foreach ($timezones as $timezone) {
+        echo '<option value="' . htmlspecialchars($timezone) . '"';
+        if ($timezone === $selected_timezone) {
+            echo ' selected';
+        }
+        echo '>' . htmlspecialchars($timezone) . '</option>';
+    }
+				?>
+            </select>
+		</div>
+
         <div class="meta_form_row">
             <label>
                 <?php _e('Map', '12-step-meeting-list') ?>

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -161,7 +161,7 @@ add_action('admin_init', function () {
         'location',
         __('Location Information', '12-step-meeting-list'),
         function () {
-            global $tsml_mapbox_key, $tsml_google_maps_key;
+            global $tsml_mapbox_key, $tsml_google_maps_key, $tsml_timezone, $tsml_user_interface;
             $meeting = tsml_get_meeting();
             $location = $meetings = [];
             if ($meeting->post_parent) {
@@ -278,18 +278,16 @@ add_action('admin_init', function () {
                 <?php _e('Timezone', '12-step-meeting-list') ?>
             </label>
 
-            <?php
-            $timezones = DateTimeZone::listIdentifiers();
-            array_unshift($timezones, '');
-            ?>
-            <select name="timezone" id="timezone">
-                <?php foreach ($timezones as $timezone) { ?>
-                    <option value="<?php echo esc_attr($timezone); ?>" <?php selected($timezone, $meeting->timezone); ?>>
-                        <?php echo esc_html($timezone); ?>
-                    </option>
-                <?php } ?>
-            </select>
+            <?php echo tsml_timezone_select($location->timezone) ?>
         </div>
+
+        <?php if (empty($location->timezone) && empty($tsml_timezone) && $tsml_user_interface === 'tsml_ui') {?>
+            <div class="meta_form_separator">
+                <p>
+                    <?php _e('Because your site does not have a default timezone set, a timezone must be selected here for the meeting to appear on the meeting finder page.', '12-step-meeting-list') ?>
+                </p>
+            </div>
+        <?php } ?>
 
         <?php if (count($meetings) > 1) { ?>
             <div class="meta_form_row">

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -244,20 +244,20 @@ add_action('admin_init', function () {
                 </label>
             </div>
         <?php }
-        if (wp_count_terms('tsml_region')) { ?>
+            if (wp_count_terms('tsml_region')) { ?>
             <div class="meta_form_row">
                 <label for="region">
                     <?php _e('Region', '12-step-meeting-list') ?>
                 </label>
                 <?php wp_dropdown_categories([
-                    'name' => 'region',
-                    'taxonomy' => 'tsml_region',
-                    'hierarchical' => true,
-                    'hide_empty' => false,
-                    'orderby' => 'name',
-                    'selected' => empty($location->region_id) ? null : $location->region_id,
-                    'show_option_none' => __('Region', '12-step-meeting-list'),
-                ]) ?>
+                        'name' => 'region',
+                        'taxonomy' => 'tsml_region',
+                        'hierarchical' => true,
+                        'hide_empty' => false,
+                        'orderby' => 'name',
+                        'selected' => empty($location->region_id) ? null : $location->region_id,
+                        'show_option_none' => __('Region', '12-step-meeting-list'),
+                    ]) ?>
             </div>
         <?php } ?>
 
@@ -298,10 +298,10 @@ add_action('admin_init', function () {
                 </label>
                 <ol>
                     <?php foreach ($meetings as $m) {
-                        if ($m['id'] != $meeting->ID) {
-                            $m['name'] = '<a href="' . get_edit_post_link($m['id']) . '">' . $m['name'] . '</a>';
-                        }
-                        ?>
+                            if ($m['id'] != $meeting->ID) {
+                                $m['name'] = '<a href="' . get_edit_post_link($m['id']) . '">' . $m['name'] . '</a>';
+                            }
+                            ?>
                         <li>
                             <span>
                                 <?php echo tsml_format_day_and_time(@$m['day'], @$m['time'], ' ', true) ?>

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -15,7 +15,7 @@ function tsml_ajax_info()
 {
     global $tsml_sharing, $tsml_program, $tsml_data_sources, $tsml_google_maps_key, $tsml_mapbox_key, $tsml_sharing_keys,
     $tsml_contact_display, $tsml_cache_writable, $tsml_feedback_addresses, $tsml_user_interface, $tsml_notification_addresses,
-    $tsml_google_geocoding_key;
+    $tsml_google_geocoding_key, $tsml_timezone;
 
     $theme = wp_get_theme();
 
@@ -43,7 +43,7 @@ function tsml_ajax_info()
         ],
         'theme' => $theme->get_stylesheet(),
         'theme_parent' => $theme->exists() && $theme->parent() ? $theme->parent()->get_stylesheet() : null,
-        'timezone' => wp_timezone_string(),
+        'timezone' => $tsml_timezone,
         'versions' => [
             'php' => phpversion(),
             'tsml' => TSML_VERSION,

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -64,6 +64,7 @@ add_action('wp_ajax_tsml_locations', function () {
             'latitude' => $location['latitude'],
             'longitude' => $location['longitude'],
             'region' => $location['region_id'],
+            'timezone' => $location['timezone'],
             'notes' => html_entity_decode($location['location_notes']),
             'tokens' => tsml_string_tokens($location['location']),
         ];
@@ -449,6 +450,11 @@ add_action('wp_ajax_tsml_import', function () {
             add_post_meta($location_id, 'longitude', $geocoded['longitude']);
             add_post_meta($location_id, 'approximate', $geocoded['approximate']);
             wp_set_object_terms($location_id, $region_id, 'tsml_region');
+
+            // timezone
+            if (!empty($meeting['timezone']) && in_array($meeting['timezone'], DateTimeZone::listIdentifiers())) {
+                add_post_meta($location_id, 'timezone', $meeting['timezone']);
+            }
         }
 
         //save meeting to this location

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -986,6 +986,7 @@ function tsml_get_locations()
             'approximate' => empty($location_meta[$post->ID]['approximate']) ? null : $location_meta[$post->ID]['approximate'],
             'latitude' => empty($location_meta[$post->ID]['latitude']) ? null : $location_meta[$post->ID]['latitude'],
             'longitude' => empty($location_meta[$post->ID]['longitude']) ? null : $location_meta[$post->ID]['longitude'],
+            'timezone' => empty($location_meta[$post->ID]['timezone']) ? null : $location_meta[$post->ID]['timezone'],
             'region_id' => $region_id,
             'region' => $region,
             'sub_region' => $sub_region,
@@ -1353,7 +1354,7 @@ function tsml_get_meta($type, $id = null)
     global $wpdb, $tsml_custom_meeting_fields, $tsml_contact_fields;
     $keys = [
         'tsml_group' => array_keys($tsml_contact_fields),
-        'tsml_location' => ['formatted_address', 'latitude', 'longitude', 'approximate'],
+        'tsml_location' => ['formatted_address', 'latitude', 'longitude', 'approximate', 'timezone'],
         'tsml_meeting' => array_merge(
             [
                 'day',

--- a/includes/functions_timezone.php
+++ b/includes/functions_timezone.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ *
+ * Check if the timezone is valid
+ * Used in variables, save, and settings
+ *
+ * @param $timezone
+ * @return bool
+ */
+function tsml_timezone_is_valid($timezone)
+{
+    return in_array($timezone, DateTimeZone::listIdentifiers());
+}
+
+/**
+ *
+ * Render the timezone select menu
+ * Used in admin_edit and settings
+ *
+ * @param $selected
+ * @return string
+ */
+function tsml_timezone_select($selected = null)
+{
+    $continents = [];
+    foreach (DateTimeZone::listIdentifiers() as $timezone) {
+        $count_slashes = substr_count($timezone, '/');
+        if ($count_slashes < 1) {
+            continue;
+        }
+        list($continent, $city) = explode('/', $timezone, 2);
+        if (!isset($continents[$continent])) {
+            $continents[$continent] = [];
+        }
+        $continents[$continent][$timezone] = str_replace('_', ' ', str_replace('/', ' - ', $city));
+    }
+    $continents['UTC'] = ['UTC' => 'UTC'];
+    ?>
+    <select name="timezone" id="timezone">
+        <option value="" <?php selected($timezone, null) ?>></option>
+        <?php foreach ($continents as $continent => $cities) { ?>
+            <optgroup label="<?php echo $continent ?>">
+                <?php foreach ($cities as $timezone => $city) { ?>
+                    <option value="<?php echo $timezone ?>" <?php selected($timezone, $selected) ?>>
+                        <?php echo $city ?>
+                    </option>
+                <?php } ?>
+            </optgroup>
+        <?php } ?>
+    </select>
+    <?php
+}

--- a/includes/save.php
+++ b/includes/save.php
@@ -300,9 +300,9 @@ add_action('save_post', function ($post_id, $post, $update) {
     if (!$update || strcmp($old_meeting->timezone, $_POST['timezone']) !== 0) {
         $changes[] = 'timezone'	;
         if (!in_array($_POST['timezone'], DateTimeZone::listIdentifiers())) {
-            delete_post_meta($post->ID, 'timezone');
+            delete_post_meta($location_id, 'timezone');
         } else {
-            update_post_meta($post->ID, 'timezone', $_POST['timezone']);
+            update_post_meta($location_id, 'timezone', $_POST['timezone']);
         }
     }
 

--- a/includes/save.php
+++ b/includes/save.php
@@ -63,7 +63,7 @@ add_action('save_post', function ($post_id, $post, $update) {
     $old_meeting = null;
     if ($update) {
         $old_meeting = tsml_get_meeting($post_id);
-        $decode_keys = array('post_title', 'post_content', 'location', 'location_notes', 'group', 'group_notes');
+        $decode_keys = array('post_title', 'post_content', 'location', 'timezone', 'location_notes', 'group', 'group_notes');
         foreach ($decode_keys as $key) {
             if (!empty($old_meeting->{$key})) {
                 $old_meeting->{$key} = html_entity_decode($old_meeting->{$key});
@@ -183,9 +183,7 @@ add_action('save_post', function ($post_id, $post, $update) {
             if (empty($_POST['time'])) {
                 delete_post_meta($post->ID, 'time');
             } else {
-                //$time_temp = $old_meeting->time;
                 update_post_meta($post->ID, 'time', $_POST['time']);
-                //if ($time_temp != $old_meeting->time) die('what the fuck');
             }
         }
 
@@ -297,6 +295,16 @@ add_action('save_post', function ($post_id, $post, $update) {
             update_post_meta($location_id, 'formatted_address', $_POST['formatted_address']);
         }
     }
+
+	// save timezone
+	if (!$update || strcmp($old_meeting->timezone, $_POST['timezone']) !==0) {
+		$changes[] = 'timezone'	;
+		if (empty($_POST['timezone'])) {
+			delete_post_meta($post->ID, 'timezone');
+		} else {
+			update_post_meta($post->ID, 'timezone', $_POST['timezone']);
+		}
+	}
 
     //set parent on this post (or all meetings at location) without re-triggering the save_posts hook (update 7/25/17: removing post_status from this)
     if (!$update || ($old_meeting->post_parent != $location_id)) {

--- a/includes/save.php
+++ b/includes/save.php
@@ -299,7 +299,7 @@ add_action('save_post', function ($post_id, $post, $update) {
     // save timezone
     if (!$update || strcmp($old_meeting->timezone, $_POST['timezone']) !== 0) {
         $changes[] = 'timezone'	;
-		if (!in_array($_POST['timezone'], DateTimeZone::listIdentifiers())) {
+        if (!in_array($_POST['timezone'], DateTimeZone::listIdentifiers())) {
             delete_post_meta($post->ID, 'timezone');
         } else {
             update_post_meta($post->ID, 'timezone', $_POST['timezone']);

--- a/includes/save.php
+++ b/includes/save.php
@@ -44,7 +44,7 @@ add_action('save_post', function ($post_id, $post, $update) {
     $update = ($post->post_date !== $post->post_modified);
 
     //sanitize strings (website, website_2, paypal are not included)
-    $strings = ['post_title', 'location', 'formatted_address', 'mailing_address', 'venmo', 'square', 'post_status', 'group', 'last_contact', 'conference_url_notes', 'conference_phone', 'conference_phone_notes'];
+    $strings = ['post_title', 'location', 'formatted_address', 'timezone', 'mailing_address', 'venmo', 'square', 'post_status', 'group', 'last_contact', 'conference_url_notes', 'conference_phone', 'conference_phone_notes'];
     foreach ($strings as $string) {
         if (isset($_POST[$string])) {
             $_POST[$string] = stripslashes(sanitize_text_field($_POST[$string]));
@@ -296,15 +296,15 @@ add_action('save_post', function ($post_id, $post, $update) {
         }
     }
 
-	// save timezone
-	if (!$update || strcmp($old_meeting->timezone, $_POST['timezone']) !==0) {
-		$changes[] = 'timezone'	;
-		if (empty($_POST['timezone'])) {
-			delete_post_meta($post->ID, 'timezone');
-		} else {
-			update_post_meta($post->ID, 'timezone', $_POST['timezone']);
-		}
-	}
+    // save timezone
+    if (!$update || strcmp($old_meeting->timezone, $_POST['timezone']) !== 0) {
+        $changes[] = 'timezone'	;
+		if (!in_array($_POST['timezone'], DateTimeZone::listIdentifiers())) {
+            delete_post_meta($post->ID, 'timezone');
+        } else {
+            update_post_meta($post->ID, 'timezone', $_POST['timezone']);
+        }
+    }
 
     //set parent on this post (or all meetings at location) without re-triggering the save_posts hook (update 7/25/17: removing post_status from this)
     if (!$update || ($old_meeting->post_parent != $location_id)) {

--- a/includes/save.php
+++ b/includes/save.php
@@ -299,7 +299,7 @@ add_action('save_post', function ($post_id, $post, $update) {
     // save timezone
     if (!$update || strcmp($old_meeting->timezone, $_POST['timezone']) !== 0) {
         $changes[] = 'timezone'	;
-        if (!in_array($_POST['timezone'], DateTimeZone::listIdentifiers())) {
+        if (!tsml_timezone_is_valid($_POST['timezone'])) {
             delete_post_meta($location_id, 'timezone');
         } else {
             update_post_meta($location_id, 'timezone', $_POST['timezone']);

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -110,7 +110,7 @@ add_shortcode('tsml_types_list', function () {
 function tsml_ui()
 {
     global $tsml_mapbox_key, $tsml_nonce, $tsml_conference_providers, $tsml_language, $tsml_programs, $tsml_program, $tsml_ui_config,
-    $tsml_feedback_addresses, $tsml_cache, $tsml_cache_writable, $tsml_distance_units, $tsml_columns;
+    $tsml_feedback_addresses, $tsml_cache, $tsml_cache_writable, $tsml_distance_units, $tsml_columns, $tsml_timezone;
 
     //enqueue app script
     $js = defined('TSML_UI_PATH') ? TSML_UI_PATH : 'https://tsml-ui.code4recovery.org/app.js';
@@ -154,7 +154,7 @@ function tsml_ui()
 
     return '<div id="tsml-ui"
 					data-src="' . $data . '"
-					data-timezone="' . wp_timezone_string() . '"
+					data-timezone="' . $tsml_timezone . '"
 					data-mapbox="' . $tsml_mapbox_key . '"></div>';
 }
 add_shortcode('tsml_react', 'tsml_ui');

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -581,6 +581,10 @@ $tsml_street_only = true;
 //for timing
 $tsml_timestamp = microtime(true);
 
+//timezone
+$default_tz = tsml_timezone_is_valid(wp_timezone_string()) ? wp_timezone_string() : null;
+$tsml_timezone = get_option('tsml_timezone', $default_tz);
+
 //for customizing TSML-UI
 $tsml_ui_config = [];
 

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -112,6 +112,7 @@ $tsml_export_columns = [
     'types' => 'Types',
     'notes' => 'Notes',
     'location_notes' => 'Location Notes',
+    'timezone' => 'Timezone',
     'group' => 'Group',
     'district' => 'District',
     'sub_district' => 'Sub District',

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ These help improve code readability and maintainability:
 - Functions ought to be useful in multiple places (except functions that are available to end users such as `tsml_custom_types`)
 - Use anonymous functions when possible (we are PHP 5.6+)
 - Use bracket syntax for arrays (we are PHP 5.6+)
+- We are [PSR-12 compliant](https://www.php-fig.org/psr/psr-12/)
 
 Also some best practices:
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Code for Recovery
 Requires at least: 3.2
 Requires PHP: 5.6
 Tested up to: 6.5
-Stable tag: 3.14.34
+Stable tag: 3.14.35
 
 This plugin helps twelve step recovery programs list their meetings. It standardizes addresses, and displays results in a searchable list and map.
 
@@ -302,6 +302,9 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.14.35 =
+* Add timezone support [more info](https://github.com/code4recovery/12-step-meeting-list/issues/930)
 
 = 3.14.34 =
 * Fix PHP vulnerability [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1415)


### PR DESCRIPTION
adds:
* optional timezone dropdown to meeting edit screen
* timezone key to JSON (when present)
* timezone column in export CSV
* timezone import

here it is on the edit screen (a future PR could prettify the dropdown to group it by continent and remove underscores):
<img width="1527" alt="Screenshot 2024-05-17 at 7 29 25 AM" src="https://github.com/code4recovery/12-step-meeting-list/assets/1551689/ce7b62c3-5216-478d-83c4-dbc617f02b6f">

only TSML UI is affected. in this example the site's timezone is California, and the meeting is America/New_York, and the time is 7pm, so the meeting shows up at 4pm in the list and on the detail screen:

<img width="1527" alt="Screenshot 2024-05-17 at 7 29 23 AM" src="https://github.com/code4recovery/12-step-meeting-list/assets/1551689/e761a5d5-ade1-4dc8-b55b-05e808f51778">

