### PR TITLE
fix custom flags and descriptions functions

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -5,7 +5,7 @@
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Description: Manage a list of recovery meetings
- * Version: 3.16.11
+ * Version: 3.16.12
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -31,7 +31,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 define('TSML_PATH', plugin_dir_path(__FILE__));
 define('TSML_SETTINGS_PERMISSION', 'manage_options');
-define('TSML_VERSION', '3.16.11');
+define('TSML_VERSION', '3.16.12');
 
 // include these files first
 include TSML_PATH . '/includes/filter_meetings.php';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -448,8 +448,10 @@ function tsml_custom_addresses($custom_overrides)
  */
 function tsml_custom_descriptions($descriptions)
 {
-    global $tsml_programs, $tsml_program;
-    $tsml_programs[$tsml_program]['type_descriptions'] = $descriptions;
+    add_action('init', function () use ($descriptions) {
+        global $tsml_programs, $tsml_program;
+        $tsml_programs[$tsml_program]['type_descriptions'] = $descriptions;
+    });
 }
 
 /**
@@ -461,8 +463,10 @@ function tsml_custom_descriptions($descriptions)
  */
 function tsml_custom_flags($flags)
 {
-    global $tsml_programs, $tsml_program;
-    $tsml_programs[$tsml_program]['flags'] = $flags;
+    add_action('init', function () use ($flags) {
+        global $tsml_programs, $tsml_program;
+        $tsml_programs[$tsml_program]['flags'] = $flags;
+    });
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 7.2
 Tested up to: 6.7
-Stable tag: 3.16.11
+Stable tag: 3.16.12
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -300,6 +300,10 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.16.12 =
+* New meetings block [more info](https://github.com/code4recovery/12-step-meeting-list/pull/1383)
+* Fix custom type descriptions and flags [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1606)
 
 = 3.16.11 =
 * Fix meetings with apostrophe values always showing up as changed [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1599)


### PR DESCRIPTION
fix #1606 

make these functions use the `init` hook so user customizations are preserved
release prep for `3.16.12`

