### PR TITLE
add Google Sheets directly

### DIFF
--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -160,23 +160,29 @@ if (!function_exists('tsml_import_page')) {
         if (!empty($_POST['tsml_add_data_source']) && isset($_POST['tsml_nonce']) && wp_verify_nonce($_POST['tsml_nonce'], $tsml_nonce)) {
 
             //sanitize URL, name, parent region id, and Change Detection values
-            $data_source_url = trim(esc_url_raw($_POST['tsml_add_data_source'], array('http', 'https')));
+            $data_source_url = $imported_data_source_url = trim(esc_url_raw($_POST['tsml_add_data_source'], array('http', 'https')));
             $data_source_name = sanitize_text_field($_POST['tsml_add_data_source_name']);
             $data_source_parent_region_id = (int) $_POST['tsml_add_data_source_parent_region_id'];
             $data_source_change_detect = sanitize_text_field($_POST['tsml_add_data_source_change_detect']);
 
+            //use c4r sheets service for Google Sheets URLs
+            if (strpos($data_source_url, 'docs.google.com/spreadsheets') !== false) {
+                $url_parts = explode('/', $data_source_url);
+                $sheet_id = $url_parts[5];
+                $imported_data_source_url = 'https://sheets.code4recovery.org/tsml/' . $sheet_id;
+            }
+
             //initialize variables 
             $import_meetings = $delete_meeting_ids = [];
-            
             //try fetching	
-            $response = wp_safe_remote_get($data_source_url, [
+            $response = wp_safe_remote_get($imported_data_source_url, [
                 'timeout' => 30,
                 'sslverify' => false,
             ]);
             if (is_array($response) && !empty($response['body']) && ($meetings = json_decode($response['body'], true))) {
 
                 //allow reformatting as necessary
-                $meetings = tsml_sanitize_import_meetings($meetings, $data_source_url, $data_source_parent_region_id);
+                $meetings = tsml_sanitize_import_meetings($meetings, $imported_data_source_url, $data_source_parent_region_id);
 
                 //actual meetings to import
                 $import_meetings = array();
@@ -199,9 +205,8 @@ if (!function_exists('tsml_import_page')) {
                     // Create a cron job to run daily when Change Detection is enabled for the new data source
                     if ($data_source_change_detect === 'enabled') {
                         tsml_schedule_import_scan($data_source_url, $data_source_name);
-                    }                    
+                    }
                 } else {
-                    
                     //get updated feed import record set 
                     list($import_meetings, $delete_meeting_ids, $change_log) = tsml_get_changed_import_meetings($meetings, $data_source_url, $data_source_parent_region_id);
 
@@ -209,17 +214,15 @@ if (!function_exists('tsml_import_page')) {
                     if (count($delete_meeting_ids)) {
                         tsml_delete($delete_meeting_ids);
                     }
-                    
                     tsml_delete_orphans();
 
                     if (count($change_log) && $tsml_debug) {
                         $message = tsml_build_import_change_report($data_source_name, $change_log);
                         tsml_alert($message, 'info');
                     }
-                    
                     //empty change log means we're up to date
                     if (!count($change_log)) {
-                        tsml_alert(__('Your meeting list is already in sync with the feed.', '12-step-meeting-list'), 'success');                    
+                        tsml_alert(__('Your meeting list is already in sync with the feed.', '12-step-meeting-list'), 'success');
                     }
 
                     //update data source timestamp
@@ -320,7 +323,7 @@ if (!function_exists('tsml_import_page')) {
                         <?php _e('Import Data Sources', '12-step-meeting-list') ?>
                     </h2>
                     <p>
-                        <?php printf(__('Data sources are JSON feeds that contain a website\'s public meeting data. They can be used to aggregate meetings from different sites into a single master list. 
+                        <?php printf(__('Data sources are JSON feeds or Google Sheets that contain a website\'s public meeting data. They can be used to aggregate meetings from different sites into a single master list. 
 				Data sources listed below will pull meeting information into this website. A configurable schedule allows for each enabled data source to be scanned at least once per day looking 
 				for updates to the listing. Change Notification email addresses are sent an email when action is required to re-sync a data source with its meeting list information. 
 				Please note: records that you intend to maintain on your website should always be imported using the Import CSV feature below. <b>Data Source records will be overwritten when the 
@@ -332,7 +335,7 @@ if (!function_exists('tsml_import_page')) {
                                 <tr>
                                     <th class="small align-center"></th>
                                     <th>
-                                        <?php _e('Feed', '12-step-meeting-list') ?>
+                                        <?php _e('Source', '12-step-meeting-list') ?>
                                     </th>
                                     <th class="align-left">
                                         <?php _e('Parent Region', '12-step-meeting-list') ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1529,8 +1529,25 @@ function tsml_sanitize_import_meetings($meetings, $data_source_url = null, $data
     //track sanitized meeting slug counts
     $meeting_slugs = array();
 
+    //handle requests to Google Sheets API (obsolete - remove on or after May 2025)
     if (strpos($data_source_url, "sheets.googleapis.com") !== false) {
+        tsml_alert(__('You can now add a Google Sheet directly to TSML. Please replace this feed with the Sheet URL. We will be dropping support for the Google Sheets API in a future release.', '12-step-meeting-list'), 'warning');
         $meetings = tsml_import_reformat_googlesheet($meetings);
+    }
+
+    //handle requests to C4R sheets service
+    if (strpos($data_source_url, "sheets.code4recovery.org/tsml") !== false) {
+        if (count($meetings['warnings'])) {
+            $warnings = __('The following issues were detected with this Google Sheet:', '12-step-meeting-list') . '</p><ol>' . 
+                implode(array_map(function($warning) {
+                    return '<li><a href="' . $warning['link'] . '">' . $warning['error'] . '</a>: ' .
+                        implode(array_map(function($value) { return '<code>' . $value . '</code>'; }, $warning['value'])) . 
+                    '</li>';
+                }, $meetings['warnings'])) . 
+            '</ol><p hidden>';
+            tsml_alert($warnings, 'warning');
+        }
+        $meetings = $meetings['meetings'];
     }
 
     //allow theme-defined function to reformat data source import - issue #439

--- a/languages/12-step-meeting-list.pot
+++ b/languages/12-step-meeting-list.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the 12 Step Meeting List plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: 12 Step Meeting List 3.15.1\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/12-step-meeting-list\n"
+"Project-Id-Version: 12 Step Meeting List 3.16.2\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/trunk\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-09-24T21:59:04+00:00\n"
+"POT-Creation-Date: 2024-10-26T17:13:30+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.10.0\n"
 "X-Domain: 12-step-meeting-list\n"
@@ -91,344 +91,344 @@ msgstr ""
 msgid "Either Address or City is required."
 msgstr ""
 
-#: includes/admin_import.php:222
+#: includes/admin_import.php:225
 msgid "Your meeting list is already in sync with the feed."
 msgstr ""
 
-#: includes/admin_import.php:239
-#: includes/functions.php:2343
+#: includes/admin_import.php:242
+#: includes/functions.php:2382
 msgid "Invalid response, <pre>"
 msgstr ""
 
-#: includes/admin_import.php:242
-#: includes/functions.php:2346
+#: includes/admin_import.php:245
+#: includes/functions.php:2385
 msgid "Data source gave an empty response, you might need to try again."
 msgstr ""
 
-#: includes/admin_import.php:247
-#: includes/functions.php:2351
+#: includes/admin_import.php:250
+#: includes/functions.php:2390
 msgid "JSON: no errors."
 msgstr ""
 
-#: includes/admin_import.php:250
-#: includes/functions.php:2354
+#: includes/admin_import.php:253
+#: includes/functions.php:2393
 msgid "JSON: Maximum stack depth exceeded."
 msgstr ""
 
-#: includes/admin_import.php:253
-#: includes/functions.php:2357
+#: includes/admin_import.php:256
+#: includes/functions.php:2396
 msgid "JSON: Underflow or the modes mismatch."
 msgstr ""
 
-#: includes/admin_import.php:256
-#: includes/functions.php:2360
+#: includes/admin_import.php:259
+#: includes/functions.php:2399
 msgid "JSON: Unexpected control character found."
 msgstr ""
 
-#: includes/admin_import.php:259
-#: includes/functions.php:2363
+#: includes/admin_import.php:262
+#: includes/functions.php:2402
 msgid "JSON: Syntax error, malformed JSON."
 msgstr ""
 
-#: includes/admin_import.php:262
-#: includes/functions.php:2366
+#: includes/admin_import.php:265
+#: includes/functions.php:2405
 msgid "JSON: Malformed UTF-8 characters, possibly incorrectly encoded."
 msgstr ""
 
-#: includes/admin_import.php:265
-#: includes/functions.php:2369
+#: includes/admin_import.php:268
+#: includes/functions.php:2408
 msgid "JSON: Unknown error."
 msgstr ""
 
-#: includes/admin_import.php:292
+#: includes/admin_import.php:295
 msgid "Data source removed."
 msgstr ""
 
-#: includes/admin_import.php:320
+#: includes/admin_import.php:323
 msgid "Import Data Sources"
 msgstr ""
 
-#: includes/admin_import.php:323
+#: includes/admin_import.php:326
 msgid ""
-"Data sources are JSON feeds that contain a website's public meeting data. They can be used to aggregate meetings from different sites into a single master list. \n"
+"Data sources are JSON feeds or Google Sheets that contain a website's public meeting data. They can be used to aggregate meetings from different sites into a single master list. \n"
 "\t\t\t\tData sources listed below will pull meeting information into this website. A configurable schedule allows for each enabled data source to be scanned at least once per day looking \n"
 "\t\t\t\tfor updates to the listing. Change Notification email addresses are sent an email when action is required to re-sync a data source with its meeting list information. \n"
 "\t\t\t\tPlease note: records that you intend to maintain on your website should always be imported using the Import CSV feature below. <b>Data Source records will be overwritten when the \n"
 "\t\t\t\tparent data source is refreshed.</b> More information is available at the <a href=\"%s\" target=\"_blank\">Meeting Guide API Specification</a>."
 msgstr ""
 
-#: includes/admin_import.php:335
-msgid "Feed"
+#: includes/admin_import.php:338
+msgid "Source"
 msgstr ""
 
-#: includes/admin_import.php:338
+#: includes/admin_import.php:341
 #: includes/functions.php:315
 msgid "Parent Region"
 msgstr ""
 
-#: includes/admin_import.php:341
+#: includes/admin_import.php:344
 msgid "Change Detection"
 msgstr ""
 
-#: includes/admin_import.php:344
+#: includes/admin_import.php:347
 #: includes/admin_meeting.php:304
 #: includes/functions.php:352
-#: includes/variables.php:1488
+#: includes/variables.php:1496
 #: templates/archive-meetings.php:199
 #: templates/archive-meetings.php:215
 msgid "Meetings"
 msgstr ""
 
-#: includes/admin_import.php:347
+#: includes/admin_import.php:350
 msgid "Last Refresh"
 msgstr ""
 
-#: includes/admin_import.php:370
+#: includes/admin_import.php:373
 msgid "Unnamed Feed"
 msgstr ""
 
-#: includes/admin_import.php:377
-#: includes/admin_import.php:383
+#: includes/admin_import.php:380
+#: includes/admin_import.php:386
 msgid "Top-level region"
 msgstr ""
 
-#: includes/admin_import.php:396
+#: includes/admin_import.php:399
 msgid "Disabled"
 msgstr ""
 
-#: includes/admin_import.php:428
+#: includes/admin_import.php:431
 msgid "District or Intergroup Name"
 msgstr ""
 
-#: includes/admin_import.php:439
+#: includes/admin_import.php:442
 msgid "Append regions created by this data source to… (top-level, if none selected)"
 msgstr ""
 
-#: includes/admin_import.php:440
+#: includes/admin_import.php:443
 msgid "Parent Region…"
 msgstr ""
 
-#: includes/admin_import.php:446
+#: includes/admin_import.php:449
 msgid "Change Detection Disabled"
 msgstr ""
 
-#: includes/admin_import.php:446
+#: includes/admin_import.php:449
 msgid "Change Detection Enabled"
 msgstr ""
 
-#: includes/admin_import.php:453
+#: includes/admin_import.php:456
 msgid "Add Data Source"
 msgstr ""
 
-#: includes/admin_import.php:461
+#: includes/admin_import.php:464
 msgid "Import CSV"
 msgstr ""
 
-#: includes/admin_import.php:468
+#: includes/admin_import.php:471
 msgid "When importing..."
 msgstr ""
 
-#: includes/admin_import.php:471
+#: includes/admin_import.php:474
 msgid "don't delete anything"
 msgstr ""
 
-#: includes/admin_import.php:472
+#: includes/admin_import.php:475
 msgid "delete only the meetings, locations, and groups for the regions present in this CSV"
 msgstr ""
 
-#: includes/admin_import.php:473
+#: includes/admin_import.php:476
 msgid "delete all meetings, locations, groups, districts, and regions"
 msgstr ""
 
-#: includes/admin_import.php:476
+#: includes/admin_import.php:479
 msgid "delete all meetings, locations, and groups not from a data source"
 msgstr ""
 
-#: includes/admin_import.php:486
+#: includes/admin_import.php:489
 msgid "Begin"
 msgstr ""
 
-#: includes/admin_import.php:492
+#: includes/admin_import.php:495
 msgid "Example CSV"
 msgstr ""
 
-#: includes/admin_import.php:497
+#: includes/admin_import.php:500
 msgid "Example spreadsheet"
 msgstr ""
 
-#: includes/admin_import.php:505
+#: includes/admin_import.php:508
 msgid "<strong>Time</strong>, if present, should be in a standard date format such as 6:00 AM or 06:00. Non-standard or empty dates will be imported as \"by appointment.\""
 msgstr ""
 
-#: includes/admin_import.php:508
+#: includes/admin_import.php:511
 msgid "<strong>End Time</strong>, if present, should be in a standard date format such as <code>6:00 AM</code> or <code>06:00</code>."
 msgstr ""
 
-#: includes/admin_import.php:511
+#: includes/admin_import.php:514
 msgid "<strong>Day</strong> if present, should either <code>Sunday</code>, <code>Monday</code>, <code>Tuesday</code>, <code>Wednesday</code>, <code>Thursday</code>, <code>Friday</code>, or <code>Saturday</code>. Meetings that occur on multiple days should be listed separately. 'Daily' or 'Mondays' will not work. Non-standard days will be imported as \"by appointment.\""
 msgstr ""
 
-#: includes/admin_import.php:514
+#: includes/admin_import.php:517
 msgid "<strong>Name</strong> is the name of the meeting, and is optional, although it's valuable information for the user. If it's missing, a name will be created by combining the location, day, and time."
 msgstr ""
 
-#: includes/admin_import.php:517
+#: includes/admin_import.php:520
 msgid "<strong>Slug</strong> optional, and sets the meeting post's \"slug\" or unique string, which is used in the URL. This should be unique to the meeting. Setting this helps preserve user bookmarks."
 msgstr ""
 
-#: includes/admin_import.php:520
+#: includes/admin_import.php:523
 msgid "<strong>Location</strong> is the name of the location, and is optional. Generally it's the group or building name. If it's missing, the address will be used. In the event that there are multiple location names for the same address, the first location name will be used."
 msgstr ""
 
-#: includes/admin_import.php:523
+#: includes/admin_import.php:526
 msgid "<strong>Address</strong> is strongly encouraged and will be corrected by Google, so it may look different afterward. Ideally, every address for the same location should be exactly identical, and not contain extra information about the address, such as the building name or descriptors like \"around back.\""
 msgstr ""
 
-#: includes/admin_import.php:526
+#: includes/admin_import.php:529
 msgid "If <strong>Address</strong> is specified, then <strong>City</strong>, <strong>State</strong>, and <strong>Country</strong> are optional, but they might be useful if your addresses sound ambiguous to Google. If address is not specified, then these fields are required."
 msgstr ""
 
-#: includes/admin_import.php:529
+#: includes/admin_import.php:532
 msgid "<strong>Notes</strong> are freeform notes that are specific to the meeting. For example, <code>last Saturday is birthday night</code>."
 msgstr ""
 
-#: includes/admin_import.php:532
+#: includes/admin_import.php:535
 msgid "<strong>Conference URL</strong> is an optional URL to a specific public videoconference meeting. This should be a common videoconferencing service such as Zoom or Google Hangouts. It should launch directly into the meeting and not link to an intermediary page."
 msgstr ""
 
-#: includes/admin_import.php:535
+#: includes/admin_import.php:538
 msgid "<strong>Conference URL Notes</strong> is an optional string which contains metadata about the Conference URL (e.g. meeting password in plain text for those groups unwilling to publish a one-tap URL)."
 msgstr ""
 
-#: includes/admin_import.php:538
+#: includes/admin_import.php:541
 msgid "<strong>Conference Phone</strong> is the telephone number to dial into a specific meeting. Should be numeric, except a plus('+') symbol may be used for international dialers, and the comma(','), asterisk('*'), and pound('#') symbols can be used to form one-tap phone links."
 msgstr ""
 
-#: includes/admin_import.php:541
+#: includes/admin_import.php:544
 msgid "<strong>Conference Phone Notes</strong> is an optional string with metadata about the 'Conference Phone' (e.g. a numeric meeting password or other user instructions)."
 msgstr ""
 
-#: includes/admin_import.php:544
+#: includes/admin_import.php:547
 msgid "<strong>Region</strong> is user-defined and can be anything. Often this is a small municipality or neighborhood. Since these go in a dropdown, ideally you would have 10 to 20 regions, although it's ok to be over or under."
 msgstr ""
 
-#: includes/admin_import.php:547
+#: includes/admin_import.php:550
 msgid "<strong>Sub Region</strong> makes the Region hierarchical; in San Jose we have sub regions for East San Jose, West San Jose, etc. New York City might have Manhattan be a Region, and Greenwich Village be a Sub Region."
 msgstr ""
 
-#: includes/admin_import.php:550
+#: includes/admin_import.php:553
 msgid "<strong>Location Notes</strong> are freeform notes that will show up on every meeting that this location. For example, \"Enter from the side.\""
 msgstr ""
 
-#: includes/admin_import.php:553
+#: includes/admin_import.php:556
 msgid "<strong>Group</strong> is a way of grouping contacts. Meetings with the same group name will be linked and share contact information."
 msgstr ""
 
-#: includes/admin_import.php:556
+#: includes/admin_import.php:559
 msgid "<strong>District</strong> is user-defined and can be anything, but should be a string rather than an integer (e.g. <b>District 01</b> rather than <b>1</b>). A group name must also be specified."
 msgstr ""
 
-#: includes/admin_import.php:559
+#: includes/admin_import.php:562
 msgid "<strong>Sub District</strong> makes the District hierachical."
 msgstr ""
 
-#: includes/admin_import.php:562
+#: includes/admin_import.php:565
 msgid "<strong>Group Notes</strong> is for stuff like a short group history, or when the business meeting meets."
 msgstr ""
 
-#: includes/admin_import.php:565
+#: includes/admin_import.php:568
 msgid "<strong>Website</strong> and <strong>Website 2</strong> are optional."
 msgstr ""
 
-#: includes/admin_import.php:568
+#: includes/admin_import.php:571
 msgid "<strong>Email</strong> is optional. This is a public email address."
 msgstr ""
 
-#: includes/admin_import.php:571
+#: includes/admin_import.php:574
 msgid "<strong>Phone</strong> is optional. This is a public phone number."
 msgstr ""
 
-#: includes/admin_import.php:574
+#: includes/admin_import.php:577
 msgid "<strong>Venmo</strong> is an optional string and should be a valid Venmo handle, (e.g. <code>@AAGroupName</code>). This is understood to be the address for 7th Tradition contributions to the meeting, and not any other entity."
 msgstr ""
 
-#: includes/admin_import.php:577
+#: includes/admin_import.php:580
 msgid "<strong>Square</strong> is an optional string and should be a valid Square Cash App cashtag, (e.g. <code>$AAGroupName</code>). This is understood to be the address for 7th Tradition contributions to the meeting, and not any other entity."
 msgstr ""
 
-#: includes/admin_import.php:580
+#: includes/admin_import.php:583
 msgid "<strong>PayPal</strong> is an optional string and should be a valid PayPal username, (e.g. <code>AAGroupName</code>). This is understood to be the address for 7th Tradition contributions to the meeting, and not any other entity."
 msgstr ""
 
-#: includes/admin_import.php:583
+#: includes/admin_import.php:586
 msgid "<strong>URL</strong> is optional and should point to the meeting's listing on the area website."
 msgstr ""
 
-#: includes/admin_import.php:586
+#: includes/admin_import.php:589
 msgid "<strong>Feedback URL</strong> is an optional string URL that can be used to provide feedback about the meeting. These could be local links (e.g. <code>https://mywebsite.org/feedback?meeting=meeting-slug-1</code>), remote links (e.g. <code>https://typeform.com/to/23904203?meeting=meeting-slug-1</code>), or email links (e.g. <code>mailto:webservant@domain.org?subject=meeting-slug-1</code>)."
 msgstr ""
 
-#: includes/admin_import.php:589
+#: includes/admin_import.php:592
 msgid "<strong>Edit URL</strong> is an optional string URL that trusted servants can use to edit the specific meeting's listing."
 msgstr ""
 
-#: includes/admin_import.php:592
+#: includes/admin_import.php:595
 msgid "<strong>Contact 1/2/3 Name/Email/Phone</strong> (nine fields in total) are all optional. By default, contact information is only visible inside the WordPress dashboard."
 msgstr ""
 
-#: includes/admin_import.php:595
+#: includes/admin_import.php:598
 msgid "<strong>Last Contact</strong> is an optional date."
 msgstr ""
 
-#: includes/admin_import.php:599
+#: includes/admin_import.php:602
 msgid "<strong>Types</strong> should be a comma-separated list of the following options. This list is determined by which program is selected on the Settings tab."
 msgstr ""
 
-#: includes/admin_import.php:630
+#: includes/admin_import.php:633
 msgid "Where's My Info?"
 msgstr ""
 
-#: includes/admin_import.php:634
+#: includes/admin_import.php:637
 msgid "Your public meetings page is <a href=\"%s\">right here</a>. Link that page from your site's nav menu to make it visible to the public."
 msgstr ""
 
-#: includes/admin_import.php:642
+#: includes/admin_import.php:645
 msgid "You have:"
 msgstr ""
 
-#: includes/admin_import.php:647
-#: includes/ajax.php:662
+#: includes/admin_import.php:650
+#: includes/ajax.php:668
 msgid "%s meeting"
 msgid_plural "%s meetings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/admin_import.php:650
-#: includes/ajax.php:663
+#: includes/admin_import.php:653
+#: includes/ajax.php:669
 msgid "%s location"
 msgid_plural "%s locations"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/admin_import.php:653
-#: includes/ajax.php:664
+#: includes/admin_import.php:656
+#: includes/ajax.php:670
 msgid "%s group"
 msgid_plural "%s groups"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/admin_import.php:656
-#: includes/ajax.php:665
+#: includes/admin_import.php:659
+#: includes/ajax.php:671
 msgid "%s region"
 msgid_plural "%s regions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/admin_import.php:666
+#: includes/admin_import.php:669
 msgid "Export Meeting List"
 msgstr ""
 
-#: includes/admin_import.php:682
+#: includes/admin_import.php:685
 msgid "Want to send a mass email to your contacts? <a href=\"%s\" target=\"_blank\">Click here</a> to see their email addresses."
 msgstr ""
 
@@ -449,7 +449,7 @@ msgstr ""
 #: includes/admin_meeting.php:76
 #: includes/shortcodes.php:80
 #: includes/variables.php:28
-#: includes/variables.php:966
+#: includes/variables.php:974
 msgid "Time"
 msgstr ""
 
@@ -473,7 +473,7 @@ msgstr ""
 #: includes/functions.php:581
 #: includes/save.php:479
 #: includes/save.php:481
-#: includes/variables.php:1477
+#: includes/variables.php:1485
 #: templates/archive-meetings.php:651
 msgid "Appointment"
 msgstr ""
@@ -651,7 +651,7 @@ msgid "Map"
 msgstr ""
 
 #: includes/admin_meeting.php:287
-#: includes/admin_settings.php:509
+#: includes/admin_settings.php:517
 msgid "Timezone"
 msgstr ""
 
@@ -747,12 +747,12 @@ msgid "Contacts"
 msgstr ""
 
 #: includes/admin_meeting.php:476
-#: includes/admin_settings.php:342
+#: includes/admin_settings.php:344
 msgid "Public"
 msgstr ""
 
 #: includes/admin_meeting.php:478
-#: includes/admin_settings.php:342
+#: includes/admin_settings.php:344
 msgid "Private"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr ""
 #: includes/admin_menu.php:22
 #: includes/functions.php:306
 #: includes/functions.php:308
-#: includes/variables.php:1491
+#: includes/variables.php:1499
 msgid "Regions"
 msgstr ""
 
@@ -835,302 +835,302 @@ msgstr ""
 msgid "Feedback address added."
 msgstr ""
 
-#: includes/admin_settings.php:109
+#: includes/admin_settings.php:110
 msgid "Feedback address removed."
 msgstr ""
 
-#: includes/admin_settings.php:112
-#: includes/admin_settings.php:144
+#: includes/admin_settings.php:114
+#: includes/admin_settings.php:146
 msgid "<p><code>%s</code> was not found in the list of addresses. Please try again.</p>"
 msgstr ""
 
-#: includes/admin_settings.php:121
+#: includes/admin_settings.php:123
 msgid "<p><code>%s</code> is not a valid email address. Please try again.</p>"
 msgstr ""
 
-#: includes/admin_settings.php:127
+#: includes/admin_settings.php:129
 msgid "Notification address added."
 msgstr ""
 
-#: includes/admin_settings.php:141
+#: includes/admin_settings.php:143
 msgid "Notification address removed."
 msgstr ""
 
-#: includes/admin_settings.php:153
-#: includes/admin_settings.php:169
+#: includes/admin_settings.php:155
+#: includes/admin_settings.php:171
 msgid "API key removed."
 msgstr ""
 
-#: includes/admin_settings.php:156
-#: includes/admin_settings.php:173
+#: includes/admin_settings.php:158
+#: includes/admin_settings.php:175
 msgid "API key saved."
 msgstr ""
 
-#: includes/admin_settings.php:192
+#: includes/admin_settings.php:194
 msgid "User interface is now set to <strong>"
 msgstr ""
 
-#: includes/admin_settings.php:200
+#: includes/admin_settings.php:202
 msgid "Timezone updated."
 msgstr ""
 
-#: includes/admin_settings.php:202
+#: includes/admin_settings.php:204
 msgid "Invalid timezone selected."
 msgstr ""
 
-#: includes/admin_settings.php:219
+#: includes/admin_settings.php:221
 msgid "Entity details saved."
 msgstr ""
 
-#: includes/admin_settings.php:231
+#: includes/admin_settings.php:233
 msgid "If you enable SSL (https), your users will be able to search near their location."
 msgstr ""
 
-#: includes/admin_settings.php:258
-#: includes/admin_settings.php:286
-#: includes/admin_settings.php:461
-#: includes/admin_settings.php:555
-#: includes/admin_settings.php:574
-#: includes/admin_settings.php:665
-#: includes/admin_settings.php:698
+#: includes/admin_settings.php:260
+#: includes/admin_settings.php:288
+#: includes/admin_settings.php:469
+#: includes/admin_settings.php:563
+#: includes/admin_settings.php:582
+#: includes/admin_settings.php:673
+#: includes/admin_settings.php:706
 msgid "Add"
 msgstr ""
 
-#: includes/admin_settings.php:297
+#: includes/admin_settings.php:299
 msgid "General"
 msgstr ""
 
-#: includes/admin_settings.php:301
+#: includes/admin_settings.php:303
 msgid "Program"
 msgstr ""
 
-#: includes/admin_settings.php:304
+#: includes/admin_settings.php:306
 msgid "Select the recovery program your site targets here."
 msgstr ""
 
-#: includes/admin_settings.php:317
+#: includes/admin_settings.php:319
 msgid "Distance Units"
 msgstr ""
 
-#: includes/admin_settings.php:320
+#: includes/admin_settings.php:322
 msgid "This determines which units are used on the meeting list page."
 msgstr ""
 
-#: includes/admin_settings.php:325
+#: includes/admin_settings.php:327
 msgid "Kilometers"
 msgstr ""
 
-#: includes/admin_settings.php:325
+#: includes/admin_settings.php:327
 msgid "Miles"
 msgstr ""
 
-#: includes/admin_settings.php:334
+#: includes/admin_settings.php:336
 msgid "Contact Visibility"
 msgstr ""
 
-#: includes/admin_settings.php:337
+#: includes/admin_settings.php:339
 msgid "This determines whether contacts are displayed publicly on meeting detail pages."
 msgstr ""
 
-#: includes/admin_settings.php:358
+#: includes/admin_settings.php:366
 msgid "Service Entity Information"
 msgstr ""
 
-#: includes/admin_settings.php:361
+#: includes/admin_settings.php:369
 msgid "Enter information for your service entity here to help identity the meeting source when sharing feeds with others."
 msgstr ""
 
-#: includes/admin_settings.php:367
-#: includes/admin_settings.php:370
+#: includes/admin_settings.php:375
+#: includes/admin_settings.php:378
 msgid "Entity Name"
 msgstr ""
 
-#: includes/admin_settings.php:372
+#: includes/admin_settings.php:380
 msgid "Administrative Contact Email"
 msgstr ""
 
-#: includes/admin_settings.php:377
+#: includes/admin_settings.php:385
 msgid "Public Phone Number"
 msgstr ""
 
-#: includes/admin_settings.php:382
+#: includes/admin_settings.php:390
 msgid "Service Area"
 msgstr ""
 
-#: includes/admin_settings.php:385
+#: includes/admin_settings.php:393
 msgid "City, State, Country"
 msgstr ""
 
-#: includes/admin_settings.php:387
+#: includes/admin_settings.php:395
 msgid "Website Address"
 msgstr ""
 
-#: includes/admin_settings.php:392
+#: includes/admin_settings.php:400
 msgid "Save"
 msgstr ""
 
-#: includes/admin_settings.php:403
+#: includes/admin_settings.php:411
 msgid "Feed Management"
 msgstr ""
 
-#: includes/admin_settings.php:407
+#: includes/admin_settings.php:415
 msgid "Feed Sharing"
 msgstr ""
 
-#: includes/admin_settings.php:410
+#: includes/admin_settings.php:418
 msgid "Open means your feeds are available publicly. Restricted means people need a key or to be logged in to get the feed."
 msgstr ""
 
-#: includes/admin_settings.php:415
-#: includes/variables.php:669
-#: includes/variables.php:762
-#: includes/variables.php:802
-#: includes/variables.php:844
-#: includes/variables.php:907
-#: includes/variables.php:962
-#: includes/variables.php:986
-#: includes/variables.php:1019
-#: includes/variables.php:1069
-#: includes/variables.php:1110
-#: includes/variables.php:1148
-#: includes/variables.php:1217
-#: includes/variables.php:1249
-#: includes/variables.php:1286
-#: includes/variables.php:1303
-#: includes/variables.php:1323
-#: includes/variables.php:1343
-#: includes/variables.php:1368
-#: includes/variables.php:1412
-#: includes/variables.php:1458
+#: includes/admin_settings.php:423
+#: includes/variables.php:677
+#: includes/variables.php:770
+#: includes/variables.php:810
+#: includes/variables.php:852
+#: includes/variables.php:915
+#: includes/variables.php:970
+#: includes/variables.php:994
+#: includes/variables.php:1027
+#: includes/variables.php:1077
+#: includes/variables.php:1118
+#: includes/variables.php:1156
+#: includes/variables.php:1225
+#: includes/variables.php:1257
+#: includes/variables.php:1294
+#: includes/variables.php:1311
+#: includes/variables.php:1331
+#: includes/variables.php:1351
+#: includes/variables.php:1376
+#: includes/variables.php:1420
+#: includes/variables.php:1466
 msgid "Open"
 msgstr ""
 
-#: includes/admin_settings.php:415
+#: includes/admin_settings.php:423
 msgid "Restricted"
 msgstr ""
 
-#: includes/admin_settings.php:427
+#: includes/admin_settings.php:435
 msgid "Authorized Apps"
 msgstr ""
 
-#: includes/admin_settings.php:431
+#: includes/admin_settings.php:439
 msgid "You may allow access to your meeting data for specific purposes, such as the <a target=\"_blank\" href=\"https://meetingguide.org/\">Meeting Guide App</a>."
 msgstr ""
 
-#: includes/admin_settings.php:460
+#: includes/admin_settings.php:468
 msgid "Meeting Guide"
 msgstr ""
 
-#: includes/admin_settings.php:467
+#: includes/admin_settings.php:475
 msgid "Public Feed"
 msgstr ""
 
-#: includes/admin_settings.php:470
+#: includes/admin_settings.php:478
 msgid "The following feed contains your publicly available meeting information."
 msgstr ""
 
-#: includes/admin_settings.php:474
+#: includes/admin_settings.php:482
 msgid "Public Data Source"
 msgstr ""
 
-#: includes/admin_settings.php:485
+#: includes/admin_settings.php:493
 msgid "User Interface Display"
 msgstr ""
 
-#: includes/admin_settings.php:488
+#: includes/admin_settings.php:496
 msgid "Please select the user interface that is right for your <a href=\"%s\" target=\"_blank\">meeting finder page</a>. Choose between our latest design that we call <b>TSML UI</b> or stay with the standard <b>Legacy UI</b>."
 msgstr ""
 
-#: includes/admin_settings.php:495
+#: includes/admin_settings.php:503
 msgid "Legacy UI"
 msgstr ""
 
-#: includes/admin_settings.php:498
+#: includes/admin_settings.php:506
 msgid "TSML UI"
 msgstr ""
 
-#: includes/admin_settings.php:513
+#: includes/admin_settings.php:521
 msgid "If your site features meetings in a variety of timezones, leave this blank and meetings will be displayed in the user's timezone. This requires a timezone to be set on each meeting location."
 msgstr ""
 
-#: includes/admin_settings.php:517
+#: includes/admin_settings.php:525
 msgid "If your site features meetings in a single timezone, select it here and meetings will be displayed in that timezone. There is no need to specify a timezone for each meeting."
 msgstr ""
 
-#: includes/admin_settings.php:526
+#: includes/admin_settings.php:534
 msgid "Timezone settings are only relevant to the TSML UI interface."
 msgstr ""
 
-#: includes/admin_settings.php:536
+#: includes/admin_settings.php:544
 msgid "Maps"
 msgstr ""
 
-#: includes/admin_settings.php:539
+#: includes/admin_settings.php:547
 msgid "Display of maps requires an authorization key from <strong><a href=\"https://www.mapbox.com/\" target=\"_blank\">Mapbox</a></strong> or <strong><a href=\"https://console.cloud.google.com/home/\" target=\"_blank\">Google</a></strong>."
 msgstr ""
 
-#: includes/admin_settings.php:542
+#: includes/admin_settings.php:550
 msgid "Please note that TSML UI only supports Mapbox."
 msgstr ""
 
-#: includes/admin_settings.php:547
+#: includes/admin_settings.php:555
 msgid "Mapbox Access Token"
 msgstr ""
 
-#: includes/admin_settings.php:557
-#: includes/admin_settings.php:576
+#: includes/admin_settings.php:565
+#: includes/admin_settings.php:584
 msgid "Update"
 msgstr ""
 
-#: includes/admin_settings.php:564
+#: includes/admin_settings.php:572
 msgid "Google Maps API Key"
 msgstr ""
 
-#: includes/admin_settings.php:567
+#: includes/admin_settings.php:575
 msgid "Be sure to enable JavaScript Maps API (<a href=\"https://developers.google.com/maps/documentation/javascript/get-api-key\" target=\"_blank\">read more</a>)."
 msgstr ""
 
-#: includes/admin_settings.php:589
+#: includes/admin_settings.php:597
 msgid "About Us"
 msgstr ""
 
-#: includes/admin_settings.php:596
+#: includes/admin_settings.php:604
 msgid "This <b>12 Step Meeting List</b> plugin (TSML) is one of the free services offered by the nonprofit organization <b>Code For Recovery</b> whose volunteer members build and maintain technology services for recovery fellowships such as AA and Al-Anon."
 msgstr ""
 
-#: includes/admin_settings.php:608
+#: includes/admin_settings.php:616
 msgid "Need Help?"
 msgstr ""
 
-#: includes/admin_settings.php:612
+#: includes/admin_settings.php:620
 msgid "To get information about this product or our organization, simply use one of the linked buttons below which are great sources for information and answers."
 msgstr ""
 
-#: includes/admin_settings.php:621
+#: includes/admin_settings.php:629
 msgid "View Documentation"
 msgstr ""
 
-#: includes/admin_settings.php:625
+#: includes/admin_settings.php:633
 msgid "Ask a Question"
 msgstr ""
 
-#: includes/admin_settings.php:633
+#: includes/admin_settings.php:641
 msgid "Email Addresses"
 msgstr ""
 
-#: includes/admin_settings.php:638
+#: includes/admin_settings.php:646
 msgid "User Feedback Emails"
 msgstr ""
 
-#: includes/admin_settings.php:641
+#: includes/admin_settings.php:649
 msgid "Enable a meeting info feedback form by adding email addresses here."
 msgstr ""
 
-#: includes/admin_settings.php:671
+#: includes/admin_settings.php:679
 msgid "Change Notification Emails"
 msgstr ""
 
-#: includes/admin_settings.php:674
+#: includes/admin_settings.php:682
 msgid "Receive notifications of meeting changes at the email addresses below."
 msgstr ""
 
@@ -1142,67 +1142,67 @@ msgstr ""
 msgid "When"
 msgstr ""
 
-#: includes/ajax.php:306
+#: includes/ajax.php:312
 msgid "Error: nonce value not set correctly. Email was not sent."
 msgstr ""
 
-#: includes/ajax.php:308
+#: includes/ajax.php:314
 msgid "Error: required form value missing. Email was not sent."
 msgstr ""
 
-#: includes/ajax.php:311
+#: includes/ajax.php:317
 msgid "Meeting Feedback Form"
 msgstr ""
 
-#: includes/ajax.php:313
+#: includes/ajax.php:319
 msgid "Thank you for your feedback."
 msgstr ""
 
-#: includes/ajax.php:317
-#: includes/functions.php:2333
+#: includes/ajax.php:323
+#: includes/functions.php:2372
 msgid "Error: %s"
 msgstr ""
 
-#: includes/ajax.php:319
+#: includes/ajax.php:325
 msgid "An error occurred while sending email!"
 msgstr ""
 
-#: includes/ajax.php:423
+#: includes/ajax.php:429
 msgid "No location information provided for <code>%s</code>."
 msgstr ""
 
 #: includes/functions.php:47
-#: includes/variables.php:629
+#: includes/variables.php:637
 msgid "Sunday"
 msgstr ""
 
 #: includes/functions.php:48
-#: includes/variables.php:630
+#: includes/variables.php:638
 msgid "Monday"
 msgstr ""
 
 #: includes/functions.php:49
-#: includes/variables.php:631
+#: includes/variables.php:639
 msgid "Tuesday"
 msgstr ""
 
 #: includes/functions.php:50
-#: includes/variables.php:632
+#: includes/variables.php:640
 msgid "Wednesday"
 msgstr ""
 
 #: includes/functions.php:51
-#: includes/variables.php:633
+#: includes/variables.php:641
 msgid "Thursday"
 msgstr ""
 
 #: includes/functions.php:52
-#: includes/variables.php:634
+#: includes/variables.php:642
 msgid "Friday"
 msgstr ""
 
 #: includes/functions.php:53
-#: includes/variables.php:635
+#: includes/variables.php:643
 msgid "Saturday"
 msgstr ""
 
@@ -1312,7 +1312,7 @@ msgstr ""
 
 #: includes/functions.php:373
 #: includes/functions.php:375
-#: includes/variables.php:1487
+#: includes/variables.php:1495
 msgid "Locations"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgstr ""
 
 #: includes/functions.php:402
 #: includes/functions.php:404
-#: includes/variables.php:1486
+#: includes/variables.php:1494
 msgid "Groups"
 msgstr ""
 
@@ -1423,67 +1423,75 @@ msgstr ""
 msgid "Midnight"
 msgstr ""
 
-#: includes/functions.php:1656
+#: includes/functions.php:1534
+msgid "You can now add a Google Sheet directly to TSML. Please replace this feed with the Sheet URL. We will be dropping support for the Google Sheets API in a future release."
+msgstr ""
+
+#: includes/functions.php:1541
+msgid "The following issues were detected with this Google Sheet:"
+msgstr ""
+
+#: includes/functions.php:1676
 msgid "Meeting Location"
 msgstr ""
 
-#: includes/functions.php:1669
+#: includes/functions.php:1689
 msgid "%s by Appointment"
 msgstr ""
 
-#: includes/functions.php:1673
+#: includes/functions.php:1693
 msgid "%s %ss at %s"
 msgstr ""
 
-#: includes/functions.php:1958
+#: includes/functions.php:1988
 msgid "District %s"
 msgstr ""
 
-#: includes/functions.php:2104
-#: includes/functions.php:2112
+#: includes/functions.php:2143
+#: includes/functions.php:2151
 msgid "You do not have sufficient permissions to access this page (<code>"
 msgstr ""
 
-#: includes/functions.php:2320
+#: includes/functions.php:2359
 msgid "<p>Please sign in to your website and refresh the <b> %s </b> feed on the Import & Export page.</p><br>"
 msgstr ""
 
-#: includes/functions.php:2323
+#: includes/functions.php:2362
 msgid "Go to Import & Export page"
 msgstr ""
 
-#: includes/functions.php:2327
+#: includes/functions.php:2366
 msgid "Data Source Changes Detected"
 msgstr ""
 
-#: includes/functions.php:2335
+#: includes/functions.php:2374
 msgid "<div class='bg-warning text-dark'>An error occurred while sending email!</div>"
 msgstr ""
 
-#: includes/functions.php:2339
+#: includes/functions.php:2378
 msgid "Send Email: Data Source Changes Detected."
 msgstr ""
 
-#: includes/functions.php:2543
+#: includes/functions.php:2582
 #: templates/single-locations.php:122
-#: templates/single-meetings.php:363
+#: templates/single-meetings.php:397
 msgid "Updated"
 msgstr ""
 
-#: includes/functions.php:2544
+#: includes/functions.php:2583
 msgid "Changed"
 msgstr ""
 
-#: includes/functions.php:2556
-#: includes/functions.php:2557
+#: includes/functions.php:2595
+#: includes/functions.php:2596
 msgid "New"
 msgstr ""
 
-#: includes/functions.php:2572
+#: includes/functions.php:2611
 msgid "Removed / Missing"
 msgstr ""
 
-#: includes/functions.php:2573
+#: includes/functions.php:2612
 msgid "Removed"
 msgstr ""
 
@@ -1516,7 +1524,7 @@ msgid "In-person and Online"
 msgstr ""
 
 #: includes/variables.php:22
-#: includes/variables.php:1018
+#: includes/variables.php:1026
 msgid "Online"
 msgstr ""
 
@@ -1532,1471 +1540,1471 @@ msgstr ""
 msgid "Location / Group"
 msgstr ""
 
-#: includes/variables.php:650
+#: includes/variables.php:658
 msgid "ACA"
 msgstr ""
 
-#: includes/variables.php:652
+#: includes/variables.php:660
 msgid "Adult Children of Alcoholics"
 msgstr ""
 
-#: includes/variables.php:654
+#: includes/variables.php:662
 msgid "This meeting is closed; only those who have a desire to recover from the effects of growing up in an alcoholic or otherwise dysfunctional family may attend."
 msgstr ""
 
-#: includes/variables.php:655
-#: includes/variables.php:869
+#: includes/variables.php:663
+#: includes/variables.php:877
 msgid "This meeting is open and anyone may attend."
 msgstr ""
 
-#: includes/variables.php:658
+#: includes/variables.php:666
 msgid "Age Restricted 18+"
 msgstr ""
 
-#: includes/variables.php:659
+#: includes/variables.php:667
 msgid "Audio / Visual"
 msgstr ""
 
-#: includes/variables.php:660
-#: includes/variables.php:825
-#: includes/variables.php:933
-#: includes/variables.php:1231
-#: includes/variables.php:1268
-#: includes/variables.php:1316
-#: includes/variables.php:1354
+#: includes/variables.php:668
+#: includes/variables.php:833
+#: includes/variables.php:941
+#: includes/variables.php:1239
+#: includes/variables.php:1276
+#: includes/variables.php:1324
+#: includes/variables.php:1362
 msgid "Book Study"
 msgstr ""
 
-#: includes/variables.php:661
-#: includes/variables.php:1230
-#: includes/variables.php:1267
+#: includes/variables.php:669
+#: includes/variables.php:1238
+#: includes/variables.php:1275
 msgid "Beginners"
 msgstr ""
 
-#: includes/variables.php:662
-#: includes/variables.php:733
-#: includes/variables.php:796
-#: includes/variables.php:828
-#: includes/variables.php:882
-#: includes/variables.php:956
-#: includes/variables.php:981
-#: includes/variables.php:1005
-#: includes/variables.php:1051
-#: includes/variables.php:1097
-#: includes/variables.php:1135
-#: includes/variables.php:1214
-#: includes/variables.php:1233
-#: includes/variables.php:1270
-#: includes/variables.php:1300
-#: includes/variables.php:1317
-#: includes/variables.php:1337
-#: includes/variables.php:1357
-#: includes/variables.php:1393
-#: includes/variables.php:1454
+#: includes/variables.php:670
+#: includes/variables.php:741
+#: includes/variables.php:804
+#: includes/variables.php:836
+#: includes/variables.php:890
+#: includes/variables.php:964
+#: includes/variables.php:989
+#: includes/variables.php:1013
+#: includes/variables.php:1059
+#: includes/variables.php:1105
+#: includes/variables.php:1143
+#: includes/variables.php:1222
+#: includes/variables.php:1241
+#: includes/variables.php:1278
+#: includes/variables.php:1308
+#: includes/variables.php:1325
+#: includes/variables.php:1345
+#: includes/variables.php:1365
+#: includes/variables.php:1401
+#: includes/variables.php:1462
 msgid "Closed"
 msgstr ""
 
-#: includes/variables.php:663
-#: includes/variables.php:739
-#: includes/variables.php:888
-#: includes/variables.php:982
-#: includes/variables.php:1056
-#: includes/variables.php:1339
+#: includes/variables.php:671
+#: includes/variables.php:747
+#: includes/variables.php:896
+#: includes/variables.php:990
+#: includes/variables.php:1064
+#: includes/variables.php:1347
 msgid "Discussion"
 msgstr ""
 
-#: includes/variables.php:664
+#: includes/variables.php:672
 msgid "Fellowship Text"
 msgstr ""
 
-#: includes/variables.php:665
-#: includes/variables.php:1099
-#: includes/variables.php:1137
+#: includes/variables.php:673
+#: includes/variables.php:1107
+#: includes/variables.php:1145
 msgid "Gay/Lesbian"
 msgstr ""
 
-#: includes/variables.php:666
-#: includes/variables.php:700
-#: includes/variables.php:755
-#: includes/variables.php:810
-#: includes/variables.php:840
-#: includes/variables.php:901
-#: includes/variables.php:958
-#: includes/variables.php:983
-#: includes/variables.php:1064
-#: includes/variables.php:1105
-#: includes/variables.php:1143
-#: includes/variables.php:1179
-#: includes/variables.php:1215
-#: includes/variables.php:1245
-#: includes/variables.php:1282
-#: includes/variables.php:1306
-#: includes/variables.php:1318
-#: includes/variables.php:1341
-#: includes/variables.php:1363
-#: includes/variables.php:1407
-#: includes/variables.php:1456
+#: includes/variables.php:674
+#: includes/variables.php:708
+#: includes/variables.php:763
+#: includes/variables.php:818
+#: includes/variables.php:848
+#: includes/variables.php:909
+#: includes/variables.php:966
+#: includes/variables.php:991
+#: includes/variables.php:1072
+#: includes/variables.php:1113
+#: includes/variables.php:1151
+#: includes/variables.php:1187
+#: includes/variables.php:1223
+#: includes/variables.php:1253
+#: includes/variables.php:1290
+#: includes/variables.php:1314
+#: includes/variables.php:1326
+#: includes/variables.php:1349
+#: includes/variables.php:1371
+#: includes/variables.php:1415
+#: includes/variables.php:1464
 msgid "Location Temporarily Closed"
 msgstr ""
 
-#: includes/variables.php:667
-#: includes/variables.php:701
-#: includes/variables.php:757
-#: includes/variables.php:799
-#: includes/variables.php:842
-#: includes/variables.php:903
-#: includes/variables.php:959
-#: includes/variables.php:984
-#: includes/variables.php:1017
-#: includes/variables.php:1066
-#: includes/variables.php:1106
-#: includes/variables.php:1144
-#: includes/variables.php:1246
-#: includes/variables.php:1283
-#: includes/variables.php:1301
-#: includes/variables.php:1320
-#: includes/variables.php:1365
-#: includes/variables.php:1408
-#: includes/variables.php:1441
-#: includes/variables.php:1489
+#: includes/variables.php:675
+#: includes/variables.php:709
+#: includes/variables.php:765
+#: includes/variables.php:807
+#: includes/variables.php:850
+#: includes/variables.php:911
+#: includes/variables.php:967
+#: includes/variables.php:992
+#: includes/variables.php:1025
+#: includes/variables.php:1074
+#: includes/variables.php:1114
+#: includes/variables.php:1152
+#: includes/variables.php:1254
+#: includes/variables.php:1291
+#: includes/variables.php:1309
+#: includes/variables.php:1328
+#: includes/variables.php:1373
+#: includes/variables.php:1416
+#: includes/variables.php:1449
+#: includes/variables.php:1497
 msgid "Men"
 msgstr ""
 
-#: includes/variables.php:668
-#: includes/variables.php:702
-#: includes/variables.php:761
-#: includes/variables.php:843
-#: includes/variables.php:906
-#: includes/variables.php:961
-#: includes/variables.php:985
-#: includes/variables.php:1068
-#: includes/variables.php:1109
-#: includes/variables.php:1147
-#: includes/variables.php:1187
-#: includes/variables.php:1216
-#: includes/variables.php:1248
-#: includes/variables.php:1285
-#: includes/variables.php:1302
-#: includes/variables.php:1322
-#: includes/variables.php:1342
-#: includes/variables.php:1367
-#: includes/variables.php:1411
-#: includes/variables.php:1457
+#: includes/variables.php:676
+#: includes/variables.php:710
+#: includes/variables.php:769
+#: includes/variables.php:851
+#: includes/variables.php:914
+#: includes/variables.php:969
+#: includes/variables.php:993
+#: includes/variables.php:1076
+#: includes/variables.php:1117
+#: includes/variables.php:1155
+#: includes/variables.php:1195
+#: includes/variables.php:1224
+#: includes/variables.php:1256
+#: includes/variables.php:1293
+#: includes/variables.php:1310
+#: includes/variables.php:1330
+#: includes/variables.php:1350
+#: includes/variables.php:1375
+#: includes/variables.php:1419
+#: includes/variables.php:1465
 #: templates/single-meetings.php:138
 msgid "Online Meeting"
 msgstr ""
 
-#: includes/variables.php:670
-#: includes/variables.php:707
-#: includes/variables.php:776
-#: includes/variables.php:807
-#: includes/variables.php:851
-#: includes/variables.php:915
-#: includes/variables.php:964
-#: includes/variables.php:1026
-#: includes/variables.php:1078
-#: includes/variables.php:1114
-#: includes/variables.php:1153
-#: includes/variables.php:1190
-#: includes/variables.php:1218
-#: includes/variables.php:1325
-#: includes/variables.php:1344
-#: includes/variables.php:1371
-#: includes/variables.php:1423
+#: includes/variables.php:678
+#: includes/variables.php:715
+#: includes/variables.php:784
+#: includes/variables.php:815
+#: includes/variables.php:859
+#: includes/variables.php:923
+#: includes/variables.php:972
+#: includes/variables.php:1034
+#: includes/variables.php:1086
+#: includes/variables.php:1122
+#: includes/variables.php:1161
+#: includes/variables.php:1198
+#: includes/variables.php:1226
+#: includes/variables.php:1333
+#: includes/variables.php:1352
+#: includes/variables.php:1379
+#: includes/variables.php:1431
 msgid "Speaker"
 msgstr ""
 
-#: includes/variables.php:671
-#: includes/variables.php:706
-#: includes/variables.php:775
-#: includes/variables.php:806
-#: includes/variables.php:850
-#: includes/variables.php:914
-#: includes/variables.php:1025
-#: includes/variables.php:1077
-#: includes/variables.php:1251
-#: includes/variables.php:1288
-#: includes/variables.php:1370
-#: includes/variables.php:1422
-#: includes/variables.php:1442
+#: includes/variables.php:679
+#: includes/variables.php:714
+#: includes/variables.php:783
+#: includes/variables.php:814
+#: includes/variables.php:858
+#: includes/variables.php:922
+#: includes/variables.php:1033
+#: includes/variables.php:1085
+#: includes/variables.php:1259
+#: includes/variables.php:1296
+#: includes/variables.php:1378
+#: includes/variables.php:1430
+#: includes/variables.php:1450
 msgid "Spanish"
 msgstr ""
 
-#: includes/variables.php:672
-#: includes/variables.php:1443
+#: includes/variables.php:680
+#: includes/variables.php:1451
 msgid "Steps"
 msgstr ""
 
-#: includes/variables.php:673
-#: includes/variables.php:711
-#: includes/variables.php:782
-#: includes/variables.php:811
-#: includes/variables.php:858
-#: includes/variables.php:920
-#: includes/variables.php:970
-#: includes/variables.php:989
-#: includes/variables.php:1033
-#: includes/variables.php:1083
-#: includes/variables.php:1121
-#: includes/variables.php:1160
-#: includes/variables.php:1255
-#: includes/variables.php:1292
-#: includes/variables.php:1307
-#: includes/variables.php:1327
-#: includes/variables.php:1375
-#: includes/variables.php:1432
-#: includes/variables.php:1445
-#: includes/variables.php:1492
+#: includes/variables.php:681
+#: includes/variables.php:719
+#: includes/variables.php:790
+#: includes/variables.php:819
+#: includes/variables.php:866
+#: includes/variables.php:928
+#: includes/variables.php:978
+#: includes/variables.php:997
+#: includes/variables.php:1041
+#: includes/variables.php:1091
+#: includes/variables.php:1129
+#: includes/variables.php:1168
+#: includes/variables.php:1263
+#: includes/variables.php:1300
+#: includes/variables.php:1315
+#: includes/variables.php:1335
+#: includes/variables.php:1383
+#: includes/variables.php:1440
+#: includes/variables.php:1453
+#: includes/variables.php:1500
 msgid "Women"
 msgstr ""
 
-#: includes/variables.php:674
+#: includes/variables.php:682
 msgid "Yellow Workbook Study"
 msgstr ""
 
-#: includes/variables.php:678
-#: includes/variables.php:680
+#: includes/variables.php:686
+#: includes/variables.php:688
 msgid "Al-Anon"
 msgstr ""
 
-#: includes/variables.php:682
+#: includes/variables.php:690
 msgid "Closed Meetings are limited to members and prospective members. These are persons who feel their lives have been or are being affected by alcoholism in a family member or friend."
 msgstr ""
 
-#: includes/variables.php:683
+#: includes/variables.php:691
 msgid "Open to anyone interested in the family disease of alcoholism. Some groups invite members of the professional community to hear how the Al-Anon program aids in recovery."
 msgstr ""
 
-#: includes/variables.php:686
+#: includes/variables.php:694
 msgid "Adult Child Focus"
 msgstr ""
 
-#: includes/variables.php:687
+#: includes/variables.php:695
 msgid "Alateen"
 msgstr ""
 
-#: includes/variables.php:688
-#: includes/variables.php:822
-#: includes/variables.php:875
+#: includes/variables.php:696
+#: includes/variables.php:830
+#: includes/variables.php:883
 msgid "Atheist / Agnostic"
 msgstr ""
 
-#: includes/variables.php:689
-#: includes/variables.php:727
-#: includes/variables.php:823
-#: includes/variables.php:876
-#: includes/variables.php:979
-#: includes/variables.php:1000
-#: includes/variables.php:1047
+#: includes/variables.php:697
+#: includes/variables.php:735
+#: includes/variables.php:831
+#: includes/variables.php:884
+#: includes/variables.php:987
+#: includes/variables.php:1008
+#: includes/variables.php:1055
 msgid "Babysitting Available"
 msgstr ""
 
-#: includes/variables.php:690
-#: includes/variables.php:824
-#: includes/variables.php:1315
-#: includes/variables.php:1335
+#: includes/variables.php:698
+#: includes/variables.php:832
+#: includes/variables.php:1323
+#: includes/variables.php:1343
 msgid "Beginner"
 msgstr ""
 
-#: includes/variables.php:691
+#: includes/variables.php:699
 msgid "Concurrent with AA Meeting"
 msgstr ""
 
-#: includes/variables.php:692
+#: includes/variables.php:700
 msgid "Concurrent with Alateen Meeting"
 msgstr ""
 
-#: includes/variables.php:693
-#: includes/variables.php:741
-#: includes/variables.php:890
-#: includes/variables.php:1007
-#: includes/variables.php:1057
-#: includes/variables.php:1238
-#: includes/variables.php:1275
-#: includes/variables.php:1395
+#: includes/variables.php:701
+#: includes/variables.php:749
+#: includes/variables.php:898
+#: includes/variables.php:1015
+#: includes/variables.php:1065
+#: includes/variables.php:1246
+#: includes/variables.php:1283
+#: includes/variables.php:1403
 msgid "English"
 msgstr ""
 
-#: includes/variables.php:694
+#: includes/variables.php:702
 msgid "Families Friends and Observers Welcome"
 msgstr ""
 
-#: includes/variables.php:695
+#: includes/variables.php:703
 msgid "Families and Friends Only"
 msgstr ""
 
-#: includes/variables.php:696
-#: includes/variables.php:742
-#: includes/variables.php:834
-#: includes/variables.php:891
-#: includes/variables.php:1358
-#: includes/variables.php:1397
+#: includes/variables.php:704
+#: includes/variables.php:750
+#: includes/variables.php:842
+#: includes/variables.php:899
+#: includes/variables.php:1366
+#: includes/variables.php:1405
 msgid "Fragrance Free"
 msgstr ""
 
-#: includes/variables.php:697
-#: includes/variables.php:744
-#: includes/variables.php:835
-#: includes/variables.php:893
+#: includes/variables.php:705
+#: includes/variables.php:752
+#: includes/variables.php:843
+#: includes/variables.php:901
 msgid "Gay"
 msgstr ""
 
-#: includes/variables.php:698
-#: includes/variables.php:751
-#: includes/variables.php:837
-#: includes/variables.php:897
+#: includes/variables.php:706
+#: includes/variables.php:759
+#: includes/variables.php:845
+#: includes/variables.php:905
 msgid "Lesbian"
 msgstr ""
 
-#: includes/variables.php:699
+#: includes/variables.php:707
 msgid "LGBTQIA+"
 msgstr ""
 
-#: includes/variables.php:703
+#: includes/variables.php:711
 msgid "Parents of Alcoholics"
 msgstr ""
 
-#: includes/variables.php:704
-#: includes/variables.php:764
-#: includes/variables.php:804
-#: includes/variables.php:1021
-#: includes/variables.php:1414
+#: includes/variables.php:712
+#: includes/variables.php:772
+#: includes/variables.php:812
+#: includes/variables.php:1029
+#: includes/variables.php:1422
 msgid "People of Color"
 msgstr ""
 
-#: includes/variables.php:705
-#: includes/variables.php:774
-#: includes/variables.php:805
-#: includes/variables.php:849
-#: includes/variables.php:913
-#: includes/variables.php:1076
+#: includes/variables.php:713
+#: includes/variables.php:782
+#: includes/variables.php:813
+#: includes/variables.php:857
+#: includes/variables.php:921
+#: includes/variables.php:1084
 msgid "Smoking Permitted"
 msgstr ""
 
-#: includes/variables.php:708
-#: includes/variables.php:777
-#: includes/variables.php:808
-#: includes/variables.php:852
-#: includes/variables.php:916
-#: includes/variables.php:987
-#: includes/variables.php:1079
-#: includes/variables.php:1304
+#: includes/variables.php:716
+#: includes/variables.php:785
+#: includes/variables.php:816
+#: includes/variables.php:860
+#: includes/variables.php:924
+#: includes/variables.php:995
+#: includes/variables.php:1087
+#: includes/variables.php:1312
 msgid "Step Meeting"
 msgstr ""
 
-#: includes/variables.php:709
-#: includes/variables.php:779
-#: includes/variables.php:809
-#: includes/variables.php:856
-#: includes/variables.php:918
-#: includes/variables.php:1030
-#: includes/variables.php:1427
+#: includes/variables.php:717
+#: includes/variables.php:787
+#: includes/variables.php:817
+#: includes/variables.php:864
+#: includes/variables.php:926
+#: includes/variables.php:1038
+#: includes/variables.php:1435
 msgid "Transgender"
 msgstr ""
 
-#: includes/variables.php:710
-#: includes/variables.php:857
-#: includes/variables.php:969
-#: includes/variables.php:1120
-#: includes/variables.php:1159
+#: includes/variables.php:718
+#: includes/variables.php:865
+#: includes/variables.php:977
+#: includes/variables.php:1128
+#: includes/variables.php:1167
 msgid "Wheelchair Accessible"
 msgstr ""
 
-#: includes/variables.php:712
+#: includes/variables.php:720
 msgid "Young Adults"
 msgstr ""
 
-#: includes/variables.php:716
+#: includes/variables.php:724
 msgid "AA"
 msgstr ""
 
-#: includes/variables.php:718
+#: includes/variables.php:726
 msgid "Alcoholics Anonymous"
 msgstr ""
 
-#: includes/variables.php:720
+#: includes/variables.php:728
 msgid "Closed meetings are for A.A. members only, or for those who have a drinking problem and “have a desire to stop drinking.”"
 msgstr ""
 
-#: includes/variables.php:721
+#: includes/variables.php:729
 msgid "Open meetings are available to anyone interested in Alcoholics Anonymous’ program of recovery from alcoholism. Nonalcoholics may attend open meetings as observers."
 msgstr ""
 
-#: includes/variables.php:724
-#: includes/variables.php:872
-#: includes/variables.php:998
+#: includes/variables.php:732
+#: includes/variables.php:880
+#: includes/variables.php:1006
 msgid "11th Step Meditation"
 msgstr ""
 
-#: includes/variables.php:725
-#: includes/variables.php:873
-#: includes/variables.php:929
-#: includes/variables.php:978
-#: includes/variables.php:999
-#: includes/variables.php:1388
-#: includes/variables.php:1453
+#: includes/variables.php:733
+#: includes/variables.php:881
+#: includes/variables.php:937
+#: includes/variables.php:986
+#: includes/variables.php:1007
+#: includes/variables.php:1396
+#: includes/variables.php:1461
 msgid "12 Steps & 12 Traditions"
 msgstr ""
 
-#: includes/variables.php:726
-#: includes/variables.php:874
-#: includes/variables.php:931
+#: includes/variables.php:734
+#: includes/variables.php:882
+#: includes/variables.php:939
 msgid "As Bill Sees It"
 msgstr ""
 
-#: includes/variables.php:728
-#: includes/variables.php:877
-#: includes/variables.php:932
-#: includes/variables.php:1002
-#: includes/variables.php:1048
-#: includes/variables.php:1173
-#: includes/variables.php:1392
+#: includes/variables.php:736
+#: includes/variables.php:885
+#: includes/variables.php:940
+#: includes/variables.php:1010
+#: includes/variables.php:1056
+#: includes/variables.php:1181
+#: includes/variables.php:1400
 msgid "Big Book"
 msgstr ""
 
-#: includes/variables.php:729
-#: includes/variables.php:878
+#: includes/variables.php:737
+#: includes/variables.php:886
 msgid "Birthday"
 msgstr ""
 
-#: includes/variables.php:730
-#: includes/variables.php:879
+#: includes/variables.php:738
+#: includes/variables.php:887
 msgid "Breakfast"
 msgstr ""
 
-#: includes/variables.php:731
-#: includes/variables.php:829
-#: includes/variables.php:883
-#: includes/variables.php:1049
-#: includes/variables.php:1095
-#: includes/variables.php:1133
+#: includes/variables.php:739
+#: includes/variables.php:837
+#: includes/variables.php:891
+#: includes/variables.php:1057
+#: includes/variables.php:1103
+#: includes/variables.php:1141
 msgid "Candlelight"
 msgstr ""
 
-#: includes/variables.php:732
-#: includes/variables.php:826
-#: includes/variables.php:881
-#: includes/variables.php:1004
-#: includes/variables.php:1050
+#: includes/variables.php:740
+#: includes/variables.php:834
+#: includes/variables.php:889
+#: includes/variables.php:1012
+#: includes/variables.php:1058
 msgid "Child-Friendly"
 msgstr ""
 
-#: includes/variables.php:734
-#: includes/variables.php:830
-#: includes/variables.php:884
+#: includes/variables.php:742
+#: includes/variables.php:838
+#: includes/variables.php:892
 msgid "Concurrent with Al-Anon"
 msgstr ""
 
-#: includes/variables.php:735
-#: includes/variables.php:831
-#: includes/variables.php:885
+#: includes/variables.php:743
+#: includes/variables.php:839
+#: includes/variables.php:893
 msgid "Concurrent with Alateen"
 msgstr ""
 
-#: includes/variables.php:736
-#: includes/variables.php:832
-#: includes/variables.php:886
+#: includes/variables.php:744
+#: includes/variables.php:840
+#: includes/variables.php:894
 msgid "Cross Talk Permitted"
 msgstr ""
 
-#: includes/variables.php:737
-#: includes/variables.php:887
-#: includes/variables.php:936
-#: includes/variables.php:1055
+#: includes/variables.php:745
+#: includes/variables.php:895
+#: includes/variables.php:944
+#: includes/variables.php:1063
 msgid "Daily Reflections"
 msgstr ""
 
-#: includes/variables.php:738
+#: includes/variables.php:746
 msgid "Digital Basket"
 msgstr ""
 
-#: includes/variables.php:740
-#: includes/variables.php:889
+#: includes/variables.php:748
+#: includes/variables.php:897
 msgid "Dual Diagnosis"
 msgstr ""
 
-#: includes/variables.php:743
-#: includes/variables.php:892
-#: includes/variables.php:1058
-#: includes/variables.php:1240
-#: includes/variables.php:1277
-#: includes/variables.php:1398
+#: includes/variables.php:751
+#: includes/variables.php:900
+#: includes/variables.php:1066
+#: includes/variables.php:1248
+#: includes/variables.php:1285
+#: includes/variables.php:1406
 msgid "French"
 msgstr ""
 
-#: includes/variables.php:745
-#: includes/variables.php:836
-#: includes/variables.php:894
+#: includes/variables.php:753
+#: includes/variables.php:844
+#: includes/variables.php:902
 msgid "Grapevine"
 msgstr ""
 
-#: includes/variables.php:746
-#: includes/variables.php:1400
+#: includes/variables.php:754
+#: includes/variables.php:1408
 msgid "Hebrew"
 msgstr ""
 
-#: includes/variables.php:747
-#: includes/variables.php:1011
-#: includes/variables.php:1401
+#: includes/variables.php:755
+#: includes/variables.php:1019
+#: includes/variables.php:1409
 msgid "Indigenous"
 msgstr ""
 
-#: includes/variables.php:748
-#: includes/variables.php:895
-#: includes/variables.php:1013
-#: includes/variables.php:1060
-#: includes/variables.php:1402
+#: includes/variables.php:756
+#: includes/variables.php:903
+#: includes/variables.php:1021
+#: includes/variables.php:1068
+#: includes/variables.php:1410
 msgid "Italian"
 msgstr ""
 
-#: includes/variables.php:749
-#: includes/variables.php:1403
+#: includes/variables.php:757
+#: includes/variables.php:1411
 msgid "Japanese"
-msgstr ""
-
-#: includes/variables.php:750
-#: includes/variables.php:896
-#: includes/variables.php:1061
-#: includes/variables.php:1404
-msgid "Korean"
-msgstr ""
-
-#: includes/variables.php:752
-#: includes/variables.php:798
-#: includes/variables.php:838
-#: includes/variables.php:898
-#: includes/variables.php:1014
-#: includes/variables.php:1062
-#: includes/variables.php:1406
-msgid "Literature"
-msgstr ""
-
-#: includes/variables.php:753
-#: includes/variables.php:899
-#: includes/variables.php:938
-msgid "Living Sober"
-msgstr ""
-
-#: includes/variables.php:754
-#: includes/variables.php:797
-#: includes/variables.php:839
-#: includes/variables.php:900
-#: includes/variables.php:1063
-#: includes/variables.php:1244
-#: includes/variables.php:1281
-#: includes/variables.php:1305
-#: includes/variables.php:1405
-msgid "LGBTQ"
-msgstr ""
-
-#: includes/variables.php:756
-#: includes/variables.php:841
-#: includes/variables.php:902
-#: includes/variables.php:940
-#: includes/variables.php:1016
-#: includes/variables.php:1065
-#: includes/variables.php:1107
-#: includes/variables.php:1145
-#: includes/variables.php:1181
-#: includes/variables.php:1319
-#: includes/variables.php:1364
-msgid "Meditation"
 msgstr ""
 
 #: includes/variables.php:758
 #: includes/variables.php:904
-#: includes/variables.php:1409
-msgid "Native American"
-msgstr ""
-
-#: includes/variables.php:759
-#: includes/variables.php:800
-#: includes/variables.php:905
-#: includes/variables.php:1067
-#: includes/variables.php:1183
-#: includes/variables.php:1410
-#: includes/variables.php:1455
-msgid "Newcomer"
+#: includes/variables.php:1069
+#: includes/variables.php:1412
+msgid "Korean"
 msgstr ""
 
 #: includes/variables.php:760
-msgid "Non-Binary"
+#: includes/variables.php:806
+#: includes/variables.php:846
+#: includes/variables.php:906
+#: includes/variables.php:1022
+#: includes/variables.php:1070
+#: includes/variables.php:1414
+msgid "Literature"
 msgstr ""
 
-#: includes/variables.php:763
-#: includes/variables.php:803
-msgid "Outdoor Meeting"
+#: includes/variables.php:761
+#: includes/variables.php:907
+#: includes/variables.php:946
+msgid "Living Sober"
 msgstr ""
 
-#: includes/variables.php:765
+#: includes/variables.php:762
+#: includes/variables.php:805
+#: includes/variables.php:847
 #: includes/variables.php:908
 #: includes/variables.php:1071
-#: includes/variables.php:1416
-msgid "Polish"
+#: includes/variables.php:1252
+#: includes/variables.php:1289
+#: includes/variables.php:1313
+#: includes/variables.php:1413
+msgid "LGBTQ"
+msgstr ""
+
+#: includes/variables.php:764
+#: includes/variables.php:849
+#: includes/variables.php:910
+#: includes/variables.php:948
+#: includes/variables.php:1024
+#: includes/variables.php:1073
+#: includes/variables.php:1115
+#: includes/variables.php:1153
+#: includes/variables.php:1189
+#: includes/variables.php:1327
+#: includes/variables.php:1372
+msgid "Meditation"
 msgstr ""
 
 #: includes/variables.php:766
-#: includes/variables.php:909
-#: includes/variables.php:1072
+#: includes/variables.php:912
 #: includes/variables.php:1417
-msgid "Portuguese"
+msgid "Native American"
 msgstr ""
 
 #: includes/variables.php:767
-msgid "Professionals"
+#: includes/variables.php:808
+#: includes/variables.php:913
+#: includes/variables.php:1075
+#: includes/variables.php:1191
+#: includes/variables.php:1418
+#: includes/variables.php:1463
+msgid "Newcomer"
 msgstr ""
 
 #: includes/variables.php:768
-msgid "Proof of Attendance"
-msgstr ""
-
-#: includes/variables.php:769
-#: includes/variables.php:910
-#: includes/variables.php:1073
-#: includes/variables.php:1418
-msgid "Punjabi"
-msgstr ""
-
-#: includes/variables.php:770
-#: includes/variables.php:911
-#: includes/variables.php:1074
-#: includes/variables.php:1420
-msgid "Russian"
+msgid "Non-Binary"
 msgstr ""
 
 #: includes/variables.php:771
-#: includes/variables.php:1023
-msgid "Secular"
-msgstr ""
-
-#: includes/variables.php:772
-#: includes/variables.php:1024
-msgid "Seniors"
+#: includes/variables.php:811
+msgid "Outdoor Meeting"
 msgstr ""
 
 #: includes/variables.php:773
-#: includes/variables.php:795
-#: includes/variables.php:848
-#: includes/variables.php:912
-#: includes/variables.php:1075
-msgid "Sign Language"
+#: includes/variables.php:916
+#: includes/variables.php:1079
+#: includes/variables.php:1424
+msgid "Polish"
+msgstr ""
+
+#: includes/variables.php:774
+#: includes/variables.php:917
+#: includes/variables.php:1080
+#: includes/variables.php:1425
+msgid "Portuguese"
+msgstr ""
+
+#: includes/variables.php:775
+msgid "Professionals"
+msgstr ""
+
+#: includes/variables.php:776
+msgid "Proof of Attendance"
+msgstr ""
+
+#: includes/variables.php:777
+#: includes/variables.php:918
+#: includes/variables.php:1081
+#: includes/variables.php:1426
+msgid "Punjabi"
 msgstr ""
 
 #: includes/variables.php:778
-#: includes/variables.php:917
-#: includes/variables.php:1029
-#: includes/variables.php:1081
-#: includes/variables.php:1374
-msgid "Tradition Study"
+#: includes/variables.php:919
+#: includes/variables.php:1082
+#: includes/variables.php:1428
+msgid "Russian"
+msgstr ""
+
+#: includes/variables.php:779
+#: includes/variables.php:1031
+msgid "Secular"
 msgstr ""
 
 #: includes/variables.php:780
-#: includes/variables.php:813
-#: includes/variables.php:919
-#: includes/variables.php:1031
-#: includes/variables.php:1082
-#: includes/variables.php:1254
-#: includes/variables.php:1291
-#: includes/variables.php:1430
-msgid "Wheelchair Access"
+#: includes/variables.php:1032
+msgid "Seniors"
 msgstr ""
 
 #: includes/variables.php:781
-#: includes/variables.php:814
-#: includes/variables.php:1032
-#: includes/variables.php:1431
-msgid "Wheelchair-Accessible Bathroom"
+#: includes/variables.php:803
+#: includes/variables.php:856
+#: includes/variables.php:920
+#: includes/variables.php:1083
+msgid "Sign Language"
 msgstr ""
 
-#: includes/variables.php:783
-#: includes/variables.php:812
-#: includes/variables.php:860
-#: includes/variables.php:921
-#: includes/variables.php:990
-#: includes/variables.php:1035
-#: includes/variables.php:1084
-#: includes/variables.php:1122
-#: includes/variables.php:1161
-msgid "Young People"
+#: includes/variables.php:786
+#: includes/variables.php:925
+#: includes/variables.php:1037
+#: includes/variables.php:1089
+#: includes/variables.php:1382
+msgid "Tradition Study"
 msgstr ""
 
-#: includes/variables.php:787
-msgid "CMA"
+#: includes/variables.php:788
+#: includes/variables.php:821
+#: includes/variables.php:927
+#: includes/variables.php:1039
+#: includes/variables.php:1090
+#: includes/variables.php:1262
+#: includes/variables.php:1299
+#: includes/variables.php:1438
+msgid "Wheelchair Access"
 msgstr ""
 
 #: includes/variables.php:789
-msgid "Crystal Meth Anonymous"
+#: includes/variables.php:822
+#: includes/variables.php:1040
+#: includes/variables.php:1439
+msgid "Wheelchair-Accessible Bathroom"
 msgstr ""
 
 #: includes/variables.php:791
+#: includes/variables.php:820
+#: includes/variables.php:868
+#: includes/variables.php:929
+#: includes/variables.php:998
+#: includes/variables.php:1043
+#: includes/variables.php:1092
+#: includes/variables.php:1130
+#: includes/variables.php:1169
+msgid "Young People"
+msgstr ""
+
+#: includes/variables.php:795
+msgid "CMA"
+msgstr ""
+
+#: includes/variables.php:797
+msgid "Crystal Meth Anonymous"
+msgstr ""
+
+#: includes/variables.php:799
 msgid "Closed meetings are for C.M.A members only, or for those who have a using problem and “have a desire to stop using.”"
 msgstr ""
 
-#: includes/variables.php:792
+#: includes/variables.php:800
 msgid "Open meetings are available to anyone interested in Crystal Meth Anonymous’ program of recovery from using. Non users may attend open meetings as observers."
 msgstr ""
 
-#: includes/variables.php:801
+#: includes/variables.php:809
 msgid "Online (only)"
 msgstr ""
 
-#: includes/variables.php:818
+#: includes/variables.php:826
 msgid "CoDA"
 msgstr ""
 
-#: includes/variables.php:820
+#: includes/variables.php:828
 msgid "Co-Dependents Anonymous"
 msgstr ""
 
-#: includes/variables.php:827
-#: includes/variables.php:1355
+#: includes/variables.php:835
+#: includes/variables.php:1363
 msgid "Chips"
 msgstr ""
 
-#: includes/variables.php:833
+#: includes/variables.php:841
 msgid "Daily"
 msgstr ""
 
-#: includes/variables.php:845
+#: includes/variables.php:853
 msgid "Q & A"
 msgstr ""
 
-#: includes/variables.php:846
+#: includes/variables.php:854
 msgid "Reading"
 msgstr ""
 
-#: includes/variables.php:847
+#: includes/variables.php:855
 msgid "Sharing"
 msgstr ""
 
-#: includes/variables.php:853
+#: includes/variables.php:861
 msgid "Teens"
 msgstr ""
 
-#: includes/variables.php:854
-#: includes/variables.php:1373
+#: includes/variables.php:862
+#: includes/variables.php:1381
 msgid "Topic Discussion"
 msgstr ""
 
-#: includes/variables.php:855
-#: includes/variables.php:1118
-#: includes/variables.php:1157
+#: includes/variables.php:863
+#: includes/variables.php:1126
+#: includes/variables.php:1165
 msgid "Tradition"
 msgstr ""
 
-#: includes/variables.php:859
-#: includes/variables.php:1034
-#: includes/variables.php:1200
+#: includes/variables.php:867
+#: includes/variables.php:1042
+#: includes/variables.php:1208
 msgid "Writing"
 msgstr ""
 
-#: includes/variables.php:864
+#: includes/variables.php:872
 msgid "CA"
 msgstr ""
 
-#: includes/variables.php:866
+#: includes/variables.php:874
 msgid "Cocaine Anonymous"
 msgstr ""
 
-#: includes/variables.php:868
+#: includes/variables.php:876
 msgid "This meeting is closed; only those who have a desire to stop using may attend."
 msgstr ""
 
-#: includes/variables.php:880
+#: includes/variables.php:888
 msgid "Business"
 msgstr ""
 
-#: includes/variables.php:925
+#: includes/variables.php:933
 msgid "CEA-HOW"
 msgstr ""
 
-#: includes/variables.php:927
+#: includes/variables.php:935
 msgid "Compulsive Eaters Anonymous-HOW"
 msgstr ""
 
-#: includes/variables.php:930
+#: includes/variables.php:938
 msgid "AA Comes of Age"
 msgstr ""
 
-#: includes/variables.php:934
+#: includes/variables.php:942
 msgid "Came to Believe"
 msgstr ""
 
-#: includes/variables.php:935
+#: includes/variables.php:943
 msgid "CEA-HOW Concept/Tools"
 msgstr ""
 
-#: includes/variables.php:937
+#: includes/variables.php:945
 msgid "Happy Joyous and Free"
 msgstr ""
 
-#: includes/variables.php:939
-#: includes/variables.php:1180
+#: includes/variables.php:947
+#: includes/variables.php:1188
 msgid "Maintenance"
 msgstr ""
 
-#: includes/variables.php:941
+#: includes/variables.php:949
 msgid "Pitch/Speaker"
 msgstr ""
 
-#: includes/variables.php:942
+#: includes/variables.php:950
 msgid "Promises"
 msgstr ""
 
-#: includes/variables.php:943
+#: includes/variables.php:951
 msgid "Relapse and Recovery"
 msgstr ""
 
-#: includes/variables.php:944
+#: includes/variables.php:952
 msgid "Steps/Traditions"
 msgstr ""
 
-#: includes/variables.php:945
-#: includes/variables.php:1028
+#: includes/variables.php:953
+#: includes/variables.php:1036
 msgid "Topic/Discussion"
 msgstr ""
 
-#: includes/variables.php:949
+#: includes/variables.php:957
 msgid "DA"
 msgstr ""
 
-#: includes/variables.php:951
+#: includes/variables.php:959
 msgid "Debtors Anonymous"
 msgstr ""
 
-#: includes/variables.php:953
+#: includes/variables.php:961
 msgid "Abundance"
 msgstr ""
 
-#: includes/variables.php:954
+#: includes/variables.php:962
 msgid "Artist"
 msgstr ""
 
-#: includes/variables.php:955
+#: includes/variables.php:963
 msgid "Business Owner"
 msgstr ""
 
-#: includes/variables.php:957
+#: includes/variables.php:965
 msgid "Clutter"
 msgstr ""
 
-#: includes/variables.php:960
+#: includes/variables.php:968
 msgid "Numbers"
 msgstr ""
 
-#: includes/variables.php:963
+#: includes/variables.php:971
 msgid "Prosperity"
 msgstr ""
 
-#: includes/variables.php:965
-#: includes/variables.php:1326
-#: includes/variables.php:1372
-#: includes/variables.php:1424
+#: includes/variables.php:973
+#: includes/variables.php:1334
+#: includes/variables.php:1380
+#: includes/variables.php:1432
 msgid "Step Study"
 msgstr ""
 
-#: includes/variables.php:967
+#: includes/variables.php:975
 msgid "Toolkit"
 msgstr ""
 
-#: includes/variables.php:968
+#: includes/variables.php:976
 msgid "Vision"
 msgstr ""
 
-#: includes/variables.php:974
+#: includes/variables.php:982
 msgid "DAA"
 msgstr ""
 
-#: includes/variables.php:976
+#: includes/variables.php:984
 msgid "Drug Addicts Anonymous"
 msgstr ""
 
-#: includes/variables.php:980
+#: includes/variables.php:988
 msgid "Big Book Study"
 msgstr ""
 
-#: includes/variables.php:988
+#: includes/variables.php:996
 msgid "Step Speaker"
 msgstr ""
 
-#: includes/variables.php:994
+#: includes/variables.php:1002
 msgid "EDA"
 msgstr ""
 
-#: includes/variables.php:996
+#: includes/variables.php:1004
 msgid "Eating Disorders Anonymous"
 msgstr ""
 
-#: includes/variables.php:1001
+#: includes/variables.php:1009
 msgid "Beginners'"
 msgstr ""
 
-#: includes/variables.php:1003
+#: includes/variables.php:1011
 msgid "Chair's Choice"
 msgstr ""
 
-#: includes/variables.php:1006
-#: includes/variables.php:1236
-#: includes/variables.php:1273
-#: includes/variables.php:1394
+#: includes/variables.php:1014
+#: includes/variables.php:1244
+#: includes/variables.php:1281
+#: includes/variables.php:1402
 msgid "Dutch"
 msgstr ""
 
-#: includes/variables.php:1008
-#: includes/variables.php:1241
-#: includes/variables.php:1278
+#: includes/variables.php:1016
+#: includes/variables.php:1249
+#: includes/variables.php:1286
 msgid "German"
 msgstr ""
 
-#: includes/variables.php:1009
+#: includes/variables.php:1017
 msgid "Georgian"
 msgstr ""
 
-#: includes/variables.php:1010
+#: includes/variables.php:1018
 msgid "Greek"
 msgstr ""
 
-#: includes/variables.php:1012
+#: includes/variables.php:1020
 msgid "Icelandic"
 msgstr ""
 
-#: includes/variables.php:1015
+#: includes/variables.php:1023
 msgid "LGBTQ+"
 msgstr ""
 
-#: includes/variables.php:1020
+#: includes/variables.php:1028
 msgid "Outdoor"
 msgstr ""
 
-#: includes/variables.php:1022
+#: includes/variables.php:1030
 msgid "Rotating Format"
 msgstr ""
 
-#: includes/variables.php:1027
-#: includes/variables.php:1115
-#: includes/variables.php:1154
-#: includes/variables.php:1345
+#: includes/variables.php:1035
+#: includes/variables.php:1123
+#: includes/variables.php:1162
+#: includes/variables.php:1353
 msgid "Step"
 msgstr ""
 
-#: includes/variables.php:1039
+#: includes/variables.php:1047
 msgid "GA"
 msgstr ""
 
-#: includes/variables.php:1041
+#: includes/variables.php:1049
 msgid "Gamblers Anonymous"
 msgstr ""
 
-#: includes/variables.php:1043
+#: includes/variables.php:1051
 msgid "This meeting is closed; only those who have a desire to stop gambling may attend."
 msgstr ""
 
-#: includes/variables.php:1046
+#: includes/variables.php:1054
 msgid "20 Questions/Beginner Focus"
 msgstr ""
 
-#: includes/variables.php:1052
+#: includes/variables.php:1060
 msgid "Combined GA/Gam Anon"
 msgstr ""
 
-#: includes/variables.php:1053
+#: includes/variables.php:1061
 msgid "Comment"
 msgstr ""
 
-#: includes/variables.php:1054
+#: includes/variables.php:1062
 msgid "Cross Comment"
 msgstr ""
 
-#: includes/variables.php:1059
+#: includes/variables.php:1067
 msgid "Gam Anon"
 msgstr ""
 
-#: includes/variables.php:1070
+#: includes/variables.php:1078
 msgid "Parking Meters Available"
 msgstr ""
 
-#: includes/variables.php:1080
-#: includes/variables.php:1117
-#: includes/variables.php:1156
-#: includes/variables.php:1196
+#: includes/variables.php:1088
+#: includes/variables.php:1125
+#: includes/variables.php:1164
+#: includes/variables.php:1204
 msgid "Topic"
 msgstr ""
 
-#: includes/variables.php:1088
+#: includes/variables.php:1096
 msgid "HA"
 msgstr ""
 
-#: includes/variables.php:1090
-msgid "Heroin Anonymous"
-msgstr ""
-
-#: includes/variables.php:1092
-#: includes/variables.php:1130
-msgid "12 Concepts"
-msgstr ""
-
-#: includes/variables.php:1093
-#: includes/variables.php:1131
-msgid "Basic Text"
-msgstr ""
-
-#: includes/variables.php:1094
-#: includes/variables.php:1132
-msgid "Beginner/Newcomer"
-msgstr ""
-
-#: includes/variables.php:1096
-#: includes/variables.php:1134
-msgid "Children Welcome"
-msgstr ""
-
 #: includes/variables.php:1098
-#: includes/variables.php:1136
-msgid "Discussion/Participation"
+msgid "Heroin Anonymous"
 msgstr ""
 
 #: includes/variables.php:1100
 #: includes/variables.php:1138
-msgid "IP Study"
+msgid "12 Concepts"
 msgstr ""
 
 #: includes/variables.php:1101
 #: includes/variables.php:1139
-msgid "It Works Study"
+msgid "Basic Text"
 msgstr ""
 
 #: includes/variables.php:1102
 #: includes/variables.php:1140
-msgid "Just For Today Study"
-msgstr ""
-
-#: includes/variables.php:1103
-#: includes/variables.php:1141
-#: includes/variables.php:1178
-msgid "Literature Study"
+msgid "Beginner/Newcomer"
 msgstr ""
 
 #: includes/variables.php:1104
 #: includes/variables.php:1142
-msgid "Living Clean"
+msgid "Children Welcome"
+msgstr ""
+
+#: includes/variables.php:1106
+#: includes/variables.php:1144
+msgid "Discussion/Participation"
 msgstr ""
 
 #: includes/variables.php:1108
 #: includes/variables.php:1146
-msgid "Non-Smoking"
+msgid "IP Study"
+msgstr ""
+
+#: includes/variables.php:1109
+#: includes/variables.php:1147
+msgid "It Works Study"
+msgstr ""
+
+#: includes/variables.php:1110
+#: includes/variables.php:1148
+msgid "Just For Today Study"
 msgstr ""
 
 #: includes/variables.php:1111
 #: includes/variables.php:1149
-msgid "Questions & Answers"
+#: includes/variables.php:1186
+msgid "Literature Study"
 msgstr ""
 
 #: includes/variables.php:1112
 #: includes/variables.php:1150
-msgid "Restricted Access"
-msgstr ""
-
-#: includes/variables.php:1113
-#: includes/variables.php:1151
-msgid "Smoking"
+msgid "Living Clean"
 msgstr ""
 
 #: includes/variables.php:1116
-#: includes/variables.php:1155
-msgid "Step Working Guide Study"
+#: includes/variables.php:1154
+msgid "Non-Smoking"
 msgstr ""
 
 #: includes/variables.php:1119
+#: includes/variables.php:1157
+msgid "Questions & Answers"
+msgstr ""
+
+#: includes/variables.php:1120
 #: includes/variables.php:1158
+msgid "Restricted Access"
+msgstr ""
+
+#: includes/variables.php:1121
+#: includes/variables.php:1159
+msgid "Smoking"
+msgstr ""
+
+#: includes/variables.php:1124
+#: includes/variables.php:1163
+msgid "Step Working Guide Study"
+msgstr ""
+
+#: includes/variables.php:1127
+#: includes/variables.php:1166
 msgid "Format Varies"
 msgstr ""
 
-#: includes/variables.php:1126
+#: includes/variables.php:1134
 msgid "NA"
 msgstr ""
 
-#: includes/variables.php:1128
+#: includes/variables.php:1136
 msgid "Narcotics Anonymous"
 msgstr ""
 
-#: includes/variables.php:1152
+#: includes/variables.php:1160
 msgid "Spiritual Principle a Day"
 msgstr ""
 
-#: includes/variables.php:1165
+#: includes/variables.php:1173
 msgid "OA"
 msgstr ""
 
-#: includes/variables.php:1167
+#: includes/variables.php:1175
 msgid "Overeaters Anonymous"
 msgstr ""
 
-#: includes/variables.php:1169
+#: includes/variables.php:1177
 msgid "11th Step"
 msgstr ""
 
-#: includes/variables.php:1170
+#: includes/variables.php:1178
 msgid "90 Day"
 msgstr ""
 
-#: includes/variables.php:1171
+#: includes/variables.php:1179
 msgid "AA 12/12"
 msgstr ""
 
-#: includes/variables.php:1172
+#: includes/variables.php:1180
 msgid "Ask-It-Basket"
 msgstr ""
 
-#: includes/variables.php:1174
+#: includes/variables.php:1182
 msgid "Dignity of Choice"
 msgstr ""
 
-#: includes/variables.php:1175
+#: includes/variables.php:1183
 msgid "For Today"
 msgstr ""
 
-#: includes/variables.php:1176
+#: includes/variables.php:1184
 msgid "Lifeline"
 msgstr ""
 
-#: includes/variables.php:1177
+#: includes/variables.php:1185
 msgid "Lifeline Sampler"
 msgstr ""
 
-#: includes/variables.php:1182
+#: includes/variables.php:1190
 msgid "New Beginnings"
 msgstr ""
 
-#: includes/variables.php:1184
+#: includes/variables.php:1192
 msgid "OA H.O.W."
 msgstr ""
 
-#: includes/variables.php:1185
+#: includes/variables.php:1193
 msgid "OA Second and/or Third Edition"
 msgstr ""
 
-#: includes/variables.php:1186
+#: includes/variables.php:1194
 msgid "OA Steps and/or Traditions Study"
 msgstr ""
 
-#: includes/variables.php:1188
+#: includes/variables.php:1196
 msgid "Relapse/12th Step Within"
 msgstr ""
 
-#: includes/variables.php:1189
+#: includes/variables.php:1197
 msgid "Seeking the Spiritual Path"
 msgstr ""
 
-#: includes/variables.php:1191
+#: includes/variables.php:1199
 msgid "Speaker/Discussion"
 msgstr ""
 
-#: includes/variables.php:1192
+#: includes/variables.php:1200
 msgid "Spirituality"
 msgstr ""
 
-#: includes/variables.php:1193
+#: includes/variables.php:1201
 msgid "Teen Friendly"
 msgstr ""
 
-#: includes/variables.php:1194
+#: includes/variables.php:1202
 msgid "The Promises"
 msgstr ""
 
-#: includes/variables.php:1195
-#: includes/variables.php:1444
+#: includes/variables.php:1203
+#: includes/variables.php:1452
 msgid "Tools"
 msgstr ""
 
-#: includes/variables.php:1197
+#: includes/variables.php:1205
 msgid "Varies"
 msgstr ""
 
-#: includes/variables.php:1198
+#: includes/variables.php:1206
 msgid "Voices of Recovery"
 msgstr ""
 
-#: includes/variables.php:1199
+#: includes/variables.php:1207
 msgid "Work Book Study"
 msgstr ""
 
-#: includes/variables.php:1210
+#: includes/variables.php:1218
 msgid "RCA"
 msgstr ""
 
-#: includes/variables.php:1212
+#: includes/variables.php:1220
 msgid "Recovering Couples Anonymous"
 msgstr ""
 
-#: includes/variables.php:1222
-#: includes/variables.php:1224
-msgid "Recovery Dharma"
-msgstr ""
-
-#: includes/variables.php:1226
-#: includes/variables.php:1263
-msgid "Men’s meetings are for anyone who identifies as male."
-msgstr ""
-
-#: includes/variables.php:1227
-#: includes/variables.php:1264
-msgid "Women’s meetings are for anyone who identifies as female."
-msgstr ""
-
+#: includes/variables.php:1230
 #: includes/variables.php:1232
-#: includes/variables.php:1269
-#: includes/variables.php:1356
-msgid "Child Care Available"
+msgid "Recovery Dharma"
 msgstr ""
 
 #: includes/variables.php:1234
 #: includes/variables.php:1271
-msgid "Danish"
+msgid "Men’s meetings are for anyone who identifies as male."
 msgstr ""
 
 #: includes/variables.php:1235
 #: includes/variables.php:1272
-msgid "Dog Friendly"
+msgid "Women’s meetings are for anyone who identifies as female."
 msgstr ""
 
-#: includes/variables.php:1237
-#: includes/variables.php:1274
-msgid "Eightfold Path Study"
-msgstr ""
-
-#: includes/variables.php:1239
-#: includes/variables.php:1276
-#: includes/variables.php:1396
-msgid "Finnish"
+#: includes/variables.php:1240
+#: includes/variables.php:1277
+#: includes/variables.php:1364
+msgid "Child Care Available"
 msgstr ""
 
 #: includes/variables.php:1242
-msgid "Inquiry Study"
+#: includes/variables.php:1279
+msgid "Danish"
 msgstr ""
 
 #: includes/variables.php:1243
-msgid "Inquiry Writing"
+#: includes/variables.php:1280
+msgid "Dog Friendly"
+msgstr ""
+
+#: includes/variables.php:1245
+#: includes/variables.php:1282
+msgid "Eightfold Path Study"
 msgstr ""
 
 #: includes/variables.php:1247
 #: includes/variables.php:1284
-msgid "Mindfulness Practice"
+#: includes/variables.php:1404
+msgid "Finnish"
 msgstr ""
 
 #: includes/variables.php:1250
-#: includes/variables.php:1287
+msgid "Inquiry Study"
+msgstr ""
+
+#: includes/variables.php:1251
+msgid "Inquiry Writing"
+msgstr ""
+
+#: includes/variables.php:1255
+#: includes/variables.php:1292
+msgid "Mindfulness Practice"
+msgstr ""
+
+#: includes/variables.php:1258
+#: includes/variables.php:1295
 msgid "Process Addictions"
 msgstr ""
 
-#: includes/variables.php:1252
-#: includes/variables.php:1289
+#: includes/variables.php:1260
+#: includes/variables.php:1297
 msgid "Swedish"
 msgstr ""
 
-#: includes/variables.php:1253
-#: includes/variables.php:1290
-#: includes/variables.php:1426
+#: includes/variables.php:1261
+#: includes/variables.php:1298
+#: includes/variables.php:1434
 msgid "Thai"
 msgstr ""
 
-#: includes/variables.php:1259
-#: includes/variables.php:1261
+#: includes/variables.php:1267
+#: includes/variables.php:1269
 msgid "Refuge Recovery"
 msgstr ""
 
-#: includes/variables.php:1279
+#: includes/variables.php:1287
 msgid "Inventory Study"
 msgstr ""
 
-#: includes/variables.php:1280
+#: includes/variables.php:1288
 msgid "Inventory Writing"
 msgstr ""
 
-#: includes/variables.php:1296
+#: includes/variables.php:1304
 msgid "SAA"
 msgstr ""
 
-#: includes/variables.php:1298
+#: includes/variables.php:1306
 msgid "Sex Addicts Anonymous"
 msgstr ""
 
-#: includes/variables.php:1311
+#: includes/variables.php:1319
 msgid "SA"
 msgstr ""
 
-#: includes/variables.php:1313
+#: includes/variables.php:1321
 msgid "Sexaholics Anonymous"
 msgstr ""
 
-#: includes/variables.php:1321
+#: includes/variables.php:1329
 msgid "Mixed"
 msgstr ""
 
-#: includes/variables.php:1324
+#: includes/variables.php:1332
 msgid "Primary Purpose"
 msgstr ""
 
-#: includes/variables.php:1331
+#: includes/variables.php:1339
 msgid "SCA"
 msgstr ""
 
-#: includes/variables.php:1333
+#: includes/variables.php:1341
 msgid "Sexual Compulsives Anonymous"
 msgstr ""
 
-#: includes/variables.php:1336
+#: includes/variables.php:1344
 msgid "Chip"
 msgstr ""
 
-#: includes/variables.php:1338
+#: includes/variables.php:1346
 msgid "Court"
 msgstr ""
 
-#: includes/variables.php:1340
+#: includes/variables.php:1348
 msgid "Graphic Language"
 msgstr ""
 
-#: includes/variables.php:1349
+#: includes/variables.php:1357
 msgid "SLAA"
 msgstr ""
 
-#: includes/variables.php:1351
+#: includes/variables.php:1359
 msgid "Sex and Love Addicts Anonymous"
 msgstr ""
 
-#: includes/variables.php:1353
+#: includes/variables.php:1361
 msgid "Anorexia Focus"
 msgstr ""
 
-#: includes/variables.php:1359
+#: includes/variables.php:1367
 msgid "Getting Current"
 msgstr ""
 
-#: includes/variables.php:1360
+#: includes/variables.php:1368
 msgid "Handicapped Accessible"
 msgstr ""
 
-#: includes/variables.php:1361
+#: includes/variables.php:1369
 msgid "Healthy Relationships"
 msgstr ""
 
-#: includes/variables.php:1362
+#: includes/variables.php:1370
 msgid "Literature Reading"
 msgstr ""
 
-#: includes/variables.php:1366
+#: includes/variables.php:1374
 msgid "Newcomers"
 msgstr ""
 
-#: includes/variables.php:1369
+#: includes/variables.php:1377
 msgid "Prison"
 msgstr ""
 
-#: includes/variables.php:1384
+#: includes/variables.php:1392
 msgid "SIA"
 msgstr ""
 
-#: includes/variables.php:1386
+#: includes/variables.php:1394
 msgid "Survivors of Incest Anonymous"
 msgstr ""
 
-#: includes/variables.php:1389
+#: includes/variables.php:1397
 msgid "Afrikaans"
 msgstr ""
 
-#: includes/variables.php:1390
+#: includes/variables.php:1398
 msgid "American Sign Language"
 msgstr ""
 
-#: includes/variables.php:1391
+#: includes/variables.php:1399
 msgid "Arabic"
 msgstr ""
 
-#: includes/variables.php:1399
+#: includes/variables.php:1407
 msgid "Genderqueer"
 msgstr ""
 
-#: includes/variables.php:1413
+#: includes/variables.php:1421
 msgid "Open Share Format"
 msgstr ""
 
-#: includes/variables.php:1415
+#: includes/variables.php:1423
 msgid "Persian"
 msgstr ""
 
-#: includes/variables.php:1419
+#: includes/variables.php:1427
 msgid "Ritual Abuse"
 msgstr ""
 
-#: includes/variables.php:1421
+#: includes/variables.php:1429
 msgid "Slovenian"
 msgstr ""
 
-#: includes/variables.php:1425
+#: includes/variables.php:1433
 msgid "Steps Workshop"
 msgstr ""
 
-#: includes/variables.php:1428
+#: includes/variables.php:1436
 msgid "Turkish"
 msgstr ""
 
-#: includes/variables.php:1429
+#: includes/variables.php:1437
 msgid "Ukrainian"
 msgstr ""
 
-#: includes/variables.php:1436
+#: includes/variables.php:1444
 msgid "UA"
 msgstr ""
 
-#: includes/variables.php:1438
+#: includes/variables.php:1446
 msgid "Underearners Anonymous"
 msgstr ""
 
-#: includes/variables.php:1440
+#: includes/variables.php:1448
 msgid "BIPOC"
 msgstr ""
 
-#: includes/variables.php:1449
+#: includes/variables.php:1457
 msgid "VA"
 msgstr ""
 
-#: includes/variables.php:1451
+#: includes/variables.php:1459
 msgid "Violence Anonymous"
 msgstr ""
 
-#: includes/variables.php:1478
+#: includes/variables.php:1486
 msgid "Got an improper response from the server, try refreshing the page."
 msgstr ""
 
-#: includes/variables.php:1479
+#: includes/variables.php:1487
 msgid "Email was not sent."
 msgstr ""
 
-#: includes/variables.php:1480
+#: includes/variables.php:1488
 msgid "Enter a location in the field above."
 msgstr ""
 
-#: includes/variables.php:1481
+#: includes/variables.php:1489
 msgid "Google could not find that location."
 msgstr ""
 
-#: includes/variables.php:1482
+#: includes/variables.php:1490
 msgid "Looking up address…"
 msgstr ""
 
-#: includes/variables.php:1483
+#: includes/variables.php:1491
 msgid "There was an error getting your location."
 msgstr ""
 
-#: includes/variables.php:1484
+#: includes/variables.php:1492
 msgid "Your browser does not appear to support geolocation."
 msgstr ""
 
-#: includes/variables.php:1485
+#: includes/variables.php:1493
 msgid "Finding you…"
 msgstr ""
 
-#: includes/variables.php:1490
+#: includes/variables.php:1498
 msgid "No meetings were found matching the selected criteria."
 msgstr ""
 
@@ -3159,68 +3167,68 @@ msgstr ""
 msgid " to "
 msgstr ""
 
-#: templates/single-meetings.php:151
+#: templates/single-meetings.php:150
 msgid "Join with %s"
 msgstr ""
 
-#: templates/single-meetings.php:167
+#: templates/single-meetings.php:165
 msgid "Join by Phone"
 msgstr ""
 
-#: templates/single-meetings.php:201
+#: templates/single-meetings.php:199
 msgid "7th Tradition"
 msgstr ""
 
-#: templates/single-meetings.php:218
+#: templates/single-meetings.php:215
 msgid "Contribute with %s"
 msgstr ""
 
-#: templates/single-meetings.php:231
+#: templates/single-meetings.php:228
 msgid "%d other meeting at this location"
 msgid_plural "%d other meetings at this location"
 msgstr[0] ""
 msgstr[1] ""
 
-#: templates/single-meetings.php:260
+#: templates/single-meetings.php:257
 msgid "Contact Information"
 msgstr ""
 
-#: templates/single-meetings.php:331
+#: templates/single-meetings.php:326
 msgid "Contact %s"
 msgstr ""
 
-#: templates/single-meetings.php:340
+#: templates/single-meetings.php:335
 msgid "%s’s Email"
 msgstr ""
 
-#: templates/single-meetings.php:352
+#: templates/single-meetings.php:347
 msgid "%s’s Phone"
 msgstr ""
 
-#: templates/single-meetings.php:372
-msgid "This meeting listing is provided by:"
-msgstr ""
-
-#: templates/single-meetings.php:396
-msgid "Request a change to this listing"
-msgstr ""
-
-#: templates/single-meetings.php:404
-msgid "Use this form to submit a change to the meeting information above."
-msgstr ""
-
-#: templates/single-meetings.php:408
-msgid "Your Name"
+#: templates/single-meetings.php:360
+msgid "This listing is provided by:"
 msgstr ""
 
 #: templates/single-meetings.php:413
+msgid "Request a change to this listing"
+msgstr ""
+
+#: templates/single-meetings.php:421
+msgid "Use this form to submit a change to the meeting information above."
+msgstr ""
+
+#: templates/single-meetings.php:425
+msgid "Your Name"
+msgstr ""
+
+#: templates/single-meetings.php:430
 msgid "Email Address"
 msgstr ""
 
-#: templates/single-meetings.php:418
+#: templates/single-meetings.php:435
 msgid "Message"
 msgstr ""
 
-#: templates/single-meetings.php:423
+#: templates/single-meetings.php:440
 msgid "Submit"
 msgstr ""


### PR DESCRIPTION
closes #1348 

enter a Sheet URL (i used [this one](https://docs.google.com/spreadsheets/d/17hg4oj-V_tnRJn5zrRbAAtlEsDM9pN_KeQBUu7QLfy4/edit?gid=0#gid=0) for testing) directly into the importer

leverages new feature in sheets.code4recovery.org - will allow users to do this without signing up for a Google API

show message when using the old, undocumented way (direct API access)

![Screenshot 2024-10-26 at 10-16-40 Import   Export ‹ WordPress Test — WordPress](https://github.com/user-attachments/assets/42c5cd3d-1a10-4c36-a850-a57faa7808f2)
