### PR TITLE
dashboard endpoint to debug geocodes

### DIFF
--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -278,7 +278,7 @@ add_action('admin_init', function () {
                 <?php _e('Timezone', '12-step-meeting-list') ?>
             </label>
 
-            <?php echo tsml_timezone_select($location->timezone) ?>
+            <?php echo tsml_timezone_select(@$location->timezone) ?>
         </div>
 
         <?php if (empty($location->timezone) && empty($tsml_timezone) && $tsml_user_interface === 'tsml_ui') {?>

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -352,7 +352,7 @@ function tsml_ajax_geocodes()
 
     // include the google overrides
     if (!empty($tsml_google_overrides)) {
-        //$addresses = array_merge($addresses, $tsml_google_overrides);
+        $addresses = array_merge($addresses, $tsml_google_overrides);
     }
 
     // add useful links

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -642,6 +642,8 @@ function tsml_geocode($address)
 {
     global $tsml_google_overrides;
 
+    $address = stripslashes($address);
+
     //check overrides first before anything
     if (array_key_exists($address, $tsml_google_overrides)) {
         if (empty($tsml_google_overrides[$address]['approximate'])) {


### PR DESCRIPTION
closes #1432 

* suppress a warning on timezones for new meetings
* add a new ajax url `?action=tsml_geocodes` to view and remove cached geocodes and view overrides
* strip slashes from incoming geocodes