### PR TITLE
fix counts on region admin screen

### DIFF
--- a/includes/admin_lists.php
+++ b/includes/admin_lists.php
@@ -200,9 +200,13 @@ add_filter('handle_bulk_actions-edit-tsml_meeting', function ($redirect, $doacti
         foreach ($object_ids as $post_id) {
             $meeting = tsml_get_meeting($post_id);
 
-            if ($meeting->attendance_option == 'in_person' || $meeting->attendance_option == 'hybrid') continue;
+            if ($meeting->attendance_option == 'in_person' || $meeting->attendance_option == 'hybrid') {
+                continue;
+            }
 
-            if (empty($meeting->formatted_address) || tsml_geocode($meeting->formatted_address)['approximate'] != 'no') continue;
+            if (empty($meeting->formatted_address) || tsml_geocode($meeting->formatted_address)['approximate'] != 'no') {
+                continue;
+            }
 
             // For each select post, remove TC if it's selected in "types"
             $types = get_post_meta($post_id, 'types', false)[0];
@@ -263,3 +267,46 @@ add_action(
         }
     }
 );
+
+// special global var to store region counts
+$tsml_region_counts = [];
+
+// customizing the "count" column for regions - would be nice if we could use the existing 'posts' column for sorting
+add_filter('manage_edit-tsml_region_columns', function ($columns) {
+    global $wpdb, $tsml_region_counts;
+
+    // get region meeting counts (regions are associated with locations, not meetings)
+    $results = $wpdb->get_results('SELECT 
+        x.term_id, 
+        (SELECT COUNT(*) FROM ' . $wpdb->posts . ' p WHERE p.post_parent IN 
+            (SELECT tr.object_id FROM ' . $wpdb->term_relationships . ' tr WHERE tr.term_taxonomy_id = x.term_taxonomy_id )
+        ) AS meetings
+        FROM wp_term_taxonomy x
+        WHERE x.taxonomy = "tsml_region"');
+    foreach ($results as $result) {
+        $tsml_region_counts[$result->term_id] = $result->meetings;
+    }
+
+    unset($columns['posts']);
+    $columns['meetings'] = __('Meetings', '12-step-meeting-list');
+    return $columns;
+});
+
+// customizing the "count" column for regions
+add_action('manage_tsml_region_custom_column', function ($string, $column_name, $term_id) {
+    global $tsml_region_counts;
+    if ($column_name === 'meetings') {
+        $term = get_term($term_id, 'tsml_region');
+        $query = http_build_query([
+            'post_status' => 'all',
+            'post_type' => 'tsml_meeting',
+            'region' => $term->term_id,
+            'filter_action' => 'Filter',
+            'paged' => 1,
+        ]);
+        return '<a href="' . admin_url("edit.php?$query") . '">' .
+            array_key_exists($term->term_id, $tsml_region_counts) ? $tsml_region_counts[$term->term_id] : '' .
+            '</a>';
+    }
+    return $string;
+}, 10, 3);

--- a/readme.txt
+++ b/readme.txt
@@ -303,6 +303,7 @@ Yes, you will need to know the key name of the field. Then include an array in y
 
 = 3.16.3 =
 * Redirect legacy UI query parameters when using TSML UI [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1461)
+* Fix counts on region admin screen [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1204)
 
 = 3.16.2 =
 * Fix bug when importing types from CSV [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1544)


### PR DESCRIPTION
closes #1204 

regions (as a taxonomy) are connected to locations - this makes the existing "count" that wordpress provides counter-intuitive. this gets the meeting count instead and shows that

also it now links, whether you are searching or not, to the right place

<img width="1009" alt="Screenshot 2024-10-31 at 9 55 17 AM" src="https://github.com/user-attachments/assets/307c8182-babc-4584-be2f-1a9720b1e5ef">

we do lose the ability to sort this screen by count - this seems like a small price to pay though