### PR TITLE
normalize special characters for change detection

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -5,7 +5,7 @@
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Description: Manage a list of recovery meetings
- * Version: 3.16.10
+ * Version: 3.16.11
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -31,7 +31,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 define('TSML_PATH', plugin_dir_path(__FILE__));
 define('TSML_SETTINGS_PERMISSION', 'manage_options');
-define('TSML_VERSION', '3.16.10');
+define('TSML_VERSION', '3.16.11');
 
 // include these files first
 include TSML_PATH . '/includes/filter_meetings.php';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1506,7 +1506,7 @@ function tsml_compare_imported_meeting($local_meeting, $import_meeting)
             if (is_object($value) || is_array($value)) {
                 $value = json_encode($value);
             } elseif (null !== $value) {
-                $value = trim(html_entity_decode(strval($value)));
+                $value = trim(html_entity_decode(htmlspecialchars_decode(strval($value), ENT_QUOTES)));
             } else {
                 $value = '';
             }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1506,7 +1506,7 @@ function tsml_compare_imported_meeting($local_meeting, $import_meeting)
             if (is_object($value) || is_array($value)) {
                 $value = json_encode($value);
             } elseif (null !== $value) {
-                $value = trim(html_entity_decode(htmlspecialchars_decode(strval($value), ENT_QUOTES)));
+                $value = trim(htmlspecialchars_decode(html_entity_decode(strval($value)), ENT_QUOTES));
             } else {
                 $value = '';
             }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 7.2
 Tested up to: 6.7
-Stable tag: 3.16.10
+Stable tag: 3.16.11
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -300,6 +300,9 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.16.11 =
+* Fix meetings with apostrophe values always showing up as changed [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1599)
 
 = 3.16.10 =
 * Fix syntax error on PHP 7.2 [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1598)


### PR DESCRIPTION
fix the issue with phantom changes detected in #1599 

need to decode entities when comparing local and remote, or characters like ' show up as `&#39;`