### PR TITLE
[Issue-1629] import timeout fix

### DIFF
--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -209,7 +209,7 @@ if (!function_exists('tsml_import_page')) {
                     }
                 } else {
                     // get updated feed import record set 
-                    list($import_meetings, $delete_meeting_ids, $change_log) = tsml_import_get_changed_meetings($meetings, $data_source_url, $data_source_parent_region_id);
+                    list($import_meetings, $delete_meeting_ids, $change_log) = tsml_import_get_changed_meetings($meetings, $data_source_url);
 
                     // drop meetings that weren't found in the import
                     if (count($delete_meeting_ids)) {

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -372,7 +372,11 @@ add_action('wp_ajax_tsml_import', function () {
 
     foreach ($meetings as $meeting) {
         // if meeting id is passed, this is an update vs new meeting
-        $meeting_id = intval(isset($meeting['ID']) ? $meeting['ID'] : 0);
+        $meeting_id = intval(isset($meeting['id']) ? $meeting['id'] : 0);
+        // accept 'id' or 'ID' to reduce confusion later - WP Post uses 'ID'
+        if (!$meeting_id) {
+            $meeting_id = intval(isset($meeting['ID']) ? $meeting['ID'] : $meeting_id);
+        }
         $is_new_meeting = !$meeting_id;
 
         // check address

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -372,11 +372,7 @@ add_action('wp_ajax_tsml_import', function () {
 
     foreach ($meetings as $meeting) {
         // if meeting id is passed, this is an update vs new meeting
-        $meeting_id = intval(isset($meeting['id']) ? $meeting['id'] : 0);
-        // accept 'id' or 'ID' to reduce confusion later - WP Post uses 'ID'
-        if (!$meeting_id) {
-            $meeting_id = intval(isset($meeting['ID']) ? $meeting['ID'] : $meeting_id);
-        }
+        $meeting_id = intval(isset($meeting['ID']) ? $meeting['ID'] : 0);
         $is_new_meeting = !$meeting_id;
 
         // check address

--- a/includes/filter_meetings.php
+++ b/includes/filter_meetings.php
@@ -4,6 +4,7 @@
 class tsml_filter_meetings
 {
 
+    public $data_source;
     public $day;
     public $distance;
     public $distance_units;
@@ -24,6 +25,9 @@ class tsml_filter_meetings
     // sanitize and save arguments (won't be passed to a database)
     public function __construct($arguments)
     {
+        if (!empty($arguments['data_source'])) {
+            $this->data_source = strval($arguments['data_source']);
+        }
 
         if (!empty($arguments['day']) || (isset($arguments['day']) && $arguments['day'] == 0)) {
             $this->day = is_array($arguments['day']) ? array_map('intval', $arguments['day']) : [intval($arguments['day'])];
@@ -105,6 +109,10 @@ class tsml_filter_meetings
     {
 
         // run filters
+        if ($this->data_source) {
+            $meetings = array_filter($meetings, [$this, 'filter_data_source']);
+        }
+
         if ($this->day) {
             $meetings = array_filter($meetings, [$this, 'filter_day']);
         }
@@ -167,6 +175,12 @@ class tsml_filter_meetings
 
         $meeting['distance'] = round($meeting['distance'], 1);
         return $meeting;
+    }
+
+    // callback function to pass to array_filter
+    public function filter_data_source($meeting)
+    {
+        return isset($meeting['data_source']) ? ($this->data_source === $meeting['data_source']) : false;
     }
 
     // callback function to pass to array_filter

--- a/includes/functions_get.php
+++ b/includes/functions_get.php
@@ -597,6 +597,7 @@ function tsml_get_meetings($arguments = [], $from_cache = true, $full_export = f
     // check if we are filtering
     $allowed = [
         'mode',
+        'data_source',
         'day',
         'time',
         'region',

--- a/includes/functions_get.php
+++ b/includes/functions_get.php
@@ -468,7 +468,7 @@ function tsml_get_meetings($arguments = [], $from_cache = true, $full_export = f
                 'updated' => $post->post_modified_gmt,
                 'location_id' => $post->post_parent,
                 'url' => get_permalink($post->ID),
-                'day' => @$meeting_meta[$post->ID]['day'],
+                'day' => isset($meeting_meta[$post->ID]['day']) ? $meeting_meta[$post->ID]['day'] : null,
                 'time' => isset($meeting_meta[$post->ID]['time']) ? $meeting_meta[$post->ID]['time'] : null,
                 'end_time' => isset($meeting_meta[$post->ID]['end_time']) ? $meeting_meta[$post->ID]['end_time'] : null,
                 'time_formatted' => isset($meeting_meta[$post->ID]['time']) ? tsml_format_time($meeting_meta[$post->ID]['time']) : null,

--- a/includes/functions_import.php
+++ b/includes/functions_import.php
@@ -125,12 +125,8 @@ function tsml_import_get_changed_meetings($feed_meetings, $data_source_url)
             $source_meeting_id = array_search($feed_meeting_slug, $meeting_slugs_map);
         }
         if ($source_meeting_id) {
-            foreach ($source_meetings as $meeting) {
-                if (isset($meeting['id']) && $meeting['id'] === $source_meeting_id) {
-                    $source_meeting = $meeting;
-                    break;
-                }
-            }
+            $source_meeting_index = array_search($source_meeting_id, $meeting_ids);
+            $source_meeting = ($source_meeting_index !== false) ? $source_meetings[$source_meeting_index] : null;
         }
         // if we found a local meeting, compare for update need
         if ($source_meeting) {
@@ -166,7 +162,7 @@ function tsml_import_get_changed_meetings($feed_meetings, $data_source_url)
     $delete_meeting_ids = array_diff($meeting_ids, $found_meeting_ids);
     // add to change log
     foreach ($delete_meeting_ids as $delete_meeting_id) {
-        $source_meeting_index = array_search($delete_meeting_id, array_column($source_meetings, 'id'));
+        $source_meeting_index = array_search($delete_meeting_id, $meeting_ids);
         $delete_meeting = ($source_meeting_index !== false) ? $source_meetings[$source_meeting_index] : null;
         $change_log[] = array(
             'action' => 'remove',

--- a/includes/functions_import.php
+++ b/includes/functions_import.php
@@ -147,8 +147,8 @@ function tsml_import_get_changed_meetings($feed_meetings, $data_source_url)
                     'meeting_id' => $source_meeting_id,
                 );
 
-                // add `id` field to meeting to trigger an existing post update versus new post insert
-                $feed_meeting['id'] = $source_meeting_id;
+                // add `ID` field to meeting to trigger an existing post update versus new post insert
+                $feed_meeting['ID'] = $source_meeting_id;
                 $import_meetings[] = $feed_meeting;
             }
         } else {

--- a/readme.txt
+++ b/readme.txt
@@ -303,6 +303,7 @@ Yes, you will need to know the key name of the field. Then include an array in y
 
 = 3.16.14 =
 * Fix sorting by distance in Legacy UI [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1619)
+* Updated meeting import comparison to bulk query meetings / run quicker [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1629)
 
 = 3.16.13 =
 * Fix issue saving online-only meetings with specific addresses [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1614)


### PR DESCRIPTION
Meant to resolve #1629 

Users with a large meeting lists are seeing 2 minute import refresh times that time out execution. This is to resolve that issue by replacing the individual `tsml_get_meeting()` calls which are slow with a `tsml_get_meetings()` for the entire import data source.