### PR TITLE
make tsml ui load async

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -152,7 +152,7 @@ function tsml_ui($arguments = [])
 
     //enqueue app script
     $js = defined('TSML_UI_PATH') ? TSML_UI_PATH : 'https://tsml-ui.code4recovery.org/app.js';
-    wp_enqueue_script('tsml_ui', $js, [], false, true);
+    wp_enqueue_script('tsml_ui', $js, [], false, ['in_footer' => true, 'strategy' => 'async']);
 
     //get program types and type descriptions
     $types = !empty($tsml_programs[$tsml_program]['types'])


### PR DESCRIPTION
not sure why we never made it load async before 

<img width="847" alt="Screenshot 2024-10-13 at 8 24 11 AM" src="https://github.com/user-attachments/assets/b58a23c3-b095-4f3c-bb93-dccfa374627a">

i considered stopping it from appending the wordpress version here, but perhaps that is useful info for us to have?