### PR TITLE
Refactor Languages to decouple from all programs but preserve legacy Type abbreviations

### DIFF
--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -43,8 +43,6 @@ add_action('admin_init', function () {
 
         $meeting = tsml_get_meeting();
 
-		$meeting_languages = isset($meeting->languages) && is_array($meeting->languages) ? $meeting->languages : []; // forces an array
-
         //time is before the end of april and not currently using temporary closure
         if (!in_array('TC', $tsml_types_in_use) && time() < strtotime('2020-04-30')) {
             tsml_alert('Please note: a new “Temporary Closure” meeting type has recently been added. Use this to indicate meetings that are temporarily not meeting. Find it under “View all” below.', 'warning');
@@ -112,35 +110,36 @@ add_action('admin_init', function () {
                     </div>
                 </div>
             </div>
-		<div class="meta_form_row">
-			<label for="languages">
-				<?php _e('Languages', '12-step-meeting-list') ?>
-			</label>
-			<div class="checkboxes<?php if (!empty($tsml_types_in_use) && count($tsml_types_in_use) !== count($tsml_programs[$tsml_program]['languages'])) { ?> has_more<?php } ?>">
-				<?php 
-                foreach ($tsml_programs[$tsml_program]['languages'] as $key => $type) { 
-                    ?>
+            <div class="meta_form_row">
+                <label for="languages">
+                    <?php _e('Languages', '12-step-meeting-list') ?>
+                </label>
+                <div
+                    class="checkboxes<?php if (!empty($tsml_types_in_use) && count($tsml_types_in_use) !== count($tsml_programs[$tsml_program]['languages'])) { ?> has_more<?php } ?>">
+                    <?php
+                    foreach ($tsml_programs[$tsml_program]['languages'] as $key => $type) {
+                        ?>
                         <label <?php if (!empty($tsml_types_in_use) && !in_array($key, $tsml_types_in_use)) {
                             echo ' class="not_in_use"';
                         } ?>>
-						<input type="checkbox" name="types[]" value="<?php echo $key ?>" <?php checked(in_array($key, @$meeting->types)) ?>>
-						<?php echo $type ?>
-					</label>
-				<?php } ?>
-				<div class="toggle_more">
-					<div class="more">
-						<span class="dashicons dashicons-arrow-down-alt2"></span> <a href="#more-types">
-							<?php _e('View all', '12-step-meeting-list') ?>
-						</a>
-					</div>
-					<div class="less">
-						<span class="dashicons dashicons-arrow-up-alt2"></span> <a href="#more-types">
-							<?php _e('Hide types not in use', '12-step-meeting-list') ?>
-						</a>
-					</div>
-				</div>
-			</div>
-		</div>
+                                        <input type="checkbox" name="types[]" value="<?php echo $key ?>" <?php checked(in_array($key, @$meeting->types)) ?>>
+                            <?php echo $type ?>
+                        </label>
+                    <?php } ?>
+                    <div class="toggle_more">
+                        <div class="more">
+                            <span class="dashicons dashicons-arrow-down-alt2"></span> <a href="#more-types">
+                                <?php _e('View all', '12-step-meeting-list') ?>
+                            </a>
+                        </div>
+                        <div class="less">
+                            <span class="dashicons dashicons-arrow-up-alt2"></span> <a href="#more-types">
+                                <?php _e('Hide types not in use', '12-step-meeting-list') ?>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
         <?php } ?>
         <div class="meta_form_row">
             <label for="content">
@@ -186,7 +185,7 @@ add_action('admin_init', function () {
                 value="<?php echo $meeting->conference_phone_notes ?>">
         </div>
         <?php
-	}, 'tsml_meeting', 'normal', 'low');
+    }, 'tsml_meeting', 'normal', 'low');
 
     add_meta_box(
         'location',
@@ -312,7 +311,7 @@ add_action('admin_init', function () {
             <?php echo tsml_timezone_select(@$location->timezone) ?>
         </div>
 
-        <?php if (empty($location->timezone) && empty($tsml_timezone) && $tsml_user_interface === 'tsml_ui') {?>
+        <?php if (empty($location->timezone) && empty($tsml_timezone) && $tsml_user_interface === 'tsml_ui') { ?>
             <div class="meta_form_separator">
                 <p>
                     <?php _e('Because your site does not have a default timezone set, a timezone must be selected here for the meeting to appear on the meeting finder page.', '12-step-meeting-list') ?>

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -41,6 +41,8 @@ add_action('admin_init', function () {
     add_meta_box('info', __('Meeting Information', '12-step-meeting-list'), function () {
         global $tsml_days, $tsml_programs, $tsml_program, $tsml_nonce, $tsml_types_in_use;
 
+		$meeting_languages = isset($meeting->languages) && is_array($meeting->languages) ? $meeting->languages : []; // forces an array
+
         $meeting = tsml_get_meeting();
 
         //time is before the end of april and not currently using temporary closure
@@ -111,6 +113,31 @@ add_action('admin_init', function () {
                 </div>
             </div>
         <?php } ?>
+		<div class="meta_form_row">
+			<label for="languages">
+				<?php _e('Languages', '12-step-meeting-list') ?>
+			</label>
+			<div class="checkboxes">
+				<?php foreach ($tsml_programs[$tsml_program]['languages'] as $key => $language) { ?>
+					<label>
+						<input type="checkbox" name="languages[]" value="<?php echo $key ?>" <?php checked(in_array($key, $meeting_languages)) ?>>
+						<?php echo $language ?>
+					</label>
+				<?php } ?>
+				<div class="toggle_more">
+					<div class="more">
+						<span class="dashicons dashicons-arrow-down-alt2"></span> <a href="#more-types">
+							<?php _e('View all', '12-step-meeting-list') ?>
+						</a>
+					</div>
+					<div class="less">
+						<span class="dashicons dashicons-arrow-up-alt2"></span> <a href="#more-types">
+							<?php _e('Hide types not in use', '12-step-meeting-list') ?>
+						</a>
+					</div>
+				</div>
+			</div>
+		</div>
         <div class="meta_form_row">
             <label for="content">
                 <?php _e('Notes', '12-step-meeting-list') ?>

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -116,13 +116,11 @@ add_action('admin_init', function () {
                     <?php _e('Languages', '12-step-meeting-list') ?>
                 </label>
                 <div
-                    class="checkboxes<?php if (!empty($tsml_types_in_use) && count($tsml_types_in_use) !== count($tsml_programs[$tsml_program]['languages'])) { ?> has_more<?php } ?>">
+                    class="checkboxes">
                     <?php
                     foreach ($tsml_programs[$tsml_program]['languages'] as $key => $type) {
                         ?>
-                        <label <?php if (!empty($tsml_types_in_use) && !in_array($key, $tsml_types_in_use)) {
-                            echo ' class="not_in_use"';
-                        } ?>>
+                        <label>
                             <input type="checkbox" name="types[]" value="<?php echo $key ?>" <?php checked(in_array($key, @$meeting->types)) ?>>
                             <?php echo $type ?>
                         </label>

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -87,7 +87,8 @@ add_action('admin_init', function () {
                     class="checkboxes<?php if (!empty($tsml_types_in_use) && count($tsml_types_in_use) !== count($tsml_programs[$tsml_program]['types'])) { ?> has_more<?php } ?>">
                     <?php
                     foreach ($tsml_programs[$tsml_program]['types'] as $key => $type) {
-                        if ($key == 'ONL' || $key == 'TC') continue; //hide "Online Meeting" since it's not manually settable, neither is location Temporarily Closed
+                        if ($key == 'ONL' || $key == 'TC')
+                            continue; //hide "Online Meeting" since it's not manually settable, neither is location Temporarily Closed
                         ?>
                         <label <?php if (!empty($tsml_types_in_use) && !in_array($key, $tsml_types_in_use)) {
                             echo ' class="not_in_use"';
@@ -122,7 +123,7 @@ add_action('admin_init', function () {
                         <label <?php if (!empty($tsml_types_in_use) && !in_array($key, $tsml_types_in_use)) {
                             echo ' class="not_in_use"';
                         } ?>>
-                                        <input type="checkbox" name="types[]" value="<?php echo $key ?>" <?php checked(in_array($key, @$meeting->types)) ?>>
+                            <input type="checkbox" name="types[]" value="<?php echo $key ?>" <?php checked(in_array($key, @$meeting->types)) ?>>
                             <?php echo $type ?>
                         </label>
                     <?php } ?>
@@ -134,7 +135,7 @@ add_action('admin_init', function () {
                         </div>
                         <div class="less">
                             <span class="dashicons dashicons-arrow-up-alt2"></span> <a href="#more-types">
-                                <?php _e('Hide types not in use', '12-step-meeting-list') ?>
+                                <?php _e('Hide languages not in use', '12-step-meeting-list') ?>
                             </a>
                         </div>
                     </div>

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -41,9 +41,9 @@ add_action('admin_init', function () {
     add_meta_box('info', __('Meeting Information', '12-step-meeting-list'), function () {
         global $tsml_days, $tsml_programs, $tsml_program, $tsml_nonce, $tsml_types_in_use;
 
-		$meeting_languages = isset($meeting->languages) && is_array($meeting->languages) ? $meeting->languages : []; // forces an array
-
         $meeting = tsml_get_meeting();
+
+		$meeting_languages = isset($meeting->languages) && is_array($meeting->languages) ? $meeting->languages : []; // forces an array
 
         //time is before the end of april and not currently using temporary closure
         if (!in_array('TC', $tsml_types_in_use) && time() < strtotime('2020-04-30')) {
@@ -112,16 +112,19 @@ add_action('admin_init', function () {
                     </div>
                 </div>
             </div>
-        <?php } ?>
 		<div class="meta_form_row">
 			<label for="languages">
 				<?php _e('Languages', '12-step-meeting-list') ?>
 			</label>
-			<div class="checkboxes">
-				<?php foreach ($tsml_programs[$tsml_program]['languages'] as $key => $language) { ?>
-					<label>
-						<input type="checkbox" name="languages[]" value="<?php echo $key ?>" <?php checked(in_array($key, $meeting_languages)) ?>>
-						<?php echo $language ?>
+			<div class="checkboxes<?php if (!empty($tsml_types_in_use) && count($tsml_types_in_use) !== count($tsml_programs[$tsml_program]['languages'])) { ?> has_more<?php } ?>">
+				<?php 
+                foreach ($tsml_programs[$tsml_program]['languages'] as $key => $type) { 
+                    ?>
+                        <label <?php if (!empty($tsml_types_in_use) && !in_array($key, $tsml_types_in_use)) {
+                            echo ' class="not_in_use"';
+                        } ?>>
+						<input type="checkbox" name="types[]" value="<?php echo $key ?>" <?php checked(in_array($key, @$meeting->types)) ?>>
+						<?php echo $type ?>
 					</label>
 				<?php } ?>
 				<div class="toggle_more">
@@ -138,6 +141,7 @@ add_action('admin_init', function () {
 				</div>
 			</div>
 		</div>
+        <?php } ?>
         <div class="meta_form_row">
             <label for="content">
                 <?php _e('Notes', '12-step-meeting-list') ?>
@@ -182,7 +186,7 @@ add_action('admin_init', function () {
                 value="<?php echo $meeting->conference_phone_notes ?>">
         </div>
         <?php
-    }, 'tsml_meeting', 'normal', 'low');
+	}, 'tsml_meeting', 'normal', 'low');
 
     add_meta_box(
         'location',

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -958,14 +958,7 @@ function tsml_load_config()
                 'CC' => __('Chair\'s Choice', '12-step-meeting-list'),
                 'CF' => __('Child-Friendly', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
-                'NL' => __('Dutch', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
-                'DE' => __('German', '12-step-meeting-list'),
-                'KA' => __('Georgian', '12-step-meeting-list'),
-                'EL' => __('Greek', '12-step-meeting-list'),
                 'NDG' => __('Indigenous', '12-step-meeting-list'),
-                'IS' => __('Icelandic', '12-step-meeting-list'),
-                'ITA' => __('Italian', '12-step-meeting-list'),
                 'LIT' => __('Literature', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ+', '12-step-meeting-list'),
                 'MED' => __('Meditation', '12-step-meeting-list'),
@@ -1375,12 +1368,12 @@ function tsml_load_config()
 		'EN' => __('English', '12-step-meeting-list'),
 		'FI' => __('Finnish', '12-step-meeting-list'),
 		'FR' => __('French', '12-step-meeting-list'),
-		'GE' => __('Georgian', '12-step-meeting-list'),
+		'KA' => __('Georgian', '12-step-meeting-list'),
 		'DE' => __('German', '12-step-meeting-list'),
 		'EL' => __('Greek', '12-step-meeting-list'),
 		'HE' => __('Hebrew', '12-step-meeting-list'),
 		'HI' => __('Hindi', '12-step-meeting-list'),
-		'IC' => __('Icelandic', '12-step-meeting-list'),
+		'IS' => __('Icelandic', '12-step-meeting-list'), //conflict w RD Inquiry Study; RS Inventory study
 		'ITA' => __('Italian', '12-step-meeting-list'),
 		'JA' => __('Japanese', '12-step-meeting-list'),
 		'KOR' => __('Korean', '12-step-meeting-list'),
@@ -1425,17 +1418,17 @@ function tsml_load_config()
 	$tsml_programs['ACA']['types']['S'] = __('Speaker', '12-step-meeting-list');
 	$tsml_programs['ACA']['types']['SP'] = __('Spanish', '12-step-meeting-list');
 
-	// EDA
-	unset($tsml_programs['EDA']['types']['EL']);
-	$tsml_programs['EDA']['types']['GR'] = __('Greek', '12-step-meeting-list');
-	
 	// Recovery Dharma
 	unset($tsml_programs['Recovery Dharma']['types']['S']);
 	$tsml_programs['Recovery Dharma']['types']['ES'] = __('Spanish', '12-step-meeting-list');
+	unset($tsml_programs['Recovery Dharma']['types']['IS']);
+	$tsml_programs['Recovery Dharma']['types']['IS'] =  __('Inquiry Study', '12-step-meeting-list');
 
 	// Refuge Recovery
 	unset($tsml_programs['Refuge Recovery']['types']['S']);
+	unset($tsml_programs['Refuge Recovery']['types']['IS']);
 	$tsml_programs['Refuge Recovery']['types']['ES'] =  __('Spanish', '12-step-meeting-list');
+	$tsml_programs['Refuge Recovery']['types']['IS'] =  __('Inventory Study', '12-step-meeting-list');
 
 	// UA
 	unset($tsml_programs['UA']['types']['S']);

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -597,7 +597,7 @@ if (!isset($tsml_slug)) $tsml_slug = null;
 // set up globals, common variables once plugins are loaded, but before init
 function tsml_load_config()
 {
-    global $tsml_days, $tsml_days_order, $tsml_programs, $tsml_slug, $tsml_strings, $tsml_user_interface, $tsml_types_in_use;
+    global $tsml_days, $tsml_days_order, $tsml_languages, $tsml_programs, $tsml_slug, $tsml_strings, $tsml_user_interface, $tsml_types_in_use, $tsml_languages;
 
     //load internationalization
     load_plugin_textdomain('12-step-meeting-list', false, '12-step-meeting-list/languages');
@@ -619,7 +619,7 @@ function tsml_load_config()
         $tsml_days = $remainder + $tsml_days;
     }
 
-    //used by tsml_meetings_sort() over and over
+	//used by tsml_meetings_sort() over and over
     $tsml_days_order = array_keys($tsml_days);
 
     //supported program names (alpha by the 'name' key)
@@ -646,7 +646,6 @@ function tsml_load_config()
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
                 'S' => __('Speaker', '12-step-meeting-list'),
-                'SP' => __('Spanish', '12-step-meeting-list'),
                 'ST' => __('Steps', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
                 'Y' => __('Yellow Workbook Study', '12-step-meeting-list'),
@@ -668,7 +667,6 @@ function tsml_load_config()
                 'BE' => __('Beginner', '12-step-meeting-list'),
                 'AA' => __('Concurrent with AA Meeting', '12-step-meeting-list'),
                 'AL' => __('Concurrent with Alateen Meeting', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
                 'O' => __('Families Friends and Observers Welcome', '12-step-meeting-list'),
                 'C' => __('Families and Friends Only', '12-step-meeting-list'),
                 'FF' => __('Fragrance Free', '12-step-meeting-list'),
@@ -681,7 +679,6 @@ function tsml_load_config()
                 'POA' => __('Parents of Alcoholics', '12-step-meeting-list'),
                 'POC' => __('People of Color', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Meeting', '12-step-meeting-list'),
                 'T' => __('Transgender', '12-step-meeting-list'),
@@ -716,16 +713,10 @@ function tsml_load_config()
                 'DB' => __('Digital Basket', '12-step-meeting-list'),
                 'D' => __('Discussion', '12-step-meeting-list'),
                 'DD' => __('Dual Diagnosis', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
                 'FF' => __('Fragrance Free', '12-step-meeting-list'),
-                'FR' => __('French', '12-step-meeting-list'),
                 'G' => __('Gay', '12-step-meeting-list'),
                 'GR' => __('Grapevine', '12-step-meeting-list'),
-                'HE' => __('Hebrew', '12-step-meeting-list'),
                 'NDG' => __('Indigenous', '12-step-meeting-list'),
-                'ITA' => __('Italian', '12-step-meeting-list'),
-                'JA' => __('Japanese', '12-step-meeting-list'),
-                'KOR' => __('Korean', '12-step-meeting-list'),
                 'L' => __('Lesbian', '12-step-meeting-list'),
                 'LIT' => __('Literature', '12-step-meeting-list'),
                 'LS' => __('Living Sober', '12-step-meeting-list'),
@@ -740,14 +731,10 @@ function tsml_load_config()
                 'O' => __('Open', '12-step-meeting-list'),
                 'OUT' => __('Outdoor Meeting', '12-step-meeting-list'),
                 'POC' => __('People of Color', '12-step-meeting-list'),
-                'POL' => __('Polish', '12-step-meeting-list'),
-                'POR' => __('Portuguese', '12-step-meeting-list'),
                 'P' => __('Professionals', '12-step-meeting-list'),
-                'PUN' => __('Punjabi', '12-step-meeting-list'),
-                'RUS' => __('Russian', '12-step-meeting-list'),
                 'A' => __('Secular', '12-step-meeting-list'),
                 'SEN' => __('Seniors', '12-step-meeting-list'),
-                'ASL' => __('Sign Language', '12-step-meeting-list'),
+				'ASL' => __('American Sign Language', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
                 'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
@@ -769,8 +756,8 @@ function tsml_load_config()
                 'O' => __('Open meetings are available to anyone interested in Crystal Meth Anonymous’ program of recovery from using. Non users may attend open meetings as observers.', '12-step-meeting-list'),
             ],
             'types' => [
-                'ASL' => __('Sign Language', '12-step-meeting-list'),
-                'C' => __('Closed', '12-step-meeting-list'),
+				'ASL' => __('Sign Language', '12-step-meeting-list'),
+				'C' => __('Closed', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ', '12-step-meeting-list'),
                 'LIT' => __('Literature', '12-step-meeting-list'),
                 'M' => __('Men', '12-step-meeting-list'),
@@ -780,7 +767,6 @@ function tsml_load_config()
                 'OUT' => __('Outdoor Meeting', '12-step-meeting-list'),
                 'POC' => __('People of Color', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Meeting', '12-step-meeting-list'),
                 'T' => __('Transgender', '12-step-meeting-list'),
@@ -824,7 +810,6 @@ function tsml_load_config()
                 'SHARE' => __('Sharing', '12-step-meeting-list'),
                 'ASL' => __('Sign Language', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Meeting', '12-step-meeting-list'),
                 'TEEN' => __('Teens', '12-step-meeting-list'),
@@ -864,13 +849,9 @@ function tsml_load_config()
                 'DR' => __('Daily Reflections', '12-step-meeting-list'),
                 'D' => __('Discussion', '12-step-meeting-list'),
                 'DD' => __('Dual Diagnosis', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
                 'FF' => __('Fragrance Free', '12-step-meeting-list'),
-                'FR' => __('French', '12-step-meeting-list'),
                 'G' => __('Gay', '12-step-meeting-list'),
                 'GR' => __('Grapevine', '12-step-meeting-list'),
-                'ITA' => __('Italian', '12-step-meeting-list'),
-                'KOR' => __('Korean', '12-step-meeting-list'),
                 'L' => __('Lesbian', '12-step-meeting-list'),
                 'LIT' => __('Literature', '12-step-meeting-list'),
                 'LS' => __('Living Sober', '12-step-meeting-list'),
@@ -882,13 +863,8 @@ function tsml_load_config()
                 'BE' => __('Newcomer', '12-step-meeting-list'),
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
-                'POL' => __('Polish', '12-step-meeting-list'),
-                'POR' => __('Portuguese', '12-step-meeting-list'),
-                'PUN' => __('Punjabi', '12-step-meeting-list'),
-                'RUS' => __('Russian', '12-step-meeting-list'),
-                'ASL' => __('Sign Language', '12-step-meeting-list'),
+				'ASL' => __('Sign Language', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Meeting', '12-step-meeting-list'),
                 'TR' => __('Tradition Study', '12-step-meeting-list'),
@@ -980,14 +956,7 @@ function tsml_load_config()
 				'CC' => __('Chair\'s Choice', '12-step-meeting-list'),
                 'CF' => __('Child-Friendly', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
-				'NL' => __('Dutch', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
-				'DE' => __('German', '12-step-meeting-list'),
-				'GE' => __('Georgian', '12-step-meeting-list'),
-				'GR' => __('Greek', '12-step-meeting-list'),
                 'NDG' => __('Indigenous', '12-step-meeting-list'),
-				'IC' => __('Icelandic', '12-step-meeting-list'),
-                'ITA' => __('Italian', '12-step-meeting-list'),
                 'LIT' => __('Literature', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ+', '12-step-meeting-list'),
                 'MED' => __('Meditation', '12-step-meeting-list'),
@@ -999,7 +968,6 @@ function tsml_load_config()
 				'RF' => __('Rotating Format', '12-step-meeting-list'),
                 'A' => __('Secular', '12-step-meeting-list'),
                 'SEN' => __('Seniors', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step', '12-step-meeting-list'),
 				'TO' => __('Topic/Discussion', '12-step-meeting-list'),
@@ -1031,11 +999,7 @@ function tsml_load_config()
                 'CRC' => __('Cross Comment', '12-step-meeting-list'),
                 'DR' => __('Daily Reflections', '12-step-meeting-list'),
                 'D' => __('Discussion', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
-                'FR' => __('French', '12-step-meeting-list'),
                 'GAM' => __('Gam Anon', '12-step-meeting-list'),
-                'ITA' => __('Italian', '12-step-meeting-list'),
-                'KOR' => __('Korean', '12-step-meeting-list'),
                 'LIT' => __('Literature', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ', '12-step-meeting-list'),
                 'TC' => __('Location Temporarily Closed', '12-step-meeting-list'),
@@ -1045,13 +1009,8 @@ function tsml_load_config()
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
                 'PAR' => __('Parking Meters Available', '12-step-meeting-list'),
-                'POL' => __('Polish', '12-step-meeting-list'),
-                'POR' => __('Portuguese', '12-step-meeting-list'),
-                'PUN' => __('Punjabi', '12-step-meeting-list'),
-                'RUS' => __('Russian', '12-step-meeting-list'),
-                'ASL' => __('Sign Language', '12-step-meeting-list'),
+				'ASL' => __('Sign Language', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Meeting', '12-step-meeting-list'),
                 'TOP' => __('Topic', '12-step-meeting-list'),
@@ -1208,14 +1167,8 @@ function tsml_load_config()
                 'BB' => __('Book Study', '12-step-meeting-list'),
                 'CC' => __('Child Care Available', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
-                'DA' => __('Danish', '12-step-meeting-list'),
                 'DF' => __('Dog Friendly', '12-step-meeting-list'),
-                'NL' => __('Dutch', '12-step-meeting-list'),
                 '8F' => __('Eightfold Path Study', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
-                'FI' => __('Finnish', '12-step-meeting-list'),
-                'FR' => __('French', '12-step-meeting-list'),
-                'DE' => __('German', '12-step-meeting-list'),
                 'IS' => __('Inquiry Study', '12-step-meeting-list'),
                 'IW' => __('Inquiry Writing', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ', '12-step-meeting-list'),
@@ -1225,9 +1178,6 @@ function tsml_load_config()
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
                 'PR' => __('Process Addictions', '12-step-meeting-list'),
-                'ES' => __('Spanish', '12-step-meeting-list'),
-                'SV' => __('Swedish', '12-step-meeting-list'),
-                'TH' => __('Thai', '12-step-meeting-list'),
                 'WA' => __('Wheelchair Access', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
             ],
@@ -1245,14 +1195,8 @@ function tsml_load_config()
                 'BB' => __('Book Study', '12-step-meeting-list'),
                 'CC' => __('Child Care Available', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
-                'DA' => __('Danish', '12-step-meeting-list'),
                 'DF' => __('Dog Friendly', '12-step-meeting-list'),
-                'NL' => __('Dutch', '12-step-meeting-list'),
                 '8F' => __('Eightfold Path Study', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
-                'FI' => __('Finnish', '12-step-meeting-list'),
-                'FR' => __('French', '12-step-meeting-list'),
-                'DE' => __('German', '12-step-meeting-list'),
                 'IS' => __('Inventory Study', '12-step-meeting-list'),
                 'IW' => __('Inventory Writing', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ', '12-step-meeting-list'),
@@ -1262,9 +1206,6 @@ function tsml_load_config()
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
                 'PR' => __('Process Addictions', '12-step-meeting-list'),
-                'ES' => __('Spanish', '12-step-meeting-list'),
-                'SV' => __('Swedish', '12-step-meeting-list'),
-                'TH' => __('Thai', '12-step-meeting-list'),
                 'WA' => __('Wheelchair Access', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
             ],
@@ -1344,7 +1285,6 @@ function tsml_load_config()
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
                 'PRI' => __('Prison', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Study', '12-step-meeting-list'),
                 'D' => __('Topic Discussion', '12-step-meeting-list'),
@@ -1363,22 +1303,12 @@ function tsml_load_config()
             'name' => __('Survivors of Incest Anonymous', '12-step-meeting-list'),
             'types' => [
                 '12x12' => __('12 Steps & 12 Traditions', '12-step-meeting-list'),
-                'AF' => __('Afrikaans', '12-step-meeting-list'),
-                'ASL' => __('American Sign Language', '12-step-meeting-list'),
-                'AR' => __('Arabic', '12-step-meeting-list'),
+				'ASL' => __('Sign Language', '12-step-meeting-list'),
                 'B' => __('Big Book', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
-                'NL' => __('Dutch', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
-                'FI' => __('Finnish', '12-step-meeting-list'),
                 'FF' => __('Fragrance Free', '12-step-meeting-list'),
-                'FR' => __('French', '12-step-meeting-list'),
                 'GQ' => __('Genderqueer', '12-step-meeting-list'),
-                'HE' => __('Hebrew', '12-step-meeting-list'),
                 'NDG' => __('Indigenous', '12-step-meeting-list'),
-                'ITA' => __('Italian', '12-step-meeting-list'),
-                'JA' => __('Japanese', '12-step-meeting-list'),
-                'KOR' => __('Korean', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ', '12-step-meeting-list'),
                 'LIT' => __('Literature', '12-step-meeting-list'),
                 'TC' => __('Location Temporarily Closed', '12-step-meeting-list'),
@@ -1389,21 +1319,11 @@ function tsml_load_config()
                 'O' => __('Open', '12-step-meeting-list'),
                 'OSH' => __('Open Share Format', '12-step-meeting-list'),
                 'POC' => __('People of Color', '12-step-meeting-list'),
-                'FA' => __('Persian', '12-step-meeting-list'),
-                'POL' => __('Polish', '12-step-meeting-list'),
-                'POR' => __('Portuguese', '12-step-meeting-list'),
-                'PUN' => __('Punjabi', '12-step-meeting-list'),
                 'RIT' => __('Ritual Abuse', '12-step-meeting-list'),
-                'RUS' => __('Russian', '12-step-meeting-list'),
-                'SL' => __('Slovenian', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Study', '12-step-meeting-list'),
                 'STW' => __('Steps Workshop', '12-step-meeting-list'),
-                'TH' => __('Thai', '12-step-meeting-list'),
                 'T' => __('Transgender', '12-step-meeting-list'),
-                'TR' => __('Turkish', '12-step-meeting-list'),
-                'UA' => __('Ukrainian', '12-step-meeting-list'),
                 'X' => __('Wheelchair Access', '12-step-meeting-list'),
                 'XB' => __('Wheelchair-Accessible Bathroom', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
@@ -1416,7 +1336,6 @@ function tsml_load_config()
             'types' => [
                 'BIPOC' => __('BIPOC', '12-step-meeting-list'),
                 'M' => __('Men', '12-step-meeting-list'),
-                'ES' => __('Spanish', '12-step-meeting-list'),
                 'ST' => __('Steps', '12-step-meeting-list'),
                 'T' => __('Tools', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
@@ -1437,12 +1356,91 @@ function tsml_load_config()
         ],
     ];
 
+	$tsml_languages =[
+		'AF' => __('Afrikaans', '12-step-meeting-list'),
+		'AM' => __('Amharic', '12-step-meeting-list'),
+		'AR' => __('Arabic', '12-step-meeting-list'),
+		'HR' => __('Croatian', '12-step-meeting-list'),
+		'DA' => __('Danish', '12-step-meeting-list'),
+		'NL' => __('Dutch', '12-step-meeting-list'),
+		'EN' => __('English', '12-step-meeting-list'),
+		'FI' => __('Finnish', '12-step-meeting-list'),
+		'FR' => __('French', '12-step-meeting-list'),
+		'GE' => __('Georgian', '12-step-meeting-list'),
+		'DE' => __('German', '12-step-meeting-list'),
+		'EL' => __('Greek', '12-step-meeting-list'),
+		'HE' => __('Hebrew', '12-step-meeting-list'),
+		'HI' => __('Hindi', '12-step-meeting-list'),
+		'IC' => __('Icelandic', '12-step-meeting-list'),
+		'ITA' => __('Italian', '12-step-meeting-list'),
+		'JA' => __('Japanese', '12-step-meeting-list'),
+		'KOR' => __('Korean', '12-step-meeting-list'),
+		'LT' => __('Lithuanian', '12-step-meeting-list'),
+		'ML' => __('Malayam', '12-step-meeting-list'),
+		'FA' => __('Persian', '12-step-meeting-list'),
+		'POL' => __('Polish', '12-step-meeting-list'),
+		'POR' => __('Portuguese', '12-step-meeting-list'),
+		'PUN' => __('Punjabi', '12-step-meeting-list'),
+		'RUS' => __('Russian', '12-step-meeting-list'),
+		'SK' => __('Slovak', '12-step-meeting-list'),
+		'SL' => __('Slovenian', '12-step-meeting-list'),
+		'S' => __('Spanish', '12-step-meeting-list'),
+		'SV' => __('Swedish', '12-step-meeting-list'),
+		'TL' => __('Tagalog', '12-step-meeting-list'),
+		'TH' => __('Thai', '12-step-meeting-list'),
+		'TR' => __('Turkish', '12-step-meeting-list'),
+		'UA' => __('Ukrainian', '12-step-meeting-list')
+	];
+
+	// Apply languages to all programs
+	foreach ($tsml_programs as &$program) {
+		if (!isset($program['languages'])) {
+			foreach ($tsml_languages as $language) {
+				$program['languages'][$language] = __($language, '12-step-meeting-list');
+			}
+		}
+	}
+	unset($program);
+
     //remove 'TC' and 'ONL' from default flags if meeting finder is TSML UI
     if ($tsml_user_interface === 'tsml_ui') {
         foreach ($tsml_programs as $key => $value) {
             $tsml_programs[$key]['flags'] = array_diff($value['flags'], ['TC', 'ONL']);
         }
     }
+	
+	// preserve legacy inconsistencies
+	// ACA
+	unset($tsml_programs['ACA']['types']['S']);
+	unset($tsml_programs['ACA']['types']['SP']);
+	$tsml_programs['ACA']['types']['S'] = __('Speaker', '12-step-meeting-list');
+	$tsml_programs['ACA']['types']['SP'] = __('Spanish', '12-step-meeting-list');
+
+	// EDA
+	unset($tsml_programs['EDA']['types']['EL']);
+	$tsml_programs['EDA']['types']['GR'] = __('Greek', '12-step-meeting-list');
+	
+	// Recovery Dharma
+	unset($tsml_programs['Recovery Dharma']['types']['S']);
+	$tsml_programs['Recovery Dharma']['types']['ES'] = __('Spanish', '12-step-meeting-list');
+
+	// Refuge Recovery
+	unset($tsml_programs['Refuge Recovery']['types']['S']);
+	$tsml_programs['Refuge Recovery']['types']['ES'] =  __('Spanish', '12-step-meeting-list');
+
+	// UA
+	unset($tsml_programs['UA']['types']['S']);
+	$tsml_programs['UA']['types']['ES'] = __('Spanish', '12-step-meeting-list');
+
+	// SIA
+	unset($tsml_programs['SIA']['types']['UK']);
+	$tsml_programs['SIA']['types']['UA'] = __('Ukrainian', '12-step-meeting-list');
+
+	// SLAA
+	unset($tsml_programs['SLAA']['types']['HR']);
+	$tsml_programs['SLAA']['types']['HR'] = __('Healthy Relationships', '12-step-meeting-list');
+	$tsml_programs['SLAA']['types']['CR'] = __('Croatian', '12-step-meeting-list');
+
 
     //the location where the list will show up, eg https://intergroup.org/meetings
     if ($tsml_slug === null) {

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -747,7 +747,7 @@ function tsml_load_config()
                 'P' => __('Professionals', '12-step-meeting-list'),
                 'A' => __('Secular', '12-step-meeting-list'),
                 'SEN' => __('Seniors', '12-step-meeting-list'),
-				'ASL' => __('American Sign Language', '12-step-meeting-list'),
+				'ASL' => __('Sign Language', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
                 'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
@@ -1406,14 +1406,13 @@ function tsml_load_config()
 	];
 
 	// Apply languages to all programs
-	foreach ($tsml_programs as &$program) {
+	foreach ($tsml_programs as $key => $program) {
 		if (!isset($program['languages'])) {
 			foreach ($tsml_languages as $language) {
-				$program['languages'][$language] = __($language, '12-step-meeting-list');
+				$tsml_programs[$key]['languages'][$language] = __($language, '12-step-meeting-list');
 			}
 		}
 	}
-	unset($program);
 
     //remove 'TC' and 'ONL' from default flags if meeting finder is TSML UI
     if ($tsml_user_interface === 'tsml_ui') {

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -599,7 +599,7 @@ if (!isset($tsml_slug)) {
 // set up globals, common variables once plugins are loaded, but before init
 function tsml_load_config()
 {
-    global $tsml_days, $tsml_days_order, $tsml_languages, $tsml_programs, $tsml_slug, $tsml_strings, $tsml_user_interface, $tsml_types_in_use, $tsml_languages;
+    global $tsml_days, $tsml_days_order, $tsml_languages, $tsml_programs, $tsml_slug, $tsml_strings, $tsml_user_interface, $tsml_types_in_use;
 
     //load internationalization
     load_plugin_textdomain('12-step-meeting-list', false, '12-step-meeting-list/languages');

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -1408,8 +1408,8 @@ function tsml_load_config()
 	// Apply languages to all programs
 	foreach ($tsml_programs as $key => $program) {
 		if (!isset($program['languages'])) {
-			foreach ($tsml_languages as $language) {
-				$tsml_programs[$key]['languages'][$language] = __($language, '12-step-meeting-list');
+			foreach ($tsml_languages as $lang_key => $language) {
+				$tsml_programs[$key]['languages'][$lang_key] = __($language, '12-step-meeting-list');
 			}
 		}
 	}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4c2d4d09-4d3d-4ccf-bcd7-b55dcb897304)
This separates Languages from Types but stores both in the same Types array in the db.