### PR TITLE
sanitization method fix

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -4,7 +4,7 @@
  * Plugin Name: 12 Step Meeting List
  * Plugin URI: https://wordpress.org/plugins/12-step-meeting-list/
  * Description: Manage a list of recovery meetings
- * Version: 3.16
+ * Version: 3.16.1
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -18,7 +18,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 
 define('TSML_PATH', plugin_dir_path(__FILE__));
 
-define('TSML_VERSION', '3.16');
+define('TSML_VERSION', '3.16.1');
 
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1561,7 +1561,7 @@ function tsml_sanitize_import_meetings($meetings, $data_source_url = null, $data
     }
 
     //trim and sanitize everything
-    array_walk_recursive($meetings, function ($value, $key) {
+    array_walk_recursive($meetings, function (&$value, $key) {
         //preserve <br>s as line breaks if present, otherwise clean up
         $value = preg_replace('/\<br(\s*)?\/?\>/i', PHP_EOL, $value);
         $value = stripslashes($value);

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 5.6
 Tested up to: 6.6
-Stable tag: 3.16
+Stable tag: 3.16.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -300,6 +300,9 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.16.1 =
+* Improve sanitization of imported data [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1542)
 
 = 3.16 =
 * Add entity description fields to meeting listings [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1498)


### PR DESCRIPTION
one missing character was causing it to not actually sanitize the incoming data, making meetings with `" Friday"` show up as `Appointment` in https://github.com/code4recovery/12-step-meeting-list/discussions/1542

from https://www.php.net/manual/en/function.array-walk-recursive.php

> If callback needs to be working with the actual values of the array, specify the first parameter of callback as a [reference](https://www.php.net/manual/en/language.references.php). Then, any changes made to those elements will be made in the original array itself.