### PR TITLE
protect TSML UI + widgets against display flex

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -303,6 +303,7 @@ Yes, you will need to know the key name of the field. Then include an array in y
 
 = 3.16.3 =
 * Redirect legacy UI query parameters when using TSML UI [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1461)
+* Fix TSML UI widget layout on some themes [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1427)
 
 = 3.16.2 =
 * Fix bug when importing types from CSV [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1544)

--- a/templates/archive-tsml-ui.php
+++ b/templates/archive-tsml-ui.php
@@ -1,6 +1,9 @@
 <?php
 tsml_header();
 
+// protect against parents using display: flex
+echo '<div>';
+
 if (is_active_sidebar('tsml_meetings_top')) { ?>
     <div class="widgets meetings-widgets meetings-widgets-top" role="complementary">
         <?php dynamic_sidebar('tsml_meetings_top') ?>
@@ -14,5 +17,7 @@ if (is_active_sidebar('tsml_meetings_bottom')) { ?>
         <?php dynamic_sidebar('tsml_meetings_bottom') ?>
     </div>
 <?php }
+
+echo '</div>';
 
 tsml_footer();


### PR DESCRIPTION
close #1427 

GeneratePress (and maybe others) uses `display: flex` on the content parent, which causes TSML UI when used with widgets to show like this:

<img width="1337" alt="Screenshot 2024-11-01 at 7 43 36 AM" src="https://github.com/user-attachments/assets/65d7c75e-7901-49e8-bc60-fea6b52aba78">

wrapping it in a div is the simplest fix

<img width="1727" alt="Screenshot 2024-11-01 at 7 51 02 AM" src="https://github.com/user-attachments/assets/e977e8e2-290a-4a50-bdcb-04497adbb214">