### PR TITLE
fix custom types function, meeting detail page display issues

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -5,7 +5,7 @@
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Description: Manage a list of recovery meetings
- * Version: 3.16.8
+ * Version: 3.16.9
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -31,7 +31,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 define('TSML_PATH', plugin_dir_path(__FILE__));
 define('TSML_SETTINGS_PERMISSION', 'manage_options');
-define('TSML_VERSION', '3.16.8');
+define('TSML_VERSION', '3.16.9');
 
 // include these files first
 include TSML_PATH . '/includes/filter_meetings.php';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -608,11 +608,13 @@ function tsml_custom_post_types()
  */
 function tsml_custom_types($types)
 {
-    global $tsml_programs, $tsml_program;
-    foreach ($types as $key => $value) {
-        $tsml_programs[$tsml_program]['types'][$key] = $value;
-    }
-    asort($tsml_programs[$tsml_program]['types']);
+    add_action('init', function () use ($types) {
+        global $tsml_programs, $tsml_program;
+        foreach ($types as $key => $value) {
+            $tsml_programs[$tsml_program]['types'][$key] = $value;
+        }
+        asort($tsml_programs[$tsml_program]['types']);
+    });
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -304,6 +304,7 @@ Yes, you will need to know the key name of the field. Then include an array in y
 = 3.16.9 =
 * Fix custom types [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1595)
 * Fix address not displaying on meeting detail [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1597)
+* Fix line breaks not showing up on meeting and location notes
 
 = 3.16.8 =
 * Fix compatibility with 12 Step Meeting List Feedback Enhancement plugin [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1592)

--- a/readme.txt
+++ b/readme.txt
@@ -303,6 +303,7 @@ Yes, you will need to know the key name of the field. Then include an array in y
 
 = 3.16.9 =
 * Fix custom types [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1595)
+* Fix address not displaying on meeting detail [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1597)
 
 = 3.16.8 =
 * Fix compatibility with 12 Step Meeting List Feedback Enhancement plugin [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1592)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 5.6
 Tested up to: 6.7
-Stable tag: 3.16.8
+Stable tag: 3.16.9
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -300,6 +300,9 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.16.9 =
+* Fix custom types [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1595)
 
 = 3.16.8 =
 * Fix compatibility with 12 Step Meeting List Feedback Enhancement plugin [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1592)

--- a/templates/single-locations.php
+++ b/templates/single-locations.php
@@ -76,7 +76,7 @@ tsml_header();
 
                                     if ($location->notes) { ?>
                                         <p>
-                                            <?php echo wp_kses(wpautop($location->notes), TSML_ALLOWED_HTML) ?>
+                                            <?php echo wp_kses(wpautop($location->notes), ['br' => [], 'p' => []]) ?>
                                         </p>
                                     <?php } ?>
                                 </li>

--- a/templates/single-locations.php
+++ b/templates/single-locations.php
@@ -120,11 +120,11 @@ tsml_header();
                                                         $meeting_types = tsml_format_types($meeting['types']);
                                                         if (!empty($meeting_types)) { ?>
                                                             <div class="meeting_types">
-                                                                <small>(<?php esc_html($meeting_types) ?>)</small>
+                                                                <small>(<?php echo esc_html($meeting_types) ?>)</small>
                                                             </div>
                                                         <?php } ?>
                                                         <div class="attendance-option">
-                                                            <?php esc_html($tsml_meeting_attendance_options[$meeting['attendance_option']]) ?>
+                                                            <?php echo esc_html($tsml_meeting_attendance_options[$meeting['attendance_option']]) ?>
                                                         </div>
                                                     </li>
                                                 <?php } ?>

--- a/templates/single-meetings.php
+++ b/templates/single-meetings.php
@@ -213,7 +213,7 @@ tsml_header();
                                         <?php } ?>
 
                                         <p class="location-address notranslate">
-                                            <?php esc_html(tsml_format_address($meeting->formatted_address)) ?>
+                                            <?php echo wp_kses(tsml_format_address($meeting->formatted_address), TSML_ALLOWED_HTML) ?>
                                         </p>
 
                                         <?php if (!empty($meeting->location_notes)) { ?>

--- a/templates/single-meetings.php
+++ b/templates/single-meetings.php
@@ -123,7 +123,7 @@ tsml_header();
 
                                     if (!empty($meeting->notes)) { ?>
                                         <section class="meeting-notes">
-                                            <?php echo wp_kses(wpautop($meeting->notes), TSML_ALLOWED_HTML) ?>
+                                            <?php echo wp_kses(wpautop($meeting->notes), ['br' => [], 'p' => []]) ?>
                                         </section>
                                     <?php } ?>
                                 </li>
@@ -218,7 +218,7 @@ tsml_header();
 
                                         <?php if (!empty($meeting->location_notes)) { ?>
                                             <section class="location-notes">
-                                                <?php echo wp_kses(wpautop($meeting->location_notes), TSML_ALLOWED_HTML) ?>
+                                                <?php echo wp_kses(wpautop($meeting->location_notes), ['br' => [], 'p' => []]) ?>
                                             </section>
                                         <?php }
 
@@ -242,7 +242,7 @@ tsml_header();
                                         <?php
                                         if (!empty($meeting->group_notes)) { ?>
                                             <section class="group-notes">
-                                                <?php echo wp_kses(wpautop($meeting->group_notes), TSML_ALLOWED_HTML) ?>
+                                                <?php echo wp_kses(wpautop($meeting->group_notes), ['br' => [], 'p' => []]) ?>
                                             </section>
                                         <?php }
                                         if (!empty($meeting->district)) { ?>


### PR DESCRIPTION
it appears that [this pr](https://github.com/code4recovery/12-step-meeting-list/pull/1574) broke the `tsml_custom_types` function 

context: we were seeing a warning in wordpress that we were calling translations too early - so we moved our program definitions to the `init` hook. however `tsml_custom_types` in a theme's `functions.php` runs before `init`, so those changes were getting overwritten

hopefully this is the right fix for this issue. another option would be to make a global variable for custom types and then import it into our `tsml_load_config()` function and use it at the end to apply the custom types

close #1595

also close #1597 - this was not being output

also fix line breaks not showing up in meeting descriptions