### PR TITLE
Issue 1511 Shortcode to Filter Meetings 

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2168,6 +2168,7 @@ function tsml_to_css_classes($types, $prefix = 'type-')
     }
 
     $types = array_map('strtolower', $types);
+    $types = array_map('trim', $types);
 
     return $prefix . implode(' ' . $prefix, $types);
 }

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -6,113 +6,26 @@ add_shortcode('tsml_location_count', 'tsml_count_locations');
 add_shortcode('tsml_meeting_count', 'tsml_count_meetings');
 add_shortcode('tsml_region_count', 'tsml_count_regions');
 
-//output the Legacy UI meeting finder
-//example:  [tsml_query_string key="type" value="women"]
-function tsml_legacy_ui($atts, $content = null)
-{
-    global $tsml_meeting_attendance_options;
-
-    //Load Shortcode values into array, overriding default values
-    $params = shortcode_atts(array('key' => '', 'value' => '', ), $atts);
-
-    $key = (isset($params['key'])) ? sanitize_text_field($params['key']) : '';
-    $value = (isset($params['value'])) ? sanitize_text_field($params['value']) : '';
-
-    $meetings = tsml_get_meetings([
-        $key => strtoupper($value),
-        'attendance_option' => 'active',
-    ]);
-
-    if (!count($meetings)) {
-        return '<div class="tsml-no-upcoming-meetings">No Meetings Available</div>';
-    }
-
-    $rows = '';
-    foreach ($meetings as $meeting) {
-        $meeting_types = $classes = '';
-        if (!empty($meeting['types'])) {
-            $classes = tsml_to_css_classes($meeting['types']);
-            $meeting_types = ' <small><span class="meeting_types">' . tsml_format_types($meeting['types']) . '</span></small>';
-        }
-
-        if (!empty($meeting['notes'])) {
-            $classes .= ' notes';
-        }
-
-        $meeting_location = '';
-        if (!empty($meeting['location'])) {
-            $meeting_location = $meeting['location'];
-        }
-
-        if ($meeting['attendance_option'] == 'online' || $meeting['attendance_option'] == 'inactive') {
-            $meeting_location = !empty($meeting['group']) ? $meeting['group'] : '';
-        }
-
-        $region = '';
-        if (!empty($meeting['sub_region'])) {
-            $region = $meeting['sub_region'];
-        } elseif (!empty($meeting['region'])) {
-            $region = $meeting['region'];
-        }
-
-        $rows .= '<tr class="meeting ' . $classes . ' attendance-' . $meeting['attendance_option'] . '">
-				<td class="time">' . tsml_format_day_and_time($meeting['day'], $meeting['time']) . '</td>
-				<td class="name"><a href="' . $meeting['url'] . '">' . @$meeting['name'] . '</a>' . $meeting_types . '</td>
-				<td class="location">
-					<div class="location-name">' . $meeting_location . '</div>
-					<div class="attendance-option attendance-' . $meeting['attendance_option'] . '"><small>' . ($meeting['attendance_option'] != 'in_person' ? $tsml_meeting_attendance_options[$meeting['attendance_option']] : '') . '</small></div>
-				</td>
-				<td class="region">' . $region . '</td>
-			</tr>';
-    }
-    return '
-	<style>
-		table.tsml_query_string div.attendance-hybrid small,
-		table.tsml_query_string div.attendance-online small {
-			color: green;
-		}
-
-		table.tsml_query_string div.attendance-inactive small {
-			color: #d40047;
-		}
-	</style>
-	<table class="table table-striped">
-		<thead>
-			<tr style="text-align: left;">
-				<th class="time">' . __('Day & Time', '12-step-meeting-list') . '</th>
-				<th class="name">' . __('Meeting', '12-step-meeting-list') . '</th>
-				<th class="location">' . __('Location', '12-step-meeting-list') . '</th>
-				<th class="region">' . __('Region', '12-step-meeting-list') . '</th>
-			</tr>
-		</thead>
-		<tbody>' . $rows . '</tbody>
-	</table>';
-
-    return;
-
-}
-add_shortcode('tsml_legacy_ui', 'tsml_legacy_ui');
-
 //function for shortcode: get a table of the next $count meetings
 //used here and in widgets.php
 //example: [tsml_next_meetings count="5"]
-function tsml_next_meetings($arguments)
+function tsml_next_meetings($atts)
 {
     global $tsml_meeting_attendance_options;
-    $arguments = shortcode_atts(['count' => 5, 'message' => ''], $arguments, 'tsml_next_meetings');
+    $atts = shortcode_atts(['count' => 5, 'message' => ''], $atts, 'tsml_next_meetings');
     $meetings = tsml_get_meetings([
         'day' => intval(current_time('w')),
         'time' => 'upcoming',
         'attendance_option' => 'active',
     ]);
-    if (!count($meetings) && empty($arguments['message'])) {
+    if (!count($meetings) && empty($atts['message'])) {
         return false;
     }
-    if (!count($meetings) && !empty($arguments['message'])) {
-        return '<div class="tsml-no-upcoming-meetings">' . $arguments['message'] . '</div>';
+    if (!count($meetings) && !empty($atts['message'])) {
+        return '<div class="tsml-no-upcoming-meetings">' . $atts['message'] . '</div>';
     }
 
-    $meetings = array_slice($meetings, 0, $arguments['count']);
+    $meetings = array_slice($meetings, 0, $atts['count']);
     $rows = '';
     foreach ($meetings as $meeting) {
         $meeting_types = $classes = '';
@@ -224,13 +137,13 @@ add_shortcode('tsml_types_list', function () {
     return '<h3>Types</h3><ul>' . implode($types) . '</ul>';
 });
 
-/*output a react meeting finder widget https://github.com/code4recovery/tsml-ui
- *examples: [tsml_ui], with parameters: [tsml_ui key="type" value="women"] */
-function tsml_ui($atts, $content = null)
+//output a react meeting finder widget https://github.com/code4recovery/tsml-ui
+//examples: [tsml_ui], with parameters: [tsml_ui key="type" value="women"] 
+function tsml_ui($atts)
 {
     global $tsml_mapbox_key, $tsml_nonce, $tsml_conference_providers, $tsml_language, $tsml_programs, $tsml_program, $tsml_ui_config,
     $tsml_feedback_addresses, $tsml_cache, $tsml_cache_writable, $tsml_distance_units, $tsml_columns, $tsml_timezone;
-    
+
     //enqueue app script
     $js = defined('TSML_UI_PATH') ? TSML_UI_PATH : 'https://tsml-ui.code4recovery.org/app.js';
     wp_enqueue_script('tsml_ui', $js, [], false, true);
@@ -246,48 +159,27 @@ function tsml_ui($atts, $content = null)
     //Load Shortcode values passed, overriding default values
     $parms = shortcode_atts(array('key' => '', 'value' => '', ), $atts);
     $key = (isset($parms['key'])) ? sanitize_text_field($parms['key']) : '';
-    $value = (isset($parms['value'])) ? sanitize_text_field($parms['value']) : '';
-    
-    if (!empty($atts)) {
-        //apply settings when parameters are passed
-        wp_localize_script(
-            'tsml_ui',
-            'tsml_react_config',
-            array_merge(
-                [
-                    'defaults' => [$key => explode(',', $value)],
-                    'columns' => array_keys($tsml_columns),
-                    'conference_providers' => $tsml_conference_providers,
-                    'distance_unit' => $tsml_distance_units,
-                    'feedback_emails' => array_values($tsml_feedback_addresses),
-                    'flags' => $tsml_programs[$tsml_program]['flags'],
-                    'strings' => [
-                        $tsml_language => array_merge($tsml_columns, compact('types', 'type_descriptions')),
-                    ],
+    $value = (isset($parms['value'])) ? sanitize_text_field($parms['value']) : 'Any Type';
+
+    //apply settings with parameters passed
+    wp_localize_script(
+        'tsml_ui',
+        'tsml_react_config',
+        array_merge(
+            [
+                'defaults' => [$key => explode(',', $value)],
+                'columns' => array_keys($tsml_columns),
+                'conference_providers' => $tsml_conference_providers,
+                'distance_unit' => $tsml_distance_units,
+                'feedback_emails' => array_values($tsml_feedback_addresses),
+                'flags' => $tsml_programs[$tsml_program]['flags'],
+                'strings' => [
+                    $tsml_language => array_merge($tsml_columns, compact('types', 'type_descriptions')),
                 ],
-                $tsml_ui_config
-            )
-        );
-    } else {
-        //apply settings
-        wp_localize_script(
-            'tsml_ui',
-            'tsml_react_config',
-            array_merge(
-                [
-                    'columns' => array_keys($tsml_columns),
-                    'conference_providers' => $tsml_conference_providers,
-                    'distance_unit' => $tsml_distance_units,
-                    'feedback_emails' => array_values($tsml_feedback_addresses),
-                    'flags' => $tsml_programs[$tsml_program]['flags'],
-                    'strings' => [
-                        $tsml_language => array_merge($tsml_columns, compact('types', 'type_descriptions')),
-                    ],
-                ],
-                $tsml_ui_config
-            )
-        );
-    }
+            ],
+            $tsml_ui_config
+        )
+    );
 
     // use meetings.json if it's writable, otherwise use the admin-ajax URL to the feed
     $data = $tsml_cache_writable && file_exists(WP_CONTENT_DIR . $tsml_cache)
@@ -297,7 +189,7 @@ function tsml_ui($atts, $content = null)
     // remove URL domain to fix CORS issues caused by GoDaddy Managed WP
     $url = parse_url($data);
     $data = $url['path'] . '?' . $url['query'];
-    
+
     return '<div id="tsml-ui"
 					data-src="' . $data . '"
 					data-timezone="' . $tsml_timezone . '"
@@ -305,4 +197,3 @@ function tsml_ui($atts, $content = null)
 }
 add_shortcode('tsml_react', 'tsml_ui');
 add_shortcode('tsml_ui', 'tsml_ui');
-

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -9,7 +9,7 @@ add_shortcode('tsml_region_count', 'tsml_count_regions');
 //function for shortcode: get a table of the next $count meetings
 //used here and in widgets.php
 //example: [tsml_next_meetings count="5"]
-function tsml_next_meetings($arguments)
+function tsml_next_meetings($arguments = array())
 {
     global $tsml_meeting_attendance_options;
     $arguments = shortcode_atts(['count' => 5, 'message' => ''], $arguments, 'tsml_next_meetings');
@@ -139,7 +139,7 @@ add_shortcode('tsml_types_list', function () {
 
 //output a react meeting finder widget https://github.com/code4recovery/tsml-ui
 //examples: [tsml_ui], with parameters: [tsml_ui key="type" first_value="women" second_value="closed" third_value=""] 
-function tsml_ui($arguments)
+function tsml_ui($arguments = array())
 {
     global $tsml_mapbox_key, $tsml_nonce, $tsml_conference_providers, $tsml_language, $tsml_programs, $tsml_program, $tsml_ui_config,
     $tsml_feedback_addresses, $tsml_cache, $tsml_cache_writable, $tsml_distance_units, $tsml_columns, $tsml_timezone;

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -6,8 +6,96 @@ add_shortcode('tsml_location_count', 'tsml_count_locations');
 add_shortcode('tsml_meeting_count', 'tsml_count_meetings');
 add_shortcode('tsml_region_count', 'tsml_count_regions');
 
+//output the Legacy UI meeting finder
+//example:  [tsml_query_string key="type" value="women"]
+function tsml_legacy_ui($atts, $content = null)
+{
+    global $tsml_meeting_attendance_options;
+
+    //Load Shortcode values into array, overriding default values
+    $params = shortcode_atts(array('key' => '', 'value' => '', ), $atts);
+
+    $key = (isset($params['key'])) ? sanitize_text_field($params['key']) : '';
+    $value = (isset($params['value'])) ? sanitize_text_field($params['value']) : '';
+
+    $meetings = tsml_get_meetings([
+        $key => strtoupper($value),
+        'attendance_option' => 'active',
+    ]);
+
+    if (!count($meetings)) {
+        return '<div class="tsml-no-upcoming-meetings">No Meetings Available</div>';
+    }
+
+    $rows = '';
+    foreach ($meetings as $meeting) {
+        $meeting_types = $classes = '';
+        if (!empty($meeting['types'])) {
+            $classes = tsml_to_css_classes($meeting['types']);
+            $meeting_types = ' <small><span class="meeting_types">' . tsml_format_types($meeting['types']) . '</span></small>';
+        }
+
+        if (!empty($meeting['notes'])) {
+            $classes .= ' notes';
+        }
+
+        $meeting_location = '';
+        if (!empty($meeting['location'])) {
+            $meeting_location = $meeting['location'];
+        }
+
+        if ($meeting['attendance_option'] == 'online' || $meeting['attendance_option'] == 'inactive') {
+            $meeting_location = !empty($meeting['group']) ? $meeting['group'] : '';
+        }
+
+        $region = '';
+        if (!empty($meeting['sub_region'])) {
+            $region = $meeting['sub_region'];
+        } elseif (!empty($meeting['region'])) {
+            $region = $meeting['region'];
+        }
+
+        $rows .= '<tr class="meeting ' . $classes . ' attendance-' . $meeting['attendance_option'] . '">
+				<td class="time">' . tsml_format_day_and_time($meeting['day'], $meeting['time']) . '</td>
+				<td class="name"><a href="' . $meeting['url'] . '">' . @$meeting['name'] . '</a>' . $meeting_types . '</td>
+				<td class="location">
+					<div class="location-name">' . $meeting_location . '</div>
+					<div class="attendance-option attendance-' . $meeting['attendance_option'] . '"><small>' . ($meeting['attendance_option'] != 'in_person' ? $tsml_meeting_attendance_options[$meeting['attendance_option']] : '') . '</small></div>
+				</td>
+				<td class="region">' . $region . '</td>
+			</tr>';
+    }
+    return '
+	<style>
+		table.tsml_query_string div.attendance-hybrid small,
+		table.tsml_query_string div.attendance-online small {
+			color: green;
+		}
+
+		table.tsml_query_string div.attendance-inactive small {
+			color: #d40047;
+		}
+	</style>
+	<table class="table table-striped">
+		<thead>
+			<tr style="text-align: left;">
+				<th class="time">' . __('Day & Time', '12-step-meeting-list') . '</th>
+				<th class="name">' . __('Meeting', '12-step-meeting-list') . '</th>
+				<th class="location">' . __('Location', '12-step-meeting-list') . '</th>
+				<th class="region">' . __('Region', '12-step-meeting-list') . '</th>
+			</tr>
+		</thead>
+		<tbody>' . $rows . '</tbody>
+	</table>';
+
+    return;
+
+}
+add_shortcode('tsml_legacy_ui', 'tsml_legacy_ui');
+
 //function for shortcode: get a table of the next $count meetings
 //used here and in widgets.php
+//example: [tsml_next_meetings count="5"]
 function tsml_next_meetings($arguments)
 {
     global $tsml_meeting_attendance_options;
@@ -88,79 +176,8 @@ function tsml_next_meetings($arguments)
 }
 add_shortcode('tsml_next_meetings', 'tsml_next_meetings');
 
-//output a list of types with links for AA-DC
-add_shortcode('tsml_types_list', function () {
-    global $tsml_types_in_use, $tsml_programs, $tsml_program, $tsml_user_interface;
-    $types = [];
-    foreach ($tsml_types_in_use as $type) {
-        if ($tsml_user_interface === 'tsml_ui') {
-            $filter_url = tsml_meetings_url([
-                'type' => str_replace(' ', '-', strtolower($tsml_programs[$tsml_program]['types'][$type]))
-            ]);
-        } else {
-            $filter_url = tsml_meetings_url(['tsml-day' => 'any', 'tsml-type' => $type]);
-        }
-        $types[$tsml_programs[$tsml_program]['types'][$type]] = '<li><a href="' . $filter_url . '">' . $tsml_programs[$tsml_program]['types'][$type] . '</a></li>';
-    }
-    ksort($types);
-    return '<h3>Types</h3><ul>' . implode($types) . '</ul>';
-});
-
-//output a react meeting finder widget https://github.com/code4recovery/tsml-ui
-function tsml_ui()
-{
-    global $tsml_mapbox_key, $tsml_nonce, $tsml_conference_providers, $tsml_language, $tsml_programs, $tsml_program, $tsml_ui_config,
-    $tsml_feedback_addresses, $tsml_cache, $tsml_cache_writable, $tsml_distance_units, $tsml_columns, $tsml_timezone;
-
-    //enqueue app script
-    $js = defined('TSML_UI_PATH') ? TSML_UI_PATH : 'https://tsml-ui.code4recovery.org/app.js';
-    wp_enqueue_script('tsml_ui', $js, [], false, true);
-
-    //get program types and type descriptions
-    $types = !empty($tsml_programs[$tsml_program]['types'])
-        ? $tsml_programs[$tsml_program]['types']
-        : [];
-    $type_descriptions = !empty($tsml_programs[$tsml_program]['type_descriptions'])
-        ? $tsml_programs[$tsml_program]['type_descriptions']
-        : [];
-
-    //apply settings
-    wp_localize_script(
-        'tsml_ui',
-        'tsml_react_config',
-        array_merge(
-            [
-                'columns' => array_keys($tsml_columns),
-                'conference_providers' => $tsml_conference_providers,
-                'distance_unit' => $tsml_distance_units,
-                'feedback_emails' => array_values($tsml_feedback_addresses),
-                'flags' => $tsml_programs[$tsml_program]['flags'],
-                'strings' => [
-                    $tsml_language => array_merge($tsml_columns, compact('types', 'type_descriptions')),
-                ],
-            ],
-            $tsml_ui_config
-        )
-    );
-
-    // use meetings.json if it's writable, otherwise use the admin-ajax URL to the feed
-    $data = $tsml_cache_writable && file_exists(WP_CONTENT_DIR . $tsml_cache)
-        ? content_url($tsml_cache) . '?' . filemtime(WP_CONTENT_DIR . $tsml_cache)
-        : admin_url('admin-ajax.php') . '?action=meetings&nonce=' . wp_create_nonce($tsml_nonce);
-
-    // remove URL domain to fix CORS issues caused by GoDaddy Managed WP
-    $url = parse_url($data);
-    $data = $url['path'] . '?' . $url['query'];
-
-    return '<div id="tsml-ui"
-					data-src="' . $data . '"
-					data-timezone="' . $tsml_timezone . '"
-					data-mapbox="' . $tsml_mapbox_key . '"></div>';
-}
-add_shortcode('tsml_react', 'tsml_ui');
-add_shortcode('tsml_ui', 'tsml_ui');
-
-//output a list of regions with links for AA-DC
+//output a list of regions with links. ex... [tsml_regions_list] 
+//example: [tsml_regions_list]  
 add_shortcode('tsml_regions_list', function () {
     //run function recursively
     function get_regions($parent = 0)
@@ -187,3 +204,105 @@ add_shortcode('tsml_regions_list', function () {
 
     return '<h3>Regions</h3>' . get_regions();
 });
+
+//output a list of types with links. ex... [tsml_types_list]
+//example: [tsml_types_list]  
+add_shortcode('tsml_types_list', function () {
+    global $tsml_types_in_use, $tsml_programs, $tsml_program, $tsml_user_interface;
+    $types = [];
+    foreach ($tsml_types_in_use as $type) {
+        if ($tsml_user_interface === 'tsml_ui') {
+            $filter_url = tsml_meetings_url([
+                'type' => str_replace(' ', '-', strtolower($tsml_programs[$tsml_program]['types'][$type]))
+            ]);
+        } else {
+            $filter_url = tsml_meetings_url(['tsml-day' => 'any', 'tsml-type' => $type]);
+        }
+        $types[$tsml_programs[$tsml_program]['types'][$type]] = '<li><a href="' . $filter_url . '">' . $tsml_programs[$tsml_program]['types'][$type] . '</a></li>';
+    }
+    ksort($types);
+    return '<h3>Types</h3><ul>' . implode($types) . '</ul>';
+});
+
+/*output a react meeting finder widget https://github.com/code4recovery/tsml-ui
+ *examples: [tsml_ui], with parameters: [tsml_ui key="type" value="women"] */
+function tsml_ui($atts, $content = null)
+{
+    global $tsml_mapbox_key, $tsml_nonce, $tsml_conference_providers, $tsml_language, $tsml_programs, $tsml_program, $tsml_ui_config,
+    $tsml_feedback_addresses, $tsml_cache, $tsml_cache_writable, $tsml_distance_units, $tsml_columns, $tsml_timezone;
+    
+    //enqueue app script
+    $js = defined('TSML_UI_PATH') ? TSML_UI_PATH : 'https://tsml-ui.code4recovery.org/app.js';
+    wp_enqueue_script('tsml_ui', $js, [], false, true);
+
+    //get program types and type descriptions
+    $types = !empty($tsml_programs[$tsml_program]['types'])
+        ? $tsml_programs[$tsml_program]['types']
+        : [];
+    $type_descriptions = !empty($tsml_programs[$tsml_program]['type_descriptions'])
+        ? $tsml_programs[$tsml_program]['type_descriptions']
+        : [];
+
+    //Load Shortcode values passed, overriding default values
+    $parms = shortcode_atts(array('key' => '', 'value' => '', ), $atts);
+    $key = (isset($parms['key'])) ? sanitize_text_field($parms['key']) : '';
+    $value = (isset($parms['value'])) ? sanitize_text_field($parms['value']) : '';
+    
+    if (!empty($atts)) {
+        //apply settings when parameters are passed
+        wp_localize_script(
+            'tsml_ui',
+            'tsml_react_config',
+            array_merge(
+                [
+                    'defaults' => [$key => explode(',', $value)],
+                    'columns' => array_keys($tsml_columns),
+                    'conference_providers' => $tsml_conference_providers,
+                    'distance_unit' => $tsml_distance_units,
+                    'feedback_emails' => array_values($tsml_feedback_addresses),
+                    'flags' => $tsml_programs[$tsml_program]['flags'],
+                    'strings' => [
+                        $tsml_language => array_merge($tsml_columns, compact('types', 'type_descriptions')),
+                    ],
+                ],
+                $tsml_ui_config
+            )
+        );
+    } else {
+        //apply settings
+        wp_localize_script(
+            'tsml_ui',
+            'tsml_react_config',
+            array_merge(
+                [
+                    'columns' => array_keys($tsml_columns),
+                    'conference_providers' => $tsml_conference_providers,
+                    'distance_unit' => $tsml_distance_units,
+                    'feedback_emails' => array_values($tsml_feedback_addresses),
+                    'flags' => $tsml_programs[$tsml_program]['flags'],
+                    'strings' => [
+                        $tsml_language => array_merge($tsml_columns, compact('types', 'type_descriptions')),
+                    ],
+                ],
+                $tsml_ui_config
+            )
+        );
+    }
+
+    // use meetings.json if it's writable, otherwise use the admin-ajax URL to the feed
+    $data = $tsml_cache_writable && file_exists(WP_CONTENT_DIR . $tsml_cache)
+        ? content_url($tsml_cache) . '?' . filemtime(WP_CONTENT_DIR . $tsml_cache)
+        : admin_url('admin-ajax.php') . '?action=meetings&nonce=' . wp_create_nonce($tsml_nonce);
+
+    // remove URL domain to fix CORS issues caused by GoDaddy Managed WP
+    $url = parse_url($data);
+    $data = $url['path'] . '?' . $url['query'];
+    
+    return '<div id="tsml-ui"
+					data-src="' . $data . '"
+					data-timezone="' . $tsml_timezone . '"
+					data-mapbox="' . $tsml_mapbox_key . '"></div>';
+}
+add_shortcode('tsml_react', 'tsml_ui');
+add_shortcode('tsml_ui', 'tsml_ui');
+

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -160,11 +160,11 @@ function tsml_ui($arguments)
     $arguments = array_change_key_case((array) $arguments, CASE_LOWER);
 
     //Load Shortcode values passed, overriding default 
-    $types = shortcode_atts(array('key' => '', 'first_value' => '', 'second_value' => '', 'third_value' => '',), $arguments);
-    $key = (isset($types['key'])) ? sanitize_text_field($types['key']) : '';
-    $first_value = (isset($types['first_value'])) ? sanitize_text_field($types['first_value']) : '';
-    $second_value = (isset($types['second_value'])) ? sanitize_text_field($types['second_value']) : '';
-    $third_value = (isset($types['third_value'])) ? sanitize_text_field($types['third_value']) : '';
+    $arguments = shortcode_atts(array('key' => '', 'first_value' => '', 'second_value' => '', 'third_value' => '',), $arguments);
+    $key = (isset($arguments['key'])) ? sanitize_text_field($arguments['key']) : '';
+    $first_value = (isset($arguments['first_value'])) ? sanitize_text_field($arguments['first_value']) : '';
+    $second_value = (isset($arguments['second_value'])) ? sanitize_text_field($arguments['second_value']) : '';
+    $third_value = (isset($arguments['third_value'])) ? sanitize_text_field($arguments['third_value']) : '';
 
     //create values array that contains no empty items
     $values = [];

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 5.6
 Tested up to: 6.6
-Stable tag: 3.15.1
+Stable tag: 3.15.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -238,7 +238,9 @@ Yes, you can use `[tsml_meeting_count]`, `[tsml_location_count]`, `[tsml_group_c
 
 Use `[tsml_types_list]` and `[tsml_regions_list]` to output linked lists to your meeting finder.
 
-Use `[tsml_ui]` to display the TSML UI meeting finder.
+Use `[tsml_ui]` to display the TSML UI meeting finder. Parameters can be passed to display just a certain type: `[tsml_ui key="type" value="women"]`.
+
+Parameters can also be passed for the Legacy UI to display just a certain type: `[tsml_legacy_ui key="type" value="women"]`.
 
 = Are there translations to other languages? =
 It is translated into Polish. If you would like to volunteer to help translate another language, we would be pleased to work with you.
@@ -300,6 +302,9 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.15.1 =
+* Create/modified shortcodes to filter meetings by passed types. [more info]
 
 = 3.15.1 =
 * Reformat 'Change Detection Email' for better legibility. [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1497)

--- a/readme.txt
+++ b/readme.txt
@@ -240,8 +240,6 @@ Use `[tsml_types_list]` and `[tsml_regions_list]` to output linked lists to your
 
 Use `[tsml_ui]` to display the TSML UI meeting finder. Parameters can be passed to display just a certain type: `[tsml_ui key="type" value="women"]`.
 
-Parameters can also be passed for the Legacy UI to display just a certain type: `[tsml_legacy_ui key="type" value="women"]`.
-
 = Are there translations to other languages? =
 It is translated into Polish. If you would like to volunteer to help translate another language, we would be pleased to work with you.
 
@@ -303,8 +301,8 @@ Yes, you will need to know the key name of the field. Then include an array in y
 
 == Changelog ==
 
-= 3.15.1 =
-* Create/modified shortcodes to filter meetings by passed types. [more info]
+= 3.15.2 =
+* Modified shortcodes tsml_ui to filter meetings by passed types. [more info] (https://github.com/code4recovery/12-step-meeting-list/pull/1513)
 
 = 3.15.1 =
 * Reformat 'Change Detection Email' for better legibility. [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1497)


### PR DESCRIPTION
Modified tsml_ui shortcode to accept passed parameters filter meeting available.
Reordered shortcode functions alphabetically for easier access. Added example text. 
Updated version, readme log and FAQ descriptions for shortcodes.

Example shortcode to limit the listing to closed meetings for women only:
 `[tsml_ui key="type" first_value="women" second_value="closed" third_value=""]`
 ![image](https://github.com/user-attachments/assets/1b7dffb6-904d-43c0-99cc-6053ebc533b6)

 Here an example to restrict meeting regions to a few sub regions of San Jose
`[tsml_ui key="region" first_value="campbell" second_value="cupertino" third_value="los-gatos"]`
![image](https://github.com/user-attachments/assets/ea968bea-edc3-42b3-8fab-f5bdbdcd0808)