### PR TITLE
close perceived vulnerabilities

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -5,7 +5,7 @@
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Description: Manage a list of recovery meetings
- * Version: 3.16.5
+ * Version: 3.16.6
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -31,7 +31,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 define('TSML_PATH', plugin_dir_path(__FILE__));
 define('TSML_SETTINGS_PERMISSION', 'manage_options');
-define('TSML_VERSION', '3.16.5');
+define('TSML_VERSION', '3.16.6');
 
 // include these files first
 include TSML_PATH . '/includes/filter_meetings.php';

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -2,57 +2,6 @@
 
 // ajax functions
 
-// delete all meetings and locations
-add_action('wp_ajax_tsml_delete', function () {
-    tsml_require_meetings_permission();
-    tsml_delete('everything');
-    die('deleted');
-});
-
-// debug info
-add_action('wp_ajax_tsml_info', 'tsml_ajax_info');
-add_action('wp_ajax_nopriv_tsml_info', 'tsml_ajax_info');
-function tsml_ajax_info()
-{
-    global $tsml_sharing, $tsml_program, $tsml_data_sources, $tsml_google_maps_key, $tsml_mapbox_key, $tsml_sharing_keys,
-    $tsml_contact_display, $tsml_cache_writable, $tsml_feedback_addresses, $tsml_user_interface, $tsml_notification_addresses,
-    $tsml_google_geocoding_key, $tsml_timezone;
-
-    $theme = wp_get_theme();
-
-    $tsml_log = tsml_get_option_array('tsml_log');
-
-    wp_send_json([
-        'language' => get_bloginfo('language'),
-        'log' => array_slice($tsml_log, 0, 25), // limit to 25 events
-        'plugins' => array_map(function ($key) {
-            return explode('/', $key)[0];
-        }, array_keys(get_plugins())),
-        'settings' => [
-            'cache_writable' => $tsml_cache_writable,
-            'contact_display' => $tsml_contact_display,
-            'data_source_count' => count($tsml_data_sources),
-            'feedback_addresses' => count($tsml_feedback_addresses),
-            'has_google_geocoding_key' => !!$tsml_google_geocoding_key,
-            'has_google_maps_key' => !!$tsml_google_maps_key,
-            'has_mapbox_key' => !!$tsml_mapbox_key,
-            'notification_addresses_count' => count($tsml_notification_addresses),
-            'program' => strToUpper($tsml_program),
-            'sharing' => $tsml_sharing,
-            'sharing_keys_count' => count($tsml_sharing_keys),
-            'user_interface' => $tsml_user_interface,
-            'wp_debug' => defined('WP_DEBUG') && WP_DEBUG,
-        ],
-        'theme' => $theme->get_stylesheet(),
-        'theme_parent' => $theme->exists() && $theme->parent() ? $theme->parent()->get_stylesheet() : null,
-        'timezone' => $tsml_timezone,
-        'versions' => [
-            'php' => phpversion(),
-            'tsml' => TSML_VERSION,
-            'wordpress' => get_bloginfo('version'),
-        ],
-    ]);
-}
 
 // ajax for the location typeahead on the meeting edit page
 add_action('wp_ajax_tsml_locations', function () {
@@ -348,10 +297,7 @@ function tsml_ajax_geocode()
 
 // function: get a list of all the geocodes in the database
 // used: for debugging
-add_action('wp_ajax_tsml_geocodes', 'tsml_ajax_geocodes');
-add_action('wp_ajax_nopriv_tsml_geocodes', 'tsml_ajax_geocodes');
-function tsml_ajax_geocodes()
-{
+add_action('wp_ajax_tsml_geocodes', function () {
     global $tsml_google_overrides;
 
     $addresses = tsml_get_option_array('tsml_addresses');
@@ -379,8 +325,10 @@ function tsml_ajax_geocodes()
         }
     }
 
+    ksort($addresses);
+
     wp_send_json($addresses);
-}
+});
 
 // ajax function to import the meetings in the import buffer
 // used by admin_import.php

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -300,6 +300,8 @@ function tsml_ajax_geocode()
 add_action('wp_ajax_tsml_geocodes', function () {
     global $tsml_google_overrides;
 
+    tsml_require_meetings_permission();
+
     $addresses = tsml_get_option_array('tsml_addresses');
 
     // handle get request to remove an address from the cache

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 5.6
 Tested up to: 6.7
-Stable tag: 3.16.5
+Stable tag: 3.16.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -300,6 +300,9 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.16.6 =
+* Handle security vulnerabilities reported by outside service [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1583)
 
 = 3.16.5 =
 * Fix PHP notice about translations [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1582)


### PR DESCRIPTION
close #1583 

we have three ajax helper functions that appear to an outside security audit like they are vulnerabilities:

1. `tsml_delete` allows logged-in users with edit permission to delete everything with an ajax command
2. `tsml_info` helps us diagnose issues on remote sites by knowing what plugins are loaded, and other site metadata
3. `tsml_geocodes` is a helper ui to see and selectively remove cached geocode data

this PR removes the first two, and restricts the third to logged-in users with edit permission