### PR TITLE
Reformat and add Change Detection Email tweaks

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -4,7 +4,7 @@
  * Plugin Name: 12 Step Meeting List
  * Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
  * Description: Manage a list of recovery meetings
- * Version: 3.15
+ * Version: 3.15.1
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -18,7 +18,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 
 define('TSML_PATH', plugin_dir_path(__FILE__));
 
-define('TSML_VERSION', '3.15');
+define('TSML_VERSION', '3.15.1');
 
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 

--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -213,8 +213,7 @@ if (!function_exists('tsml_import_page')) {
                     tsml_delete_orphans();
 
                     if (count($change_log) && $tsml_debug) {
-                        $message = __('<h2>' . $data_source_name . __(' Feed Update Report', '12-step-meeting-list') . '</h2>');
-                        $message .= tsml_build_import_change_report($data_source_name, $change_log);
+                        $message = tsml_build_import_change_report($data_source_name, $change_log);
                         tsml_alert($message, 'info');
                     }
                     
@@ -354,11 +353,7 @@ if (!function_exists('tsml_import_page')) {
                                 <?php foreach ($tsml_data_sources as $feed => $properties) { ?>
                                     <tr data-source="<?php echo $feed ?>">
                                         <td class="small ">
-                                            <?php
-                                            $refresh_form_name = 'frm_' . tsml_make_refresh_attr_name(@$properties['name'], 'frm');
-                                            ?>
-
-                                            <form name="<?php echo $refresh_form_name ?>" method="post" action="<?php echo $_SERVER['REQUEST_URI'] ?>">
+                                            <form method="post" action="<?php echo $_SERVER['REQUEST_URI'] ?>">
                                                 <?php wp_nonce_field($tsml_nonce, 'tsml_nonce', false) ?>
                                                 <input type="hidden" name="tsml_add_data_source" value="<?php echo $feed ?>">
                                                 <input type="hidden" name="tsml_add_data_source_name"

--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -213,7 +213,8 @@ if (!function_exists('tsml_import_page')) {
                     tsml_delete_orphans();
 
                     if (count($change_log) && $tsml_debug) {
-                        $message = tsml_build_import_change_report($data_source_name, $change_log);
+                        $message = __('<h2>' . $data_source_name . __(' Feed Update Report', '12-step-meeting-list') . '</h2>');
+                        $message .= tsml_build_import_change_report($data_source_name, $change_log);
                         tsml_alert($message, 'info');
                     }
                     
@@ -353,7 +354,11 @@ if (!function_exists('tsml_import_page')) {
                                 <?php foreach ($tsml_data_sources as $feed => $properties) { ?>
                                     <tr data-source="<?php echo $feed ?>">
                                         <td class="small ">
-                                            <form method="post" action="<?php echo $_SERVER['REQUEST_URI'] ?>">
+                                            <?php
+                                            $refresh_form_name = 'frm_' . tsml_make_refresh_attr_name(@$properties['name'], 'frm');
+                                            ?>
+
+                                            <form name="<?php echo $refresh_form_name ?>" method="post" action="<?php echo $_SERVER['REQUEST_URI'] ?>">
                                                 <?php wp_nonce_field($tsml_nonce, 'tsml_nonce', false) ?>
                                                 <input type="hidden" name="tsml_add_data_source" value="<?php echo $feed ?>">
                                                 <input type="hidden" name="tsml_add_data_source_name"

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2283,7 +2283,7 @@ if (!function_exists('tsml_scan_data_source')) {
                     $message = sprintf(__("<p>Please sign in to your website and refresh the <b> %s </b> feed on the Import & Export page.</p><br>", '12-step-meeting-list'), $data_source_name);
                     $message .= tsml_build_import_change_report($data_source_name, $change_log);
                     $import_page_url = admin_url('/edit.php?post_type=tsml_meeting&page=import');
-                    $button_text = __(' Go to Import & Export page', '12-step-meeting-list');
+                    $button_text = __('Go to Import & Export page', '12-step-meeting-list');
                     $message .= "<a href='" . $import_page_url . "' style=' margin: 0 auto;background-color: #4CAF50;border: none;border-radius: 3px; color: white;padding: 25px 32px;text-align: center;text-decoration: none;display: block;font-size: 18px;'>$button_text</a>";
 
                     // send Changes Detected email

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -118,11 +118,7 @@ function tsml_build_import_change_report($data_source_name, $change_log, $embed_
 {
     global $tsml_days;
     if (!$embed_in_email) {
-        $hdr_meeting_day_time = __('Meeting', '12-step-meeting-list');
-        $hdr_slug = __('Slug', '12-step-meeting-list');
-        $hdr_notes = __('Notes', '12-step-meeting-list');
         $message = "<table style=\"margin-bottom:10px;text-align:left;border:1px solid #dddddd;padding: 8px;\" cellspacing=\"5\">";
-        $message .= "<tr><th>$hdr_meeting_day_time</th><th>$hdr_slug</th><th>$hdr_notes</th></tr>";
     } else {
         $message = "<table style=\"width:100%;margin-bottom:10px;text-align:left;border:1px solid #dddddd;padding: 8px;\" cellspacing=\"5\">";
     }
@@ -1569,7 +1565,7 @@ function tsml_sanitize_import_meetings($meetings, $data_source_url = null, $data
             if (isset($meetings[$i][$field])) {
                 $meeting_slug = sanitize_title($meetings[$i][$field]);
             }
-            if ($meeting_slug) { 
+            if ($meeting_slug) {
                 break;
             }
         }
@@ -1791,8 +1787,8 @@ function tsml_sanitize_import_meetings($meetings, $data_source_url = null, $data
         $group = isset($meeting['group']) ? $meeting['group'] : '';
         if (!$group) continue;
         foreach ($groups[$group] as $field => $value) {
-            $meetings[$i][$field] = $value;        
-        }    
+            $meetings[$i][$field] = $value;
+        }
     }
 
     //allow user-defined function to filter the meetings (for gal-aa.org)
@@ -2035,14 +2031,6 @@ function tsml_log($type, $info = null, $input = null)
 
     //save
     update_option('tsml_log', $tsml_log);
-}
-
-//function: reformat data source name to use for unique refresh button name
-//used:     admin_import
-function tsml_make_refresh_attr_name($string, $prefix)
-{
-    $string = str_replace(" ", "_", strtolower($string));
-    return $prefix . '_' . $string;
 }
 
 //function: link to meetings page with parameters (added to link dropdown menus for SEO)
@@ -2296,12 +2284,11 @@ if (!function_exists('tsml_scan_data_source')) {
                 list($import_meetings, $delete_meeting_ids,  $change_log) = tsml_get_changed_import_meetings($meetings, $data_source_url, $data_source_parent_region_id);
                 if (is_array($change_log) && count($change_log)) {
                     // Send Email notifying Admins that this Data Source needs updating
-                    $message = "<br>Please sign in to your website and refresh the <b>$data_source_name</b> feed on the Import & Export page.<br><br>";
+                    $message = sprintf(__("<p>Please sign in to your website and refresh the <b> %s </b> feed on the Import & Export page.</p><br>", '12-step-meeting-list'), $data_source_name);
                     $message .= tsml_build_import_change_report($data_source_name, $change_log, true);
-                    $refresh_form_name = tsml_make_refresh_attr_name($data_source_name, 'frm');
                     $import_page_url = admin_url('/edit.php?post_type=tsml_meeting&page=import');
-		    $button_text = __("Refresh $data_source_name Data Source", '12-step-meeting-list');
-                    $message .= "<a href='" . $import_page_url . "' style=' margin: 0 auto;background-color: #4CAF50;border: none;color: white;padding: 25px 32px;text-align: center;text-decoration: none;display: block;font-size: 18px;'>$button_text</a>";
+                    $button_text = __(' Go to Import & Export page', '12-step-meeting-list');
+                    $message .= "<a href='" . $import_page_url . "' style=' margin: 0 auto;background-color: #4CAF50;border: none;border-radius: 3px; color: white;padding: 25px 32px;text-align: center;text-decoration: none;display: block;font-size: 18px;'>$button_text</a>";
 
                     // send Changes Detected email
                     $subject = __('Data Source Changes Detected', '12-step-meeting-list');
@@ -2503,8 +2490,8 @@ function tsml_get_changed_import_meetings($feed_meetings, $data_source_url, $dat
         if (empty($feed_meeting) || !is_array($feed_meeting)) {
             continue;
         }
-        
-        $feed_meeting_slug = isset($feed_meeting['slug']) ? $feed_meeting['slug'] : null; 
+
+        $feed_meeting_slug = isset($feed_meeting['slug']) ? $feed_meeting['slug'] : null;
         $source_meeting_id = array_search($feed_meeting_slug, $meeting_source_slugs_map);
         if (!$source_meeting_id) {
             $source_meeting_id = array_search($feed_meeting_slug, $meeting_slugs_map);
@@ -2534,7 +2521,7 @@ function tsml_get_changed_import_meetings($feed_meetings, $data_source_url, $dat
             $change_log[] = array(
                 'action'      => 'add',
                 'description' => __('New', '12-step-meeting-list'),
-                'notes' => __('New ', '12-step-meeting-list'),
+                'notes' => __('New', '12-step-meeting-list'),
                 'meeting'     => $feed_meeting,
             );
             $import_meetings[] = $feed_meeting;
@@ -2550,7 +2537,7 @@ function tsml_get_changed_import_meetings($feed_meetings, $data_source_url, $dat
         $change_log[] = array(
             'action'      => 'remove',
             'description' => __('Removed / Missing', '12-step-meeting-list'),
-            'notes' => __('Removed ', '12-step-meeting-list'),
+            'notes' => __('Removed', '12-step-meeting-list'),
             'meeting'     => $delete_meeting,
             'meeting_id'  => $delete_meeting_id,
         );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -117,8 +117,6 @@ function tsml_bounds()
 function tsml_build_import_change_report($data_source_name, $change_log, $embed_in_email = false)
 {
     global $tsml_days;
-    //$message .= "<tr   style=\"text-align:left;border:1px solid #dddddd;padding: 8px;\" ><tbody>";
-
     if (!$embed_in_email) {
         $hdr_meeting_day_time = __('Meeting', '12-step-meeting-list');
         $hdr_slug = __('Slug', '12-step-meeting-list');

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -114,31 +114,27 @@ function tsml_bounds()
  * @param array $change_log Built from tsml_get_changed_import_meetings()
  * @return string
  */
-function tsml_build_import_change_report($data_source_name, $change_log, $embed_in_email = false)
+function tsml_build_import_change_report($data_source_name, $change_log)
 {
     global $tsml_days;
-    if (!$embed_in_email) {
-        $message = "<table style=\"margin-bottom:10px;text-align:left;border:1px solid #dddddd;padding: 8px;\" cellspacing=\"5\">";
-    } else {
-        $message = "<table style=\"width:100%;margin-bottom:10px;text-align:left;border:1px solid #dddddd;padding: 8px;\" cellspacing=\"5\">";
-    }
+    $message = "<table style=\"width:100%;margin-bottom:10px;text-align:left;border:1px solid #dddddd;padding: 8px;\" cellspacing=\"5\">";
 
     foreach($change_log as $change_entry) {
+        $meeting_id = isset($change_entry['meeting_id']) ? $change_entry['meeting_id'] : '';
         $meeting = (array) $change_entry['meeting'];
-        $meeting_name = isset($meeting['name']) ? $meeting['name'] : '?';
+        $meeting_name = isset($meeting['name']) ? $meeting['name'] : $meeting['slug'];
         $meeting_day_val = intval(isset($meeting['day']) ? $meeting['day'] : -1);
         $meeting_day = isset($tsml_days[$meeting_day_val]) ? $tsml_days[$meeting_day_val] : '?';
         $meeting_time = isset($meeting['time']) ? tsml_format_time($meeting['time']) : '?';
         $notes = isset($change_entry['notes']) ? $change_entry['notes'] : '';
 
-        if ($embed_in_email) {
-            $message .= '<tr><td style=\"width:60%;\" >' . $meeting_name . ' → ' . $meeting_day . ' @ ' . $meeting_time . ' </td>' .
-                            '<td style=\"width:50%;\" >' . $notes . ' </td></tr>';
+        $permalink = get_permalink($meeting_id);
+        if ($permalink !== false) {
+            $meeting_name_linked = '<a href=' . $permalink . '>' . $meeting_name . '</a><br>';
         } else {
-            $message .= '<tr><td>' . $meeting_name . ' → ' . $meeting_day . ' @ ' . $meeting_time . ' </td>' .
-                '<td>' . $meeting['slug'] . ' </td>' .
-                '<td>' . $notes . ' </td></tr>';
+            $meeting_name_linked = $meeting_name;
         }
+        $message .= '<tr><td>' . $meeting_name_linked . '  ' . $meeting_day . ' @ ' . $meeting_time . ' </td>' . '<td>' . $notes . ' </td></tr>';
     }
     $message .= "</tbody></table>";
     return $message;
@@ -2285,7 +2281,7 @@ if (!function_exists('tsml_scan_data_source')) {
                 if (is_array($change_log) && count($change_log)) {
                     // Send Email notifying Admins that this Data Source needs updating
                     $message = sprintf(__("<p>Please sign in to your website and refresh the <b> %s </b> feed on the Import & Export page.</p><br>", '12-step-meeting-list'), $data_source_name);
-                    $message .= tsml_build_import_change_report($data_source_name, $change_log, true);
+                    $message .= tsml_build_import_change_report($data_source_name, $change_log);
                     $import_page_url = admin_url('/edit.php?post_type=tsml_meeting&page=import');
                     $button_text = __(' Go to Import & Export page', '12-step-meeting-list');
                     $message .= "<a href='" . $import_page_url . "' style=' margin: 0 auto;background-color: #4CAF50;border: none;border-radius: 3px; color: white;padding: 25px 32px;text-align: center;text-decoration: none;display: block;font-size: 18px;'>$button_text</a>";

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -114,33 +114,37 @@ function tsml_bounds()
  * @param array $change_log Built from tsml_get_changed_import_meetings()
  * @return string
  */
-function tsml_build_import_change_report($data_source_name, $change_log)
+function tsml_build_import_change_report($data_source_name, $change_log, $embed_in_email = false)
 {
     global $tsml_days;
-    $hdr_change = __('Change', '12-step-meeting-list');
-    $hdr_meeting_name = __('Meeting Name', '12-step-meeting-list');
-    $hdr_day_time = __('Day / Time', '12-step-meeting-list');
-    $hdr_slug = __('Meeting Slug', '12-step-meeting-list');
-    $hdr_group = __('Group Name', '12-step-meeting-list');
-    $hdr_notes = __('Notes', '12-step-meeting-list');
-    $message = __('<h2>' . $data_source_name . __(' Feed Update Report', '12-step-meeting-list') . '</h2>');
-    $message .= "<table style=\"text-align:left\" cellspacing=\"5\"><tbody><tr><th>$hdr_change</th><th>$hdr_meeting_name</th><th>$hdr_day_time</th><th>$hdr_slug</th><th>$hdr_group</th><th>$hdr_notes</th></tr>";
+    //$message .= "<tr   style=\"text-align:left;border:1px solid #dddddd;padding: 8px;\" ><tbody>";
+
+    if (!$embed_in_email) {
+        $hdr_meeting_day_time = __('Meeting', '12-step-meeting-list');
+        $hdr_slug = __('Slug', '12-step-meeting-list');
+        $hdr_notes = __('Notes', '12-step-meeting-list');
+        $message = "<table style=\"margin-bottom:10px;text-align:left;border:1px solid #dddddd;padding: 8px;\" cellspacing=\"5\">";
+        $message .= "<tr><th>$hdr_meeting_day_time</th><th>$hdr_slug</th><th>$hdr_notes</th></tr>";
+    } else {
+        $message = "<table style=\"width:100%;margin-bottom:10px;text-align:left;border:1px solid #dddddd;padding: 8px;\" cellspacing=\"5\">";
+    }
+
     foreach($change_log as $change_entry) {
         $meeting = (array) $change_entry['meeting'];
         $meeting_name = isset($meeting['name']) ? $meeting['name'] : '?';
         $meeting_day_val = intval(isset($meeting['day']) ? $meeting['day'] : -1);
         $meeting_day = isset($tsml_days[$meeting_day_val]) ? $tsml_days[$meeting_day_val] : '?';
-        $meeting_time = isset($meeting['time']) ? $meeting['time'] : '?';
-        $meeting_group = isset($meeting['group']) ? $meeting['group'] : 'No group';
+        $meeting_time = isset($meeting['time']) ? tsml_format_time($meeting['time']) : '?';
         $notes = isset($change_entry['notes']) ? $change_entry['notes'] : '';
-        $message .= '<tr>' .
-            '<td>' . $change_entry['description'] . '</td>' .
-            '<td>' . $meeting_name . '</td>' .
-            '<td>' . $meeting_day . ' @ ' . $meeting_time . '</td>' .
-            '<td>' . $meeting['slug'] . '</td>' .
-            '<td>' . $meeting_group . '</td>' .
-            '<td>' . $notes . '</td>' .
-        '</tr>';    
+
+        if ($embed_in_email) {
+            $message .= '<tr><td style=\"width:60%;\" >' . $meeting_name . ' → ' . $meeting_day . ' @ ' . $meeting_time . ' </td>' .
+                            '<td style=\"width:50%;\" >' . $notes . ' </td></tr>';
+        } else {
+            $message .= '<tr><td>' . $meeting_name . ' → ' . $meeting_day . ' @ ' . $meeting_time . ' </td>' .
+                '<td>' . $meeting['slug'] . ' </td>' .
+                '<td>' . $notes . ' </td></tr>';
+        }
     }
     $message .= "</tbody></table>";
     return $message;
@@ -2035,6 +2039,14 @@ function tsml_log($type, $info = null, $input = null)
     update_option('tsml_log', $tsml_log);
 }
 
+//function: reformat data source name to use for unique refresh button name
+//used:     admin_import
+function tsml_make_refresh_attr_name($string, $prefix)
+{
+    $string = str_replace(" ", "_", strtolower($string));
+    return $prefix . '_' . $string;
+}
+
 //function: link to meetings page with parameters (added to link dropdown menus for SEO)
 //used:		archive-meetings.php
 function tsml_meetings_url($parameters)
@@ -2286,22 +2298,18 @@ if (!function_exists('tsml_scan_data_source')) {
                 list($import_meetings, $delete_meeting_ids,  $change_log) = tsml_get_changed_import_meetings($meetings, $data_source_url, $data_source_parent_region_id);
                 if (is_array($change_log) && count($change_log)) {
                     // Send Email notifying Admins that this Data Source needs updating
-                    $message = "Data Source changes were detected during a scheduled sychronization check with this feed: $data_source_url. Your website meeting list details based on the $data_source_name feed are no longer in sync. <br><br>Please sign-in to your website and refresh the $data_source_name Data Source feed found on the Meetings Import & Export page.<br><br>";
-                    $message .= "data_source_name: $data_source_name <br>";
-                    $term = get_term_by('term_id', $data_source_parent_region_id, 'tsml_region');
-                    $parent_region = $term->name;
-                    $message .= "parent_region: $parent_region <br>";
-                    $message .= "database record count: $data_source_count_meetings <br>";
-                    $feedCount = count($meetings);
-                    $message .= "data source feed count: $feedCount<br>";
-                    $message .= "Last Refresh: <span style='color:red;'>*</span>" . Date("l F j, Y  h:i a", $data_source_last_import) . '<br>';
-                    $message .= "<br><b><u>Detected Difference</b></u><br>";
-                    $message .= tsml_build_import_change_report($data_source_name, $change_log);
-                    $import_page_url = admin_url('edit.php?post_type=tsml_meeting&page=import');
-                    $message .= "<a href='" . $import_page_url . "' style=' margin: 0 auto;background-color: #4CAF50;border: none;color: white;padding: 25px 32px;text-align: center;text-decoration: none;display: block;font-size: 18px;'>Go to Import & Settings page</a>";
+                    $message = "<br>Please sign in to your website and refresh the <b>$data_source_name</b> feed on the Import & Export page.<br><br>";
+                    $message .= tsml_build_import_change_report($data_source_name, $change_log, true);
+                    $refresh_form_name = tsml_make_refresh_attr_name($data_source_name, 'frm');
+                    $import_page_url = admin_url('/edit.php?post_type=tsml_meeting&page=import');
+
+                    //$import_page_url = 'https://' . $_SERVER['SERVER_NAME'] . '/wp-admin/edit.php?post_type=tsml_meeting&page=import';
+                    $button_text = "Refresh $data_source_name Data Source";
+                    //$message .= "<a href=" . $import_page_url . " onclick='document.forms[$refresh_form_name].submit();' style=' margin:0 auto;background-color: #4CAF50;border: none;color: white;padding: 25px 32px;text-align: center;text-decoration: none;display: block;font-size: 16px;'>$button_text</a>";
+                    $message .= "<a href='" . $import_page_url . "' style=' margin: 0 auto;background-color: #4CAF50;border: none;color: white;padding: 25px 32px;text-align: center;text-decoration: none;display: block;font-size: 18px;'>$button_text</a>";
 
                     // send Changes Detected email
-                    $subject = __('Data Source Changes Detected', '12-step-meeting-list') . ': ' . $data_source_name;
+                    $subject = __('Data Source Changes Detected', '12-step-meeting-list');
                     if (tsml_email($tsml_notification_addresses, str_replace("'s", "s", $subject), $message)) {
                         _e("<div class='bg-success text-light'>Data Source changes were detected during the daily sychronization check with this feed: $data_source_url.<br></div>", '12-step-meeting-list');
                     } else {
@@ -2518,12 +2526,12 @@ function tsml_get_changed_import_meetings($feed_meetings, $data_source_url, $dat
                 $change_log[] = array(
                     'action'         => 'update',
                     'description'    => __('Updated', '12-step-meeting-list'),
-                    'notes'          => __('Fields changed', '12-step-meeting-list') . ': ' . implode(', ', $changed_fields),
+                    'notes'          => __('Changed', '12-step-meeting-list') . ': ' . implode(', ', $changed_fields),
                     'changed_fields' => $changed_fields,
                     'meeting'        => $feed_meeting,
                     'meeting_id'     => $source_meeting_id,
                 );
-                //add `ID` field to meeting to trigger a existing post update versus new post insert
+                //add `ID` field to meeting to trigger an existing post update versus new post insert
                 $feed_meeting['ID'] = $source_meeting_id;
                 $import_meetings[] = $feed_meeting;
             }
@@ -2531,6 +2539,7 @@ function tsml_get_changed_import_meetings($feed_meetings, $data_source_url, $dat
             $change_log[] = array(
                 'action'      => 'add',
                 'description' => __('New', '12-step-meeting-list'),
+                'notes' => __('New ', '12-step-meeting-list'),
                 'meeting'     => $feed_meeting,
             );
             $import_meetings[] = $feed_meeting;
@@ -2546,6 +2555,7 @@ function tsml_get_changed_import_meetings($feed_meetings, $data_source_url, $dat
         $change_log[] = array(
             'action'      => 'remove',
             'description' => __('Removed / Missing', '12-step-meeting-list'),
+            'notes' => __('Removed ', '12-step-meeting-list'),
             'meeting'     => $delete_meeting,
             'meeting_id'  => $delete_meeting_id,
         );
@@ -2609,7 +2619,7 @@ function tsml_compare_imported_meeting($local_meeting, $import_meeting)
     $diff_fields = array();
     foreach($compare_fields as $field) {
         if ($normalized_meetings[0][$field] !== $normalized_meetings[1][$field]) {
-            $diff_fields[] = $field;
+            $diff_fields[] = $tsml_export_columns[$field];
         }
     }
     return count($diff_fields) ? $diff_fields : null;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2302,7 +2302,7 @@ if (!function_exists('tsml_scan_data_source')) {
                     $message .= tsml_build_import_change_report($data_source_name, $change_log, true);
                     $refresh_form_name = tsml_make_refresh_attr_name($data_source_name, 'frm');
                     $import_page_url = admin_url('/edit.php?post_type=tsml_meeting&page=import');
-                    $button_text = "Refresh $data_source_name Data Source";
+		    $button_text = __("Refresh $data_source_name Data Source", '12-step-meeting-list');
                     $message .= "<a href='" . $import_page_url . "' style=' margin: 0 auto;background-color: #4CAF50;border: none;color: white;padding: 25px 32px;text-align: center;text-decoration: none;display: block;font-size: 18px;'>$button_text</a>";
 
                     // send Changes Detected email

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2302,10 +2302,7 @@ if (!function_exists('tsml_scan_data_source')) {
                     $message .= tsml_build_import_change_report($data_source_name, $change_log, true);
                     $refresh_form_name = tsml_make_refresh_attr_name($data_source_name, 'frm');
                     $import_page_url = admin_url('/edit.php?post_type=tsml_meeting&page=import');
-
-                    //$import_page_url = 'https://' . $_SERVER['SERVER_NAME'] . '/wp-admin/edit.php?post_type=tsml_meeting&page=import';
                     $button_text = "Refresh $data_source_name Data Source";
-                    //$message .= "<a href=" . $import_page_url . " onclick='document.forms[$refresh_form_name].submit();' style=' margin:0 auto;background-color: #4CAF50;border: none;color: white;padding: 25px 32px;text-align: center;text-decoration: none;display: block;font-size: 16px;'>$button_text</a>";
                     $message .= "<a href='" . $import_page_url . "' style=' margin: 0 auto;background-color: #4CAF50;border: none;color: white;padding: 25px 32px;text-align: center;text-decoration: none;display: block;font-size: 18px;'>$button_text</a>";
 
                     // send Changes Detected email

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: code4recovery
 Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 5.6
-Tested up to: 6.6.1
-Stable tag: 3.15
+Tested up to: 6.6
+Stable tag: 3.15.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -300,6 +300,9 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.15.1 =
+* Reformat 'Change Detection Email' for better legability. [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1497)
 
 = 3.15 =
 * Modifies Import Data Source feature so that only the changes detected between an import feed and the local database are applied as updates. [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1075)

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: code4recovery
 Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 5.6
-Tested up to: 6.6.1
-Stable tag: 3.15
+Tested up to: 6.6
+Stable tag: 3.15.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -302,7 +302,7 @@ Yes, you will need to know the key name of the field. Then include an array in y
 == Changelog ==
 
 = 3.15.1 =
-* Reformat 'Change Detection Email' for better legability. [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1497)
+* Reformat 'Change Detection Email' for better legibility. [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1497)
 
 = 3.15 =
 * Modifies Import Data Source feature so that only the changes detected between an import feed and the local database are applied as updates. [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1075)

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: code4recovery
 Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 5.6
-Tested up to: 6.6
+Tested up to: 6.6.1
 Stable tag: 3.15
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
title: Data Source Changes Detected
text: Please sign in to your website and refresh the [data_source_name] Data Source feed on the Import & Export page.
table: two columns, no heading
footer link text: Refresh [data_source_name] Data Source
time: 12 hour format
notes: 1st word should be New, Changed, or Removed depending on the change mode. All changed fields use the $tsml_export_columns value instead of key.
group name: Remove
Should look something like this:
![image](https://github.com/user-attachments/assets/36afd41d-aeeb-4791-acb9-f6b6a582cc30)

