### PR TITLE
add standardized list of languages with backward compatibility

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -5,7 +5,7 @@
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Description: Manage a list of recovery meetings
- * Version: 3.16.16
+ * Version: 3.16.17
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -31,7 +31,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 define('TSML_PATH', plugin_dir_path(__FILE__));
 define('TSML_SETTINGS_PERMISSION', 'manage_options');
-define('TSML_VERSION', '3.16.16');
+define('TSML_VERSION', '3.16.17');
 
 // include these files first
 include TSML_PATH . '/includes/filter_meetings.php';

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -43,6 +43,10 @@ add_action('admin_init', function () {
 
         $meeting = tsml_get_meeting();
 
+        $languages = tsml_languages();
+
+        $user_language = strtoupper(substr(get_user_locale(), 0, 2));
+
         // time is before the end of april and not currently using temporary closure
         if (!in_array('TC', $tsml_types_in_use) && time() < strtotime('2020-04-30')) {
             tsml_alert('Please note: a new “Temporary Closure” meeting type has recently been added. Use this to indicate meetings that are temporarily not meeting. Find it under “View all” below.', 'warning');
@@ -89,7 +93,7 @@ add_action('admin_init', function () {
                     class="checkboxes<?php if (!empty($tsml_types_in_use) && count($tsml_types_in_use) !== count($tsml_programs[$tsml_program]['types'])) { ?> has_more<?php } ?>">
                     <?php
                     foreach ($tsml_programs[$tsml_program]['types'] as $key => $type) {
-                        if ($key == 'ONL' || $key == 'TC') {
+                        if ($key == 'ONL' || $key == 'TC' || array_key_exists($key, $languages)) {
                             // hide "Online Meeting" since it's not manually settable, neither is location Temporarily Closed
                             continue;
                         }
@@ -116,6 +120,34 @@ add_action('admin_init', function () {
                 </div>
             </div>
         <?php } ?>
+        <div class="meta_form_row">
+            <label for="languages">
+                <?php esc_html_e('Languages', '12-step-meeting-list') ?>
+            </label>
+            <div
+                class="checkboxes<?php if (!empty($tsml_types_in_use) && count($tsml_types_in_use) !== count($tsml_programs[$tsml_program]['types'])) { ?> has_more<?php } ?>">
+                <?php foreach ($languages as $key => $type) { ?>
+                    <label <?php if (!empty($tsml_types_in_use) && !in_array($key, $tsml_types_in_use) && $key !== $user_language) {
+                        echo ' class="not_in_use"';
+                    } ?>>
+                        <input type="checkbox" name="types[]" value="<?php echo esc_attr($key) ?>" <?php checked(in_array($key, @$meeting->types)) ?>>
+                        <?php echo esc_html($type) ?>
+                    </label>
+                <?php } ?>
+                <div class="toggle_more">
+                    <div class="more">
+                        <span class="dashicons dashicons-arrow-down-alt2"></span> <a href="#more-types">
+                            <?php esc_html_e('View all', '12-step-meeting-list') ?>
+                        </a>
+                    </div>
+                    <div class="less">
+                        <span class="dashicons dashicons-arrow-up-alt2"></span> <a href="#more-types">
+                            <?php esc_html_e('Hide languages not in use', '12-step-meeting-list') ?>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
         <div class="meta_form_row">
             <label for="content">
                 <?php esc_html_e('Notes', '12-step-meeting-list') ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -986,7 +986,145 @@ function tsml_meeting_types($types)
     }
     sort($return);
     return implode(', ', $return);
+}
 
+/**
+ * return an array of languages, with legacy code substitutions per-program
+ * used: variables.php, meeting-edit.php
+ */
+function tsml_languages($types = [])
+{
+    global $tsml_program;
+
+    // https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
+    $languages = [
+        'AF' => __('Afrikaans', '12-step-meeting-list'),
+        'AM' => __('Amharic', '12-step-meeting-list'),
+        'AR' => __('Arabic', '12-step-meeting-list'),
+        'BG' => __('Bulgarian', '12-step-meeting-list'),
+        'BN' => __('Bengali', '12-step-meeting-list'),
+        'BS' => __('Bosnian', '12-step-meeting-list'),
+        'CS' => __('Czech', '12-step-meeting-list'),
+        'DA' => __('Danish', '12-step-meeting-list'),
+        'DE' => __('German', '12-step-meeting-list'),
+        'EL' => __('Greek', '12-step-meeting-list'),
+        'EN' => __('English', '12-step-meeting-list'),
+        'ES' => __('Spanish', '12-step-meeting-list'),
+        'ET' => __('Estonian', '12-step-meeting-list'),
+        'FA' => __('Persian', '12-step-meeting-list'),
+        'FI' => __('Finnish', '12-step-meeting-list'),
+        'FR' => __('French', '12-step-meeting-list'),
+        'HE' => __('Hebrew', '12-step-meeting-list'),
+        'HI' => __('Hindi', '12-step-meeting-list'),
+        'HR' => __('Croatian', '12-step-meeting-list'),
+        'HU' => __('Hungarian', '12-step-meeting-list'),
+        'ID' => __('Indonesian', '12-step-meeting-list'),
+        'IS' => __('Icelandic', '12-step-meeting-list'),
+        'IT' => __('Italian', '12-step-meeting-list'),
+        'JA' => __('Japanese', '12-step-meeting-list'),
+        'KA' => __('Georgian', '12-step-meeting-list'),
+        'KO' => __('Korean', '12-step-meeting-list'),
+        'LT' => __('Lithuanian', '12-step-meeting-list'),
+        'LV' => __('Latvian', '12-step-meeting-list'),
+        'MK' => __('Macedonian', '12-step-meeting-list'),
+        'MS' => __('Malay', '12-step-meeting-list'),
+        'NO' => __('Norwegian', '12-step-meeting-list'),
+        'NL' => __('Dutch', '12-step-meeting-list'),
+        'PL' => __('Polish', '12-step-meeting-list'),
+        'PT' => __('Portuguese', '12-step-meeting-list'),
+        'PA' => __('Punjabi', '12-step-meeting-list'),
+        'RO' => __('Romanian', '12-step-meeting-list'),
+        'RU' => __('Russian', '12-step-meeting-list'),
+        'SK' => __('Slovak', '12-step-meeting-list'),
+        'SL' => __('Slovenian', '12-step-meeting-list'),
+        'SQ' => __('Albanian', '12-step-meeting-list'),
+        'SR' => __('Serbian', '12-step-meeting-list'),
+        'SV' => __('Swedish', '12-step-meeting-list'),
+        'SW' => __('Swahili', '12-step-meeting-list'),
+        'TH' => __('Thai', '12-step-meeting-list'),
+        'TL' => __('Tagalog', '12-step-meeting-list'),
+        'TR' => __('Turkish', '12-step-meeting-list'),
+        'UK' => __('Ukrainian', '12-step-meeting-list'),
+        'VI' => __('Vietnamese', '12-step-meeting-list'),
+        'ZH' => __('Chinese', '12-step-meeting-list'),
+    ];
+
+    // substitutions
+    $substitutions = [
+        'aca' => [
+            'ES' => 'SP',
+        ],
+        'al-anon' => [
+            'ES' => 'S',
+        ],
+        'aa' => [
+            'ES' => 'S',
+            'IT' => 'ITA',
+            'KO' => 'KOR',
+            'PA' => 'PUN',
+            'PL' => 'POL',
+            'PT' => 'POR',
+            'RU' => 'RUS',
+            'TR' => 'TUR',
+        ],
+        'ca' => [
+            'ES' => 'S',
+            'IT' => 'ITA',
+            'KO' => 'KOR',
+            'PA' => 'PUN',
+            'PL' => 'POL',
+            'PT' => 'POR',
+            'RU' => 'RUS',
+        ],
+        'cma' => [
+            'ES' => 'S',
+        ],
+        'coda' => [
+            'ES' => 'S',
+        ],
+        'eda' => [
+            'ES' => 'S',
+            'IT' => 'ITA',
+        ],
+        'ga' => [
+            'ES' => 'S',
+            'IT' => 'ITA',
+            'KO' => 'KOR',
+            'PA' => 'PUN',
+            'PL' => 'POL',
+            'PT' => 'POR',
+            'RU' => 'RUS',
+        ],
+        'slaa' => [
+            'ES' => 'S',
+        ],
+        'sia' => [
+            'ES' => 'S',
+            'IT' => 'ITA',
+            'KO' => 'KOR',
+            'PA' => 'PUN',
+            'PL' => 'POL',
+            'PT' => 'POR',
+            'RU' => 'RUS',
+            'UK' => 'UA',
+        ],
+    ];
+
+    // if the program has no types, return the languages
+    if (array_key_exists($tsml_program, $substitutions)) {
+        foreach ($substitutions[$tsml_program] as $key => $value) {
+            if (array_key_exists($key, $languages)) {
+                $languages[$value] = $languages[$key];
+                unset($languages[$key]);
+            }
+        }
+    }
+
+    $languages = array_merge($types, $languages);
+
+    asort($languages);
+
+    return $languages;
 }
 
 /**

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -677,7 +677,7 @@ function tsml_load_config()
                 'C' => __('This meeting is closed; only those who have a desire to recover from the effects of growing up in an alcoholic or otherwise dysfunctional family may attend.', '12-step-meeting-list'),
                 'O' => __('This meeting is open and anyone may attend.', '12-step-meeting-list'),
             ],
-            'types' => [
+            'types' => tsml_languages([
                 'ANH' => __('A New Hope', '12-step-meeting-list'),
                 'A' => __('Age Restricted 18+', '12-step-meeting-list'),
                 'AV' => __('Audio / Visual', '12-step-meeting-list'),
@@ -702,7 +702,6 @@ function tsml_load_config()
                 'O' => __('Open', '12-step-meeting-list'),
                 'ASL' => __('Sign Language ASL', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
-                'SP' => __('Spanish', '12-step-meeting-list'),
                 'S' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Steps', '12-step-meeting-list'),
                 'SMR' => __('Strengthening My Recovery', '12-step-meeting-list'),
@@ -713,7 +712,7 @@ function tsml_load_config()
                 'WOR' => __('Workshop', '12-step-meeting-list'),
                 'Y' => __('Yellow Workbook Study', '12-step-meeting-list'),
                 'YA' => __('Young Adult (Ages 18 to 26)', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'al-anon' => [
             'abbr' => __('Al-Anon', '12-step-meeting-list'),
@@ -723,7 +722,7 @@ function tsml_load_config()
                 'C' => __('Closed Meetings are limited to members and prospective members. These are persons who feel their lives have been or are being affected by alcoholism in a family member or friend.', '12-step-meeting-list'),
                 'O' => __('Open to anyone interested in the family disease of alcoholism. Some groups invite members of the professional community to hear how the Al-Anon program aids in recovery.', '12-step-meeting-list'),
             ],
-            'types' => [
+            'types' => tsml_languages([
                 'AC' => __('Adult Child Focus', '12-step-meeting-list'),
                 'Y' => __('Alateen', '12-step-meeting-list'),
                 'A' => __('Atheist / Agnostic', '12-step-meeting-list'),
@@ -731,7 +730,6 @@ function tsml_load_config()
                 'BE' => __('Beginner', '12-step-meeting-list'),
                 'AA' => __('Concurrent with AA Meeting', '12-step-meeting-list'),
                 'AL' => __('Concurrent with Alateen Meeting', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
                 'O' => __('Families Friends and Observers Welcome', '12-step-meeting-list'),
                 'C' => __('Families and Friends Only', '12-step-meeting-list'),
                 'FF' => __('Fragrance Free', '12-step-meeting-list'),
@@ -744,14 +742,13 @@ function tsml_load_config()
                 'POA' => __('Parents of Alcoholics', '12-step-meeting-list'),
                 'POC' => __('People of Color', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Meeting', '12-step-meeting-list'),
                 'T' => __('Transgender', '12-step-meeting-list'),
                 'X' => __('Wheelchair Accessible', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
                 'YA' => __('Young Adults', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'aa' => [
             'abbr' => __('AA', '12-step-meeting-list'),
@@ -761,7 +758,7 @@ function tsml_load_config()
                 'C' => __('Closed meetings are for A.A. members only, or for those who have a drinking problem and “have a desire to stop drinking.”', '12-step-meeting-list'),
                 'O' => __('Open meetings are available to anyone interested in Alcoholics Anonymous’ program of recovery from alcoholism. Nonalcoholics may attend open meetings as observers.', '12-step-meeting-list'),
             ],
-            'types' => [
+            'types' => tsml_languages([
                 '11' => __('11th Step Meditation', '12-step-meeting-list'),
                 '12x12' => __('12 Steps & 12 Traditions', '12-step-meeting-list'),
                 'ABSI' => __('As Bill Sees It', '12-step-meeting-list'),
@@ -779,17 +776,10 @@ function tsml_load_config()
                 'DB' => __('Digital Basket', '12-step-meeting-list'),
                 'D' => __('Discussion', '12-step-meeting-list'),
                 'DD' => __('Dual Diagnosis', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
-                'FI' => __('Finnish', '12-step-meeting-list'),
                 'FF' => __('Fragrance Free', '12-step-meeting-list'),
-                'FR' => __('French', '12-step-meeting-list'),
                 'G' => __('Gay', '12-step-meeting-list'),
                 'GR' => __('Grapevine', '12-step-meeting-list'),
-                'HE' => __('Hebrew', '12-step-meeting-list'),
                 'NDG' => __('Indigenous', '12-step-meeting-list'),
-                'ITA' => __('Italian', '12-step-meeting-list'),
-                'JA' => __('Japanese', '12-step-meeting-list'),
-                'KOR' => __('Korean', '12-step-meeting-list'),
                 'L' => __('Lesbian', '12-step-meeting-list'),
                 'LIT' => __('Literature', '12-step-meeting-list'),
                 'LS' => __('Living Sober', '12-step-meeting-list'),
@@ -804,17 +794,12 @@ function tsml_load_config()
                 'O' => __('Open', '12-step-meeting-list'),
                 'OUT' => __('Outdoor Meeting', '12-step-meeting-list'),
                 'POC' => __('People of Color', '12-step-meeting-list'),
-                'POL' => __('Polish', '12-step-meeting-list'),
-                'POR' => __('Portuguese', '12-step-meeting-list'),
                 'P' => __('Professionals', '12-step-meeting-list'),
                 'POA' => __('Proof of Attendance', '12-step-meeting-list'),
-                'PUN' => __('Punjabi', '12-step-meeting-list'),
-                'RUS' => __('Russian', '12-step-meeting-list'),
                 'A' => __('Secular', '12-step-meeting-list'),
                 'SEN' => __('Seniors', '12-step-meeting-list'),
                 'ASL' => __('Sign Language', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Meeting', '12-step-meeting-list'),
                 'TR' => __('Tradition Study', '12-step-meeting-list'),
@@ -823,7 +808,7 @@ function tsml_load_config()
                 'XB' => __('Wheelchair-Accessible Bathroom', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
                 'Y' => __('Young People', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'cma' => [
             'abbr' => __('CMA', '12-step-meeting-list'),
@@ -833,7 +818,7 @@ function tsml_load_config()
                 'C' => __('Closed meetings are for C.M.A members only, or for those who have a using problem and “have a desire to stop using.”', '12-step-meeting-list'),
                 'O' => __('Open meetings are available to anyone interested in Crystal Meth Anonymous’ program of recovery from using. Non users may attend open meetings as observers.', '12-step-meeting-list'),
             ],
-            'types' => [
+            'types' => tsml_languages([
                 'ASL' => __('Sign Language', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ', '12-step-meeting-list'),
@@ -845,7 +830,6 @@ function tsml_load_config()
                 'OUT' => __('Outdoor Meeting', '12-step-meeting-list'),
                 'POC' => __('People of Color', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Meeting', '12-step-meeting-list'),
                 'T' => __('Transgender', '12-step-meeting-list'),
@@ -854,13 +838,13 @@ function tsml_load_config()
                 'Y' => __('Young People', '12-step-meeting-list'),
                 'X' => __('Wheelchair Access', '12-step-meeting-list'),
                 'XB' => __('Wheelchair-Accessible Bathroom', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'coda' => [
             'abbr' => __('CoDA', '12-step-meeting-list'),
             'flags' => ['M', 'W', 'TC', 'ONL'], // for /men and /women at end of meeting name (used in tsml_format_name())
             'name' => __('Co-Dependents Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 'A' => __('Atheist / Agnostic', '12-step-meeting-list'),
                 'BA' => __('Babysitting Available', '12-step-meeting-list'),
                 'BE' => __('Beginner', '12-step-meeting-list'),
@@ -889,7 +873,6 @@ function tsml_load_config()
                 'SHARE' => __('Sharing', '12-step-meeting-list'),
                 'ASL' => __('Sign Language', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Meeting', '12-step-meeting-list'),
                 'TEEN' => __('Teens', '12-step-meeting-list'),
@@ -900,7 +883,7 @@ function tsml_load_config()
                 'W' => __('Women', '12-step-meeting-list'),
                 'WRITE' => __('Writing', '12-step-meeting-list'),
                 'Y' => __('Young People', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'ca' => [
             'abbr' => __('CA', '12-step-meeting-list'),
@@ -910,7 +893,7 @@ function tsml_load_config()
                 'C' => __('This meeting is closed; only those who have a desire to stop using may attend.', '12-step-meeting-list'),
                 'O' => __('This meeting is open and anyone may attend.', '12-step-meeting-list'),
             ],
-            'types' => [
+            'types' => tsml_languages([
                 '11' => __('11th Step Meditation', '12-step-meeting-list'),
                 '12x12' => __('12 Steps & 12 Traditions', '12-step-meeting-list'),
                 'ABSI' => __('As Bill Sees It', '12-step-meeting-list'),
@@ -929,13 +912,9 @@ function tsml_load_config()
                 'DR' => __('Daily Reflections', '12-step-meeting-list'),
                 'D' => __('Discussion', '12-step-meeting-list'),
                 'DD' => __('Dual Diagnosis', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
                 'FF' => __('Fragrance Free', '12-step-meeting-list'),
-                'FR' => __('French', '12-step-meeting-list'),
                 'G' => __('Gay', '12-step-meeting-list'),
                 'GR' => __('Grapevine', '12-step-meeting-list'),
-                'ITA' => __('Italian', '12-step-meeting-list'),
-                'KOR' => __('Korean', '12-step-meeting-list'),
                 'L' => __('Lesbian', '12-step-meeting-list'),
                 'LIT' => __('Literature', '12-step-meeting-list'),
                 'LS' => __('Living Sober', '12-step-meeting-list'),
@@ -947,13 +926,8 @@ function tsml_load_config()
                 'BE' => __('Newcomer', '12-step-meeting-list'),
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
-                'POL' => __('Polish', '12-step-meeting-list'),
-                'POR' => __('Portuguese', '12-step-meeting-list'),
-                'PUN' => __('Punjabi', '12-step-meeting-list'),
-                'RUS' => __('Russian', '12-step-meeting-list'),
                 'ASL' => __('Sign Language', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Meeting', '12-step-meeting-list'),
                 'TR' => __('Tradition Study', '12-step-meeting-list'),
@@ -961,13 +935,13 @@ function tsml_load_config()
                 'X' => __('Wheelchair Access', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
                 'Y' => __('Young People', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'cea-how' => [
             'abbr' => __('CEA-HOW', '12-step-meeting-list'),
             'flags' => [], // for /men and /women at end of meeting name (used in tsml_format_name())
             'name' => __('Compulsive Eaters Anonymous-HOW', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 '12x12' => __('12 Steps & 12 Traditions', '12-step-meeting-list'),
                 'AACOA' => __('AA Comes of Age', '12-step-meeting-list'),
                 'ABSI' => __('As Bill Sees It', '12-step-meeting-list'),
@@ -985,13 +959,13 @@ function tsml_load_config()
                 'RANDR' => __('Relapse and Recovery', '12-step-meeting-list'),
                 'ST' => __('Steps/Traditions', '12-step-meeting-list'),
                 'D' => __('Topic/Discussion', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'da' => [
             'abbr' => __('DA', '12-step-meeting-list'),
             'flags' => ['M', 'W', 'TC', 'ONL'], // for /men and /women at end of meeting name (used in tsml_format_name())
             'name' => __('Debtors Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 'AB' => __('Abundance', '12-step-meeting-list'),
                 'AR' => __('Artist', '12-step-meeting-list'),
                 'B' => __('Business Owner', '12-step-meeting-list'),
@@ -1010,13 +984,13 @@ function tsml_load_config()
                 'V' => __('Vision', '12-step-meeting-list'),
                 'X' => __('Wheelchair Accessible', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'daa' => [
             'abbr' => __('DAA', '12-step-meeting-list'),
             'flags' => ['M', 'W', 'TC', 'ONL'], // for /men and /women at end of meeting name (used in tsml_format_name())
             'name' => __('Drug Addicts Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 '12x12' => __('12 Steps & 12 Traditions', '12-step-meeting-list'),
                 'BA' => __('Babysitting Available', '12-step-meeting-list'),
                 'B' => __('Big Book Study', '12-step-meeting-list'),
@@ -1030,13 +1004,13 @@ function tsml_load_config()
                 'SS' => __('Step Speaker', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
                 'YP' => __('Young People', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'eda' => [
             'abbr' => __('EDA', '12-step-meeting-list'),
             'flags' => ['M', 'W', 'TC', 'ONL'], // for /men and /women at end of meeting name (used in tsml_format_name())
             'name' => __('Eating Disorders Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'daa' => tsml_languages([
                 '11' => __('11th Step Meditation', '12-step-meeting-list'),
                 '12x12' => __('12 Steps & 12 Traditions', '12-step-meeting-list'),
                 'BA' => __('Babysitting Available', '12-step-meeting-list'),
@@ -1045,14 +1019,7 @@ function tsml_load_config()
                 'CC' => __('Chair\'s Choice', '12-step-meeting-list'),
                 'CF' => __('Child-Friendly', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
-                'NL' => __('Dutch', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
-                'DE' => __('German', '12-step-meeting-list'),
-                'KA' => __('Georgian', '12-step-meeting-list'),
-                'EL' => __('Greek', '12-step-meeting-list'),
                 'NDG' => __('Indigenous', '12-step-meeting-list'),
-                'IS' => __('Icelandic', '12-step-meeting-list'),
-                'ITA' => __('Italian', '12-step-meeting-list'),
                 'LIT' => __('Literature', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ+', '12-step-meeting-list'),
                 'MED' => __('Meditation', '12-step-meeting-list'),
@@ -1064,7 +1031,6 @@ function tsml_load_config()
                 'RF' => __('Rotating Format', '12-step-meeting-list'),
                 'A' => __('Secular', '12-step-meeting-list'),
                 'SEN' => __('Seniors', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step', '12-step-meeting-list'),
                 'TO' => __('Topic/Discussion', '12-step-meeting-list'),
@@ -1075,7 +1041,7 @@ function tsml_load_config()
                 'W' => __('Women', '12-step-meeting-list'),
                 'WR' => __('Writing', '12-step-meeting-list'),
                 'Y' => __('Young People', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'ga' => [
             'abbr' => __('GA', '12-step-meeting-list'),
@@ -1084,7 +1050,7 @@ function tsml_load_config()
             'type_descriptions' => [
                 'C' => __('This meeting is closed; only those who have a desire to stop gambling may attend.', '12-step-meeting-list'),
             ],
-            'types' => [
+            'types' => tsml_languages([
                 '20' => __('20 Questions/Beginner Focus', '12-step-meeting-list'),
                 'BA' => __('Babysitting Available', '12-step-meeting-list'),
                 'B' => __('Big Book', '12-step-meeting-list'),
@@ -1096,11 +1062,7 @@ function tsml_load_config()
                 'CRC' => __('Cross Comment', '12-step-meeting-list'),
                 'DR' => __('Daily Reflections', '12-step-meeting-list'),
                 'D' => __('Discussion', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
-                'FR' => __('French', '12-step-meeting-list'),
                 'GAM' => __('Gam Anon', '12-step-meeting-list'),
-                'ITA' => __('Italian', '12-step-meeting-list'),
-                'KOR' => __('Korean', '12-step-meeting-list'),
                 'LIT' => __('Literature', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ', '12-step-meeting-list'),
                 'TC' => __('Location Temporarily Closed', '12-step-meeting-list'),
@@ -1110,13 +1072,8 @@ function tsml_load_config()
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
                 'PAR' => __('Parking Meters Available', '12-step-meeting-list'),
-                'POL' => __('Polish', '12-step-meeting-list'),
-                'POR' => __('Portuguese', '12-step-meeting-list'),
-                'PUN' => __('Punjabi', '12-step-meeting-list'),
-                'RUS' => __('Russian', '12-step-meeting-list'),
                 'ASL' => __('Sign Language', '12-step-meeting-list'),
                 'SM' => __('Smoking Permitted', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Meeting', '12-step-meeting-list'),
                 'TOP' => __('Topic', '12-step-meeting-list'),
@@ -1124,13 +1081,13 @@ function tsml_load_config()
                 'X' => __('Wheelchair Access', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
                 'Y' => __('Young People', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'ha' => [
             'abbr' => __('HA', '12-step-meeting-list'),
             'flags' => ['M', 'W', 'TC', 'ONL'], // for /men and /women at end of meeting name (used in tsml_format_name())
             'name' => __('Heroin Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 'CPT' => __('12 Concepts', '12-step-meeting-list'),
                 'BT' => __('Basic Text', '12-step-meeting-list'),
                 'BEG' => __('Beginner/Newcomer', '12-step-meeting-list'),
@@ -1162,13 +1119,13 @@ function tsml_load_config()
                 'X' => __('Wheelchair Accessible', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
                 'Y' => __('Young People', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'na' => [
             'abbr' => __('NA', '12-step-meeting-list'),
             'flags' => ['M', 'W', 'TC', 'ONL'], // for /men and /women at end of meeting name (used in tsml_format_name())
             'name' => __('Narcotics Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 'CPT' => __('12 Concepts', '12-step-meeting-list'),
                 'BT' => __('Basic Text', '12-step-meeting-list'),
                 'BEG' => __('Beginner/Newcomer', '12-step-meeting-list'),
@@ -1201,13 +1158,13 @@ function tsml_load_config()
                 'X' => __('Wheelchair Accessible', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
                 'Y' => __('Young People', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'oa' => [
             'abbr' => __('OA', '12-step-meeting-list'),
             'flags' => ['TC', 'ONL'],
             'name' => __('Overeaters Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 '11TH' => __('11th Step', '12-step-meeting-list'),
                 '90D' => __('90 Day', '12-step-meeting-list'),
                 'AA12' => __('AA 12/12', '12-step-meeting-list'),
@@ -1240,25 +1197,25 @@ function tsml_load_config()
                 'VOR' => __('Voices of Recovery', '12-step-meeting-list'),
                 'WORK' => __('Work Book Study', '12-step-meeting-list'),
                 'WRIT' => __('Writing', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'pal' => [
             'abbr' => 'PAL',
             'flags' => [],
             'name' => 'Parents of Addicted Loved Ones',
-            'types' => [],
+            'types' => tsml_languages([]),
         ],
         'rca' => [
             'abbr' => __('RCA', '12-step-meeting-list'),
             'flags' => ['TC', 'ONL'],
             'name' => __('Recovering Couples Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 'C' => __('Closed', '12-step-meeting-list'),
                 'TC' => __('Location Temporarily Closed', '12-step-meeting-list'),
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'rd' => [
             'abbr' => __('Recovery Dharma', '12-step-meeting-list'),
@@ -1268,19 +1225,13 @@ function tsml_load_config()
                 'M' => __('Men’s meetings are for anyone who identifies as male.', '12-step-meeting-list'),
                 'W' => __('Women’s meetings are for anyone who identifies as female.', '12-step-meeting-list'),
             ],
-            'types' => [
+            'types' => tsml_languages([
                 'BE' => __('Beginners', '12-step-meeting-list'),
                 'BB' => __('Book Study', '12-step-meeting-list'),
                 'CC' => __('Child Care Available', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
-                'DA' => __('Danish', '12-step-meeting-list'),
                 'DF' => __('Dog Friendly', '12-step-meeting-list'),
-                'NL' => __('Dutch', '12-step-meeting-list'),
                 '8F' => __('Eightfold Path Study', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
-                'FI' => __('Finnish', '12-step-meeting-list'),
-                'FR' => __('French', '12-step-meeting-list'),
-                'DE' => __('German', '12-step-meeting-list'),
                 'IS' => __('Inquiry Study', '12-step-meeting-list'),
                 'IW' => __('Inquiry Writing', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ', '12-step-meeting-list'),
@@ -1290,12 +1241,9 @@ function tsml_load_config()
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
                 'PR' => __('Process Addictions', '12-step-meeting-list'),
-                'ES' => __('Spanish', '12-step-meeting-list'),
-                'SV' => __('Swedish', '12-step-meeting-list'),
-                'TH' => __('Thai', '12-step-meeting-list'),
                 'WA' => __('Wheelchair Access', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'rr' => [
             'abbr' => __('Refuge Recovery', '12-step-meeting-list'),
@@ -1305,19 +1253,13 @@ function tsml_load_config()
                 'M' => __('Men’s meetings are for anyone who identifies as male.', '12-step-meeting-list'),
                 'W' => __('Women’s meetings are for anyone who identifies as female.', '12-step-meeting-list'),
             ],
-            'types' => [
+            'types' => tsml_languages([
                 'BE' => __('Beginners', '12-step-meeting-list'),
                 'BB' => __('Book Study', '12-step-meeting-list'),
                 'CC' => __('Child Care Available', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
-                'DA' => __('Danish', '12-step-meeting-list'),
                 'DF' => __('Dog Friendly', '12-step-meeting-list'),
-                'NL' => __('Dutch', '12-step-meeting-list'),
                 '8F' => __('Eightfold Path Study', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
-                'FI' => __('Finnish', '12-step-meeting-list'),
-                'FR' => __('French', '12-step-meeting-list'),
-                'DE' => __('German', '12-step-meeting-list'),
                 'IS' => __('Inventory Study', '12-step-meeting-list'),
                 'IW' => __('Inventory Writing', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ', '12-step-meeting-list'),
@@ -1327,18 +1269,15 @@ function tsml_load_config()
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
                 'PR' => __('Process Addictions', '12-step-meeting-list'),
-                'ES' => __('Spanish', '12-step-meeting-list'),
-                'SV' => __('Swedish', '12-step-meeting-list'),
-                'TH' => __('Thai', '12-step-meeting-list'),
                 'WA' => __('Wheelchair Access', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'saa' => [
             'abbr' => __('SAA', '12-step-meeting-list'),
             'flags' => ['M', 'W', 'TC', 'ONL'], // for /men and /women at end of meeting name (used in tsml_format_name())
             'name' => __('Sex Addicts Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 'C' => __('Closed', '12-step-meeting-list'),
                 'M' => __('Men', '12-step-meeting-list'),
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
@@ -1347,13 +1286,13 @@ function tsml_load_config()
                 'LGBTQ' => __('LGBTQ', '12-step-meeting-list'),
                 'TC' => __('Location Temporarily Closed', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'sa' => [
             'abbr' => __('SA', '12-step-meeting-list'),
             'flags' => ['M', 'W', 'TC', 'ONL'], // for /men and /women at end of meeting name (used in tsml_format_name())
             'name' => __('Sexaholics Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 'BE' => __('Beginner', '12-step-meeting-list'),
                 'B' => __('Book Study', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
@@ -1367,13 +1306,13 @@ function tsml_load_config()
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Study', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'sca' => [
             'abbr' => __('SCA', '12-step-meeting-list'),
             'flags' => ['TC', 'ONL'],
             'name' => __('Sexual Compulsives Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 'BE' => __('Beginner', '12-step-meeting-list'),
                 'H' => __('Chip', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
@@ -1385,13 +1324,13 @@ function tsml_load_config()
                 'O' => __('Open', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'slaa' => [
             'abbr' => __('SLAA', '12-step-meeting-list'),
             'flags' => ['M', 'W', 'TC', 'ONL'], // for /men and /women at end of meeting name (used in tsml_format_name())
             'name' => __('Sex and Love Addicts Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 'AN' => __('Anorexia Focus', '12-step-meeting-list'),
                 'B' => __('Book Study', '12-step-meeting-list'),
                 'H' => __('Chips', '12-step-meeting-list'),
@@ -1409,13 +1348,12 @@ function tsml_load_config()
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
                 'PRI' => __('Prison', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Study', '12-step-meeting-list'),
                 'D' => __('Topic Discussion', '12-step-meeting-list'),
                 'TR' => __('Tradition Study', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'sg' => [
             'flags' => [],
@@ -1426,24 +1364,14 @@ function tsml_load_config()
             'abbr' => __('SIA', '12-step-meeting-list'),
             'flags' => ['M', 'W', 'TC', 'ONL'],
             'name' => __('Survivors of Incest Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 '12x12' => __('12 Steps & 12 Traditions', '12-step-meeting-list'),
-                'AF' => __('Afrikaans', '12-step-meeting-list'),
                 'ASL' => __('American Sign Language', '12-step-meeting-list'),
-                'AR' => __('Arabic', '12-step-meeting-list'),
                 'B' => __('Big Book', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
-                'NL' => __('Dutch', '12-step-meeting-list'),
-                'EN' => __('English', '12-step-meeting-list'),
-                'FI' => __('Finnish', '12-step-meeting-list'),
                 'FF' => __('Fragrance Free', '12-step-meeting-list'),
-                'FR' => __('French', '12-step-meeting-list'),
                 'GQ' => __('Genderqueer', '12-step-meeting-list'),
-                'HE' => __('Hebrew', '12-step-meeting-list'),
                 'NDG' => __('Indigenous', '12-step-meeting-list'),
-                'ITA' => __('Italian', '12-step-meeting-list'),
-                'JA' => __('Japanese', '12-step-meeting-list'),
-                'KOR' => __('Korean', '12-step-meeting-list'),
                 'LGBTQ' => __('LGBTQ', '12-step-meeting-list'),
                 'LIT' => __('Literature', '12-step-meeting-list'),
                 'TC' => __('Location Temporarily Closed', '12-step-meeting-list'),
@@ -1454,51 +1382,40 @@ function tsml_load_config()
                 'O' => __('Open', '12-step-meeting-list'),
                 'OSH' => __('Open Share Format', '12-step-meeting-list'),
                 'POC' => __('People of Color', '12-step-meeting-list'),
-                'FA' => __('Persian', '12-step-meeting-list'),
-                'POL' => __('Polish', '12-step-meeting-list'),
-                'POR' => __('Portuguese', '12-step-meeting-list'),
-                'PUN' => __('Punjabi', '12-step-meeting-list'),
                 'RIT' => __('Ritual Abuse', '12-step-meeting-list'),
-                'RUS' => __('Russian', '12-step-meeting-list'),
-                'SL' => __('Slovenian', '12-step-meeting-list'),
-                'S' => __('Spanish', '12-step-meeting-list'),
                 'SP' => __('Speaker', '12-step-meeting-list'),
                 'ST' => __('Step Study', '12-step-meeting-list'),
                 'STW' => __('Steps Workshop', '12-step-meeting-list'),
-                'TH' => __('Thai', '12-step-meeting-list'),
                 'T' => __('Transgender', '12-step-meeting-list'),
-                'TR' => __('Turkish', '12-step-meeting-list'),
-                'UA' => __('Ukrainian', '12-step-meeting-list'),
                 'X' => __('Wheelchair Access', '12-step-meeting-list'),
                 'XB' => __('Wheelchair-Accessible Bathroom', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'ua' => [
             'abbr' => __('UA', '12-step-meeting-list'),
             'flags' => ['M', 'W', 'TC', 'ONL'], // for /men and /women at end of meeting name (used in tsml_format_name())
             'name' => __('Underearners Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 'BIPOC' => __('BIPOC', '12-step-meeting-list'),
                 'M' => __('Men', '12-step-meeting-list'),
-                'ES' => __('Spanish', '12-step-meeting-list'),
                 'ST' => __('Steps', '12-step-meeting-list'),
                 'T' => __('Tools', '12-step-meeting-list'),
                 'W' => __('Women', '12-step-meeting-list'),
-            ],
+            ]),
         ],
         'va' => [
             'abbr' => __('VA', '12-step-meeting-list'),
             'flags' => ['M', 'W', 'TC', 'ONL'], // for /men and /women at end of meeting name (used in tsml_format_name())
             'name' => __('Violence Anonymous', '12-step-meeting-list'),
-            'types' => [
+            'types' => tsml_languages([
                 '12x12' => __('12 Steps & 12 Traditions', '12-step-meeting-list'),
                 'C' => __('Closed', '12-step-meeting-list'),
                 'BE' => __('Newcomer', '12-step-meeting-list'),
                 'TC' => __('Location Temporarily Closed', '12-step-meeting-list'),
                 'ONL' => __('Online Meeting', '12-step-meeting-list'),
                 'O' => __('Open', '12-step-meeting-list'),
-            ],
+            ]),
         ],
     ];
 

--- a/languages/12-step-meeting-list.pot
+++ b/languages/12-step-meeting-list.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-04-05T14:50:38+00:00\n"
+"POT-Creation-Date: 2025-04-06T04:25:05+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.10.0\n"
 "X-Domain: 12-step-meeting-list\n"
@@ -162,10 +162,10 @@ msgstr ""
 
 #: includes/admin_import.php:353
 #: includes/admin_lists.php:330
-#: includes/admin_meeting.php:318
-#: includes/admin_meeting.php:375
+#: includes/admin_meeting.php:350
+#: includes/admin_meeting.php:407
 #: includes/functions.php:532
-#: includes/variables.php:1530
+#: includes/variables.php:1447
 #: templates/archive-meetings.php:200
 #: templates/archive-meetings.php:216
 msgid "Meetings"
@@ -463,21 +463,21 @@ msgid "Meeting"
 msgstr ""
 
 #: includes/admin_lists.php:76
-#: includes/admin_meeting.php:60
+#: includes/admin_meeting.php:64
 msgid "Day"
 msgstr ""
 
 #: includes/admin_lists.php:77
-#: includes/admin_meeting.php:76
+#: includes/admin_meeting.php:80
 #: includes/shortcodes.php:80
 #: includes/variables.php:639
-#: includes/variables.php:1008
+#: includes/variables.php:982
 msgid "Time"
 msgstr ""
 
 #: includes/admin_lists.php:78
-#: includes/admin_meeting.php:269
-#: includes/admin_meeting.php:278
+#: includes/admin_meeting.php:301
+#: includes/admin_meeting.php:310
 #: includes/ajax.php:243
 #: includes/functions.php:487
 #: includes/shortcodes.php:83
@@ -490,12 +490,12 @@ msgid "Date"
 msgstr ""
 
 #: includes/admin_lists.php:101
-#: includes/admin_meeting.php:70
+#: includes/admin_meeting.php:74
 #: includes/functions_format.php:43
 #: includes/functions_format.php:128
 #: includes/save.php:495
 #: includes/save.php:497
-#: includes/variables.php:1519
+#: includes/variables.php:1436
 #: templates/archive-meetings.php:647
 msgid "Appointment"
 msgstr ""
@@ -538,207 +538,216 @@ msgstr ""
 msgid "Meeting Information"
 msgstr ""
 
-#: includes/admin_meeting.php:52
+#: includes/admin_meeting.php:56
 msgid "This meeting was imported from an external data source. Any changes you make here will be overwritten when you refresh the data."
 msgstr ""
 
-#: includes/admin_meeting.php:86
+#: includes/admin_meeting.php:90
 #: includes/ajax.php:227
 #: includes/variables.php:646
 msgid "Types"
 msgstr ""
 
-#: includes/admin_meeting.php:107
+#: includes/admin_meeting.php:111
+#: includes/admin_meeting.php:140
 msgid "View all"
 msgstr ""
 
-#: includes/admin_meeting.php:112
+#: includes/admin_meeting.php:116
 msgid "Hide types not in use"
 msgstr ""
 
-#: includes/admin_meeting.php:121
+#: includes/admin_meeting.php:125
+msgid "Languages"
+msgstr ""
+
+#: includes/admin_meeting.php:145
+msgid "Hide languages not in use"
+msgstr ""
+
+#: includes/admin_meeting.php:153
 #: includes/ajax.php:231
 msgid "Notes"
 msgstr ""
 
-#: includes/admin_meeting.php:124
+#: includes/admin_meeting.php:156
 msgid "eg. Birthday speaker meeting last Saturday of the month"
 msgstr ""
 
-#: includes/admin_meeting.php:128
+#: includes/admin_meeting.php:160
 msgid "Online Meeting Details"
 msgstr ""
 
 #. translators: %s is the list of supported conference providers
-#: includes/admin_meeting.php:134
+#: includes/admin_meeting.php:166
 msgid "If this meeting has videoconference information, please enter the full valid URL here. Currently supported providers: %s. If other details are required, such as a password, they can be included in the Notes field above, but a ‘one tap’ experience is ideal. Passwords can be appended to phone numbers using this format <code>+12125551212,,123456789#,,#,,444444#</code>"
 msgstr ""
 
-#: includes/admin_meeting.php:143
+#: includes/admin_meeting.php:175
 msgid "URL"
 msgstr ""
 
-#: includes/admin_meeting.php:147
+#: includes/admin_meeting.php:179
 msgid "Zoom conference urls require a valid meeting number. Example: https://zoom.us/j/1234567890"
 msgstr ""
 
-#: includes/admin_meeting.php:150
+#: includes/admin_meeting.php:182
 msgid "Your conference url has been updated to follow the Zoom url standard."
 msgstr ""
 
-#: includes/admin_meeting.php:155
+#: includes/admin_meeting.php:187
 msgid "URL Notes"
 msgstr ""
 
-#: includes/admin_meeting.php:161
-#: includes/admin_meeting.php:423
-#: includes/admin_meeting.php:480
+#: includes/admin_meeting.php:193
+#: includes/admin_meeting.php:455
+#: includes/admin_meeting.php:512
 msgid "Phone"
 msgstr ""
 
-#: includes/admin_meeting.php:167
+#: includes/admin_meeting.php:199
 msgid "Phone Notes"
 msgstr ""
 
-#: includes/admin_meeting.php:176
+#: includes/admin_meeting.php:208
 msgid "Location Information"
 msgstr ""
 
-#: includes/admin_meeting.php:190
+#: includes/admin_meeting.php:222
 msgid "Can I currently attend this meeting in person?"
 msgstr ""
 
-#: includes/admin_meeting.php:194
+#: includes/admin_meeting.php:226
 msgid "Yes"
 msgstr ""
 
-#: includes/admin_meeting.php:198
+#: includes/admin_meeting.php:230
 msgid "No"
 msgstr ""
 
-#: includes/admin_meeting.php:202
+#: includes/admin_meeting.php:234
 msgid "Select Yes for in-person or hybrid meetings."
 msgstr ""
 
-#: includes/admin_meeting.php:203
+#: includes/admin_meeting.php:235
 msgid "Select No for online-only meetings, or meetings that are temporarily inactive."
 msgstr ""
 
-#: includes/admin_meeting.php:205
+#: includes/admin_meeting.php:237
 msgid "For meetings I can attend in person:"
 msgstr ""
 
-#: includes/admin_meeting.php:208
+#: includes/admin_meeting.php:240
 msgid "A specific address is required"
 msgstr ""
 
-#: includes/admin_meeting.php:212
+#: includes/admin_meeting.php:244
 msgid "For online or hybrid meetings:"
 msgstr ""
 
-#: includes/admin_meeting.php:215
+#: includes/admin_meeting.php:247
 msgid "Fill in the \"Online Meeting Details\" above"
 msgstr ""
 
-#: includes/admin_meeting.php:219
+#: includes/admin_meeting.php:251
 msgid "For online-only meetings:"
 msgstr ""
 
-#: includes/admin_meeting.php:222
+#: includes/admin_meeting.php:254
 msgid "Use an approximate address, example: Philadelphia, PA, USA. It may help to think of it as the meeting's origin. The Meeting Guide app uses this information to infer the meeting's time zone."
 msgstr ""
 
-#: includes/admin_meeting.php:227
+#: includes/admin_meeting.php:259
 msgid "Warning: Online meetings with a specific address will appear that the location temporarily closed. Meetings that are Online only should use appoximate addresses."
 msgstr ""
 
-#: includes/admin_meeting.php:228
+#: includes/admin_meeting.php:260
 msgid "Example:"
 msgstr ""
 
-#: includes/admin_meeting.php:229
+#: includes/admin_meeting.php:261
 msgid "Location: Online-Philadelphia"
 msgstr ""
 
-#: includes/admin_meeting.php:230
+#: includes/admin_meeting.php:262
 msgid "Address: Philadelphia, PA, USA"
 msgstr ""
 
-#: includes/admin_meeting.php:236
+#: includes/admin_meeting.php:268
 #: includes/ajax.php:235
 #: includes/functions.php:554
 #: includes/shortcodes.php:82
 msgid "Location"
 msgstr ""
 
-#: includes/admin_meeting.php:242
+#: includes/admin_meeting.php:274
 #: includes/ajax.php:239
 #: includes/variables.php:643
 msgid "Address"
 msgstr ""
 
-#: includes/admin_meeting.php:251
+#: includes/admin_meeting.php:283
 msgid "Error: In person meetings must have a specific address."
 msgstr ""
 
-#: includes/admin_meeting.php:254
+#: includes/admin_meeting.php:286
 msgid "Error: Unable to process this address for exact location."
 msgstr ""
 
-#: includes/admin_meeting.php:261
+#: includes/admin_meeting.php:293
 msgid "Apply this updated address to all meetings at this location"
 msgstr ""
 
-#: includes/admin_meeting.php:285
+#: includes/admin_meeting.php:317
 #: templates/archive-meetings.php:376
 msgid "Map"
 msgstr ""
 
 #. translators: %s is the link to the Import & Settings page
-#: includes/admin_meeting.php:292
+#: includes/admin_meeting.php:324
 msgid "Enable maps on the <a href=\"%s\">Import & Settings</a> page."
 msgstr ""
 
-#: includes/admin_meeting.php:302
+#: includes/admin_meeting.php:334
 #: includes/admin_settings.php:557
 msgid "Timezone"
 msgstr ""
 
-#: includes/admin_meeting.php:310
+#: includes/admin_meeting.php:342
 msgid "Because your site does not have a default timezone set, a timezone must be selected here for the meeting to appear on the meeting finder page."
 msgstr ""
 
-#: includes/admin_meeting.php:325
+#: includes/admin_meeting.php:357
 #: includes/ajax.php:247
 msgid "Location Notes"
 msgstr ""
 
-#: includes/admin_meeting.php:328
+#: includes/admin_meeting.php:360
 msgid "eg. Around back, basement, ring buzzer"
 msgstr ""
 
-#: includes/admin_meeting.php:337
+#: includes/admin_meeting.php:369
 msgid "Contact Information <small>Optional</small>"
 msgstr ""
 
-#: includes/admin_meeting.php:354
+#: includes/admin_meeting.php:386
 msgid "Individual meeting"
 msgstr ""
 
-#: includes/admin_meeting.php:358
+#: includes/admin_meeting.php:390
 msgid "Part of a group"
 msgstr ""
 
-#: includes/admin_meeting.php:363
+#: includes/admin_meeting.php:395
 #: includes/functions.php:583
 msgid "Group"
 msgstr ""
 
-#: includes/admin_meeting.php:370
+#: includes/admin_meeting.php:402
 msgid "Apply this group to all meetings at this location"
 msgstr ""
 
-#: includes/admin_meeting.php:383
+#: includes/admin_meeting.php:415
 #: includes/functions.php:508
 #: includes/functions.php:509
 #: includes/functions.php:510
@@ -746,78 +755,78 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: includes/admin_meeting.php:392
+#: includes/admin_meeting.php:424
 msgid "None"
 msgstr ""
 
-#: includes/admin_meeting.php:398
+#: includes/admin_meeting.php:430
 msgid "Group Notes"
 msgstr ""
 
-#: includes/admin_meeting.php:401
+#: includes/admin_meeting.php:433
 msgid "eg. Group history, when the business meeting is, etc."
 msgstr ""
 
-#: includes/admin_meeting.php:405
+#: includes/admin_meeting.php:437
 msgid "Website"
 msgstr ""
 
-#: includes/admin_meeting.php:411
+#: includes/admin_meeting.php:443
 msgid "Website 2"
 msgstr ""
 
-#: includes/admin_meeting.php:417
-#: includes/admin_meeting.php:480
+#: includes/admin_meeting.php:449
+#: includes/admin_meeting.php:512
 msgid "Email"
 msgstr ""
 
-#: includes/admin_meeting.php:429
+#: includes/admin_meeting.php:461
 msgid "Mailing Address"
 msgstr ""
 
-#: includes/admin_meeting.php:435
+#: includes/admin_meeting.php:467
 msgid "Venmo"
 msgstr ""
 
-#: includes/admin_meeting.php:441
+#: includes/admin_meeting.php:473
 msgid "Square Cash"
 msgstr ""
 
-#: includes/admin_meeting.php:447
+#: includes/admin_meeting.php:479
 msgid "PayPal"
 msgstr ""
 
-#: includes/admin_meeting.php:451
+#: includes/admin_meeting.php:483
 msgid "A valid PayPal username can only contain letters and numbers, and be less than 20 characters."
 msgstr ""
 
-#: includes/admin_meeting.php:456
+#: includes/admin_meeting.php:488
 msgid "Homegroup Online"
 msgstr ""
 
-#: includes/admin_meeting.php:460
+#: includes/admin_meeting.php:492
 msgid "A valid Homegroup Online group code can only contain letters and numbers."
 msgstr ""
 
-#: includes/admin_meeting.php:465
+#: includes/admin_meeting.php:497
 msgid "Contacts"
 msgstr ""
 
-#: includes/admin_meeting.php:469
+#: includes/admin_meeting.php:501
 #: includes/admin_settings.php:370
 msgid "Public"
 msgstr ""
 
-#: includes/admin_meeting.php:471
+#: includes/admin_meeting.php:503
 #: includes/admin_settings.php:370
 msgid "Private"
 msgstr ""
 
-#: includes/admin_meeting.php:480
+#: includes/admin_meeting.php:512
 msgid "Name"
 msgstr ""
 
-#: includes/admin_meeting.php:493
+#: includes/admin_meeting.php:525
 msgid "Last Contact"
 msgstr ""
 
@@ -825,7 +834,7 @@ msgstr ""
 #: includes/admin_menu.php:22
 #: includes/functions.php:486
 #: includes/functions.php:488
-#: includes/variables.php:1533
+#: includes/variables.php:1450
 msgid "Regions"
 msgstr ""
 
@@ -1047,25 +1056,25 @@ msgstr ""
 
 #: includes/admin_settings.php:456
 #: includes/variables.php:702
-#: includes/variables.php:804
-#: includes/variables.php:844
-#: includes/variables.php:886
-#: includes/variables.php:949
-#: includes/variables.php:1004
+#: includes/variables.php:794
+#: includes/variables.php:829
+#: includes/variables.php:870
+#: includes/variables.php:928
+#: includes/variables.php:978
+#: includes/variables.php:1002
 #: includes/variables.php:1028
-#: includes/variables.php:1061
-#: includes/variables.php:1111
-#: includes/variables.php:1152
-#: includes/variables.php:1190
-#: includes/variables.php:1259
-#: includes/variables.php:1291
-#: includes/variables.php:1328
-#: includes/variables.php:1345
-#: includes/variables.php:1365
-#: includes/variables.php:1385
-#: includes/variables.php:1410
-#: includes/variables.php:1454
-#: includes/variables.php:1500
+#: includes/variables.php:1073
+#: includes/variables.php:1109
+#: includes/variables.php:1147
+#: includes/variables.php:1216
+#: includes/variables.php:1242
+#: includes/variables.php:1270
+#: includes/variables.php:1284
+#: includes/variables.php:1304
+#: includes/variables.php:1324
+#: includes/variables.php:1349
+#: includes/variables.php:1382
+#: includes/variables.php:1417
 msgid "Open"
 msgstr ""
 
@@ -1382,7 +1391,7 @@ msgstr ""
 
 #: includes/functions.php:553
 #: includes/functions.php:555
-#: includes/variables.php:1529
+#: includes/variables.php:1446
 msgid "Locations"
 msgstr ""
 
@@ -1432,7 +1441,7 @@ msgstr ""
 
 #: includes/functions.php:582
 #: includes/functions.php:584
-#: includes/variables.php:1528
+#: includes/variables.php:1445
 msgid "Groups"
 msgstr ""
 
@@ -1480,22 +1489,218 @@ msgstr ""
 msgid "No groups found."
 msgstr ""
 
+#: includes/functions.php:1002
+msgid "Afrikaans"
+msgstr ""
+
+#: includes/functions.php:1003
+msgid "Amharic"
+msgstr ""
+
+#: includes/functions.php:1004
+msgid "Arabic"
+msgstr ""
+
+#: includes/functions.php:1005
+msgid "Bulgarian"
+msgstr ""
+
+#: includes/functions.php:1006
+msgid "Bengali"
+msgstr ""
+
+#: includes/functions.php:1007
+msgid "Bosnian"
+msgstr ""
+
+#: includes/functions.php:1008
+msgid "Czech"
+msgstr ""
+
+#: includes/functions.php:1009
+msgid "Danish"
+msgstr ""
+
+#: includes/functions.php:1010
+msgid "German"
+msgstr ""
+
+#: includes/functions.php:1011
+msgid "Greek"
+msgstr ""
+
+#: includes/functions.php:1012
+msgid "English"
+msgstr ""
+
+#: includes/functions.php:1013
+msgid "Spanish"
+msgstr ""
+
+#: includes/functions.php:1014
+msgid "Estonian"
+msgstr ""
+
+#: includes/functions.php:1015
+msgid "Persian"
+msgstr ""
+
+#: includes/functions.php:1016
+msgid "Finnish"
+msgstr ""
+
+#: includes/functions.php:1017
+msgid "French"
+msgstr ""
+
+#: includes/functions.php:1018
+msgid "Hebrew"
+msgstr ""
+
+#: includes/functions.php:1019
+msgid "Hindi"
+msgstr ""
+
+#: includes/functions.php:1020
+msgid "Croatian"
+msgstr ""
+
+#: includes/functions.php:1021
+msgid "Hungarian"
+msgstr ""
+
+#: includes/functions.php:1022
+msgid "Indonesian"
+msgstr ""
+
+#: includes/functions.php:1023
+msgid "Icelandic"
+msgstr ""
+
+#: includes/functions.php:1024
+msgid "Italian"
+msgstr ""
+
+#: includes/functions.php:1025
+msgid "Japanese"
+msgstr ""
+
+#: includes/functions.php:1026
+msgid "Georgian"
+msgstr ""
+
+#: includes/functions.php:1027
+msgid "Korean"
+msgstr ""
+
+#: includes/functions.php:1028
+msgid "Lithuanian"
+msgstr ""
+
+#: includes/functions.php:1029
+msgid "Latvian"
+msgstr ""
+
+#: includes/functions.php:1030
+msgid "Macedonian"
+msgstr ""
+
+#: includes/functions.php:1031
+msgid "Malay"
+msgstr ""
+
+#: includes/functions.php:1032
+msgid "Norwegian"
+msgstr ""
+
+#: includes/functions.php:1033
+msgid "Dutch"
+msgstr ""
+
+#: includes/functions.php:1034
+msgid "Polish"
+msgstr ""
+
+#: includes/functions.php:1035
+msgid "Portuguese"
+msgstr ""
+
+#: includes/functions.php:1036
+msgid "Punjabi"
+msgstr ""
+
+#: includes/functions.php:1037
+msgid "Romanian"
+msgstr ""
+
+#: includes/functions.php:1038
+msgid "Russian"
+msgstr ""
+
+#: includes/functions.php:1039
+msgid "Slovak"
+msgstr ""
+
+#: includes/functions.php:1040
+msgid "Slovenian"
+msgstr ""
+
+#: includes/functions.php:1041
+msgid "Albanian"
+msgstr ""
+
+#: includes/functions.php:1042
+msgid "Serbian"
+msgstr ""
+
+#: includes/functions.php:1043
+msgid "Swedish"
+msgstr ""
+
+#: includes/functions.php:1044
+msgid "Swahili"
+msgstr ""
+
+#: includes/functions.php:1045
+msgid "Thai"
+msgstr ""
+
+#: includes/functions.php:1046
+msgid "Tagalog"
+msgstr ""
+
+#: includes/functions.php:1047
+msgid "Turkish"
+msgstr ""
+
+#: includes/functions.php:1048
+msgid "Ukrainian"
+msgstr ""
+
+#: includes/functions.php:1049
+msgid "Vietnamese"
+msgstr ""
+
+#: includes/functions.php:1050
+msgid "Chinese"
+msgstr ""
+
 #. translators: %s is the permission required
-#: includes/functions.php:1128
-#: includes/functions.php:1141
+#: includes/functions.php:1267
+#: includes/functions.php:1280
 msgid "You do not have sufficient permissions to access this page (<code>%s</code>)."
 msgstr ""
 
 #. translators: %s is the name of the data source
-#: includes/functions.php:1358
+#: includes/functions.php:1497
 msgid "Please sign in to your website and refresh the <strong>%s</strong> feed on the Import & Export page."
 msgstr ""
 
-#: includes/functions.php:1361
+#: includes/functions.php:1500
 msgid "Go to Import & Export page"
 msgstr ""
 
-#: includes/functions.php:1363
+#: includes/functions.php:1502
 msgid "Data Source Changes Detected"
 msgstr ""
 
@@ -1587,7 +1792,7 @@ msgid "In-person and Online"
 msgstr ""
 
 #: includes/variables.php:632
-#: includes/variables.php:1060
+#: includes/variables.php:1027
 msgid "Online"
 msgstr ""
 
@@ -1616,7 +1821,7 @@ msgid "This meeting is closed; only those who have a desire to recover from the 
 msgstr ""
 
 #: includes/variables.php:678
-#: includes/variables.php:911
+#: includes/variables.php:894
 msgid "This meeting is open and anyone may attend."
 msgstr ""
 
@@ -1633,23 +1838,23 @@ msgid "Audio / Visual"
 msgstr ""
 
 #: includes/variables.php:684
-#: includes/variables.php:867
-#: includes/variables.php:975
-#: includes/variables.php:1273
-#: includes/variables.php:1310
-#: includes/variables.php:1358
-#: includes/variables.php:1396
+#: includes/variables.php:851
+#: includes/variables.php:949
+#: includes/variables.php:1230
+#: includes/variables.php:1258
+#: includes/variables.php:1297
+#: includes/variables.php:1335
 msgid "Book Study"
 msgstr ""
 
 #: includes/variables.php:685
-#: includes/variables.php:1272
-#: includes/variables.php:1309
+#: includes/variables.php:1229
+#: includes/variables.php:1257
 msgid "Beginners"
 msgstr ""
 
 #: includes/variables.php:686
-#: includes/variables.php:1482
+#: includes/variables.php:1400
 msgid "BIPOC"
 msgstr ""
 
@@ -1658,32 +1863,32 @@ msgid "Captions"
 msgstr ""
 
 #: includes/variables.php:688
-#: includes/variables.php:1274
-#: includes/variables.php:1311
-#: includes/variables.php:1398
+#: includes/variables.php:1231
+#: includes/variables.php:1259
+#: includes/variables.php:1337
 msgid "Child Care Available"
 msgstr ""
 
 #: includes/variables.php:689
-#: includes/variables.php:774
-#: includes/variables.php:838
-#: includes/variables.php:870
-#: includes/variables.php:924
-#: includes/variables.php:998
-#: includes/variables.php:1023
-#: includes/variables.php:1047
-#: includes/variables.php:1093
-#: includes/variables.php:1139
-#: includes/variables.php:1177
-#: includes/variables.php:1256
-#: includes/variables.php:1275
-#: includes/variables.php:1312
-#: includes/variables.php:1342
-#: includes/variables.php:1359
-#: includes/variables.php:1379
-#: includes/variables.php:1399
-#: includes/variables.php:1435
-#: includes/variables.php:1496
+#: includes/variables.php:771
+#: includes/variables.php:823
+#: includes/variables.php:854
+#: includes/variables.php:907
+#: includes/variables.php:972
+#: includes/variables.php:997
+#: includes/variables.php:1021
+#: includes/variables.php:1059
+#: includes/variables.php:1096
+#: includes/variables.php:1134
+#: includes/variables.php:1213
+#: includes/variables.php:1232
+#: includes/variables.php:1260
+#: includes/variables.php:1281
+#: includes/variables.php:1298
+#: includes/variables.php:1318
+#: includes/variables.php:1338
+#: includes/variables.php:1371
+#: includes/variables.php:1413
 msgid "Closed"
 msgstr ""
 
@@ -1692,11 +1897,11 @@ msgid "Concepts of Service"
 msgstr ""
 
 #: includes/variables.php:691
-#: includes/variables.php:780
-#: includes/variables.php:930
-#: includes/variables.php:1024
-#: includes/variables.php:1098
-#: includes/variables.php:1381
+#: includes/variables.php:777
+#: includes/variables.php:913
+#: includes/variables.php:998
+#: includes/variables.php:1064
+#: includes/variables.php:1320
 msgid "Discussion"
 msgstr ""
 
@@ -1705,18 +1910,18 @@ msgid "Fellowship Text"
 msgstr ""
 
 #: includes/variables.php:693
-#: includes/variables.php:737
-#: includes/variables.php:784
-#: includes/variables.php:876
-#: includes/variables.php:933
-#: includes/variables.php:1400
-#: includes/variables.php:1439
+#: includes/variables.php:735
+#: includes/variables.php:779
+#: includes/variables.php:860
+#: includes/variables.php:915
+#: includes/variables.php:1339
+#: includes/variables.php:1372
 msgid "Fragrance Free"
 msgstr ""
 
 #: includes/variables.php:694
-#: includes/variables.php:1141
-#: includes/variables.php:1179
+#: includes/variables.php:1098
+#: includes/variables.php:1136
 msgid "Gay/Lesbian"
 msgstr ""
 
@@ -1725,31 +1930,31 @@ msgid "Laundry Lists Workbook"
 msgstr ""
 
 #: includes/variables.php:696
-#: includes/variables.php:1057
+#: includes/variables.php:1024
 msgid "LGBTQ+"
 msgstr ""
 
 #: includes/variables.php:697
-#: includes/variables.php:741
-#: includes/variables.php:797
-#: includes/variables.php:852
-#: includes/variables.php:882
-#: includes/variables.php:943
-#: includes/variables.php:1000
-#: includes/variables.php:1025
-#: includes/variables.php:1106
-#: includes/variables.php:1147
-#: includes/variables.php:1185
-#: includes/variables.php:1221
-#: includes/variables.php:1257
+#: includes/variables.php:739
+#: includes/variables.php:787
+#: includes/variables.php:836
+#: includes/variables.php:866
+#: includes/variables.php:922
+#: includes/variables.php:974
+#: includes/variables.php:999
+#: includes/variables.php:1068
+#: includes/variables.php:1104
+#: includes/variables.php:1142
+#: includes/variables.php:1178
+#: includes/variables.php:1214
+#: includes/variables.php:1238
+#: includes/variables.php:1266
 #: includes/variables.php:1287
-#: includes/variables.php:1324
-#: includes/variables.php:1348
-#: includes/variables.php:1360
-#: includes/variables.php:1383
-#: includes/variables.php:1405
-#: includes/variables.php:1449
-#: includes/variables.php:1498
+#: includes/variables.php:1299
+#: includes/variables.php:1322
+#: includes/variables.php:1344
+#: includes/variables.php:1377
+#: includes/variables.php:1415
 msgid "Location Temporarily Closed"
 msgstr ""
 
@@ -1758,25 +1963,25 @@ msgid "Loving Parent Guidebook"
 msgstr ""
 
 #: includes/variables.php:699
-#: includes/variables.php:742
-#: includes/variables.php:799
-#: includes/variables.php:841
-#: includes/variables.php:884
-#: includes/variables.php:945
-#: includes/variables.php:1001
+#: includes/variables.php:740
+#: includes/variables.php:789
+#: includes/variables.php:826
+#: includes/variables.php:868
+#: includes/variables.php:924
+#: includes/variables.php:975
+#: includes/variables.php:1000
 #: includes/variables.php:1026
-#: includes/variables.php:1059
-#: includes/variables.php:1108
-#: includes/variables.php:1148
-#: includes/variables.php:1186
-#: includes/variables.php:1288
-#: includes/variables.php:1325
-#: includes/variables.php:1343
-#: includes/variables.php:1362
-#: includes/variables.php:1407
-#: includes/variables.php:1450
-#: includes/variables.php:1483
-#: includes/variables.php:1531
+#: includes/variables.php:1070
+#: includes/variables.php:1105
+#: includes/variables.php:1143
+#: includes/variables.php:1239
+#: includes/variables.php:1267
+#: includes/variables.php:1282
+#: includes/variables.php:1301
+#: includes/variables.php:1346
+#: includes/variables.php:1378
+#: includes/variables.php:1401
+#: includes/variables.php:1448
 msgid "Men"
 msgstr ""
 
@@ -1785,25 +1990,25 @@ msgid "Needs Support"
 msgstr ""
 
 #: includes/variables.php:701
-#: includes/variables.php:743
-#: includes/variables.php:803
-#: includes/variables.php:885
-#: includes/variables.php:948
-#: includes/variables.php:1003
-#: includes/variables.php:1027
-#: includes/variables.php:1110
-#: includes/variables.php:1151
-#: includes/variables.php:1189
-#: includes/variables.php:1229
-#: includes/variables.php:1258
-#: includes/variables.php:1290
-#: includes/variables.php:1327
-#: includes/variables.php:1344
-#: includes/variables.php:1364
-#: includes/variables.php:1384
-#: includes/variables.php:1409
-#: includes/variables.php:1453
-#: includes/variables.php:1499
+#: includes/variables.php:741
+#: includes/variables.php:793
+#: includes/variables.php:869
+#: includes/variables.php:927
+#: includes/variables.php:977
+#: includes/variables.php:1001
+#: includes/variables.php:1072
+#: includes/variables.php:1108
+#: includes/variables.php:1146
+#: includes/variables.php:1186
+#: includes/variables.php:1215
+#: includes/variables.php:1241
+#: includes/variables.php:1269
+#: includes/variables.php:1283
+#: includes/variables.php:1303
+#: includes/variables.php:1323
+#: includes/variables.php:1348
+#: includes/variables.php:1381
+#: includes/variables.php:1416
 #: templates/single-meetings.php:133
 msgid "Online Meeting"
 msgstr ""
@@ -1813,1316 +2018,1155 @@ msgid "Sign Language ASL"
 msgstr ""
 
 #: includes/variables.php:704
-#: includes/variables.php:746
-#: includes/variables.php:816
-#: includes/variables.php:847
-#: includes/variables.php:891
-#: includes/variables.php:955
-#: includes/variables.php:1118
+#: includes/variables.php:744
+#: includes/variables.php:802
+#: includes/variables.php:832
+#: includes/variables.php:875
+#: includes/variables.php:930
+#: includes/variables.php:1076
 msgid "Smoking Permitted"
 msgstr ""
 
 #: includes/variables.php:705
-#: includes/variables.php:747
-#: includes/variables.php:817
-#: includes/variables.php:848
-#: includes/variables.php:892
-#: includes/variables.php:956
-#: includes/variables.php:1067
-#: includes/variables.php:1119
-#: includes/variables.php:1293
-#: includes/variables.php:1330
-#: includes/variables.php:1412
-#: includes/variables.php:1464
-#: includes/variables.php:1484
-msgid "Spanish"
-msgstr ""
-
-#: includes/variables.php:706
-#: includes/variables.php:748
-#: includes/variables.php:818
-#: includes/variables.php:849
-#: includes/variables.php:893
-#: includes/variables.php:957
-#: includes/variables.php:1006
-#: includes/variables.php:1068
-#: includes/variables.php:1120
-#: includes/variables.php:1156
-#: includes/variables.php:1195
-#: includes/variables.php:1232
-#: includes/variables.php:1260
-#: includes/variables.php:1367
+#: includes/variables.php:745
+#: includes/variables.php:803
+#: includes/variables.php:833
+#: includes/variables.php:876
+#: includes/variables.php:931
+#: includes/variables.php:980
+#: includes/variables.php:1034
+#: includes/variables.php:1077
+#: includes/variables.php:1113
+#: includes/variables.php:1152
+#: includes/variables.php:1189
+#: includes/variables.php:1217
+#: includes/variables.php:1306
+#: includes/variables.php:1325
+#: includes/variables.php:1351
 #: includes/variables.php:1386
-#: includes/variables.php:1413
-#: includes/variables.php:1465
 msgid "Speaker"
 msgstr ""
 
-#: includes/variables.php:707
-#: includes/variables.php:1485
+#: includes/variables.php:706
+#: includes/variables.php:1402
 msgid "Steps"
 msgstr ""
 
-#: includes/variables.php:708
+#: includes/variables.php:707
 msgid "Strengthening My Recovery"
 msgstr ""
 
-#: includes/variables.php:709
+#: includes/variables.php:708
 msgid "Teen (Ages 12 to 18)"
 msgstr ""
 
-#: includes/variables.php:710
+#: includes/variables.php:709
 msgid "Traditions"
 msgstr ""
 
-#: includes/variables.php:711
-#: includes/variables.php:822
-#: includes/variables.php:855
-#: includes/variables.php:961
-#: includes/variables.php:1073
-#: includes/variables.php:1124
-#: includes/variables.php:1296
-#: includes/variables.php:1333
-#: includes/variables.php:1472
+#: includes/variables.php:710
+#: includes/variables.php:807
+#: includes/variables.php:839
+#: includes/variables.php:935
+#: includes/variables.php:1039
+#: includes/variables.php:1081
+#: includes/variables.php:1244
+#: includes/variables.php:1272
+#: includes/variables.php:1390
 msgid "Wheelchair Access"
 msgstr ""
 
-#: includes/variables.php:712
-#: includes/variables.php:752
-#: includes/variables.php:824
-#: includes/variables.php:853
-#: includes/variables.php:900
-#: includes/variables.php:962
-#: includes/variables.php:1012
-#: includes/variables.php:1031
-#: includes/variables.php:1075
-#: includes/variables.php:1125
-#: includes/variables.php:1163
-#: includes/variables.php:1202
-#: includes/variables.php:1297
-#: includes/variables.php:1334
-#: includes/variables.php:1349
-#: includes/variables.php:1369
-#: includes/variables.php:1417
-#: includes/variables.php:1474
-#: includes/variables.php:1487
-#: includes/variables.php:1534
+#: includes/variables.php:711
+#: includes/variables.php:749
+#: includes/variables.php:809
+#: includes/variables.php:837
+#: includes/variables.php:883
+#: includes/variables.php:936
+#: includes/variables.php:986
+#: includes/variables.php:1005
+#: includes/variables.php:1041
+#: includes/variables.php:1082
+#: includes/variables.php:1120
+#: includes/variables.php:1159
+#: includes/variables.php:1245
+#: includes/variables.php:1273
+#: includes/variables.php:1288
+#: includes/variables.php:1308
+#: includes/variables.php:1355
+#: includes/variables.php:1392
+#: includes/variables.php:1404
+#: includes/variables.php:1451
 msgid "Women"
 msgstr ""
 
-#: includes/variables.php:713
+#: includes/variables.php:712
 msgid "Workshop"
 msgstr ""
 
-#: includes/variables.php:714
+#: includes/variables.php:713
 msgid "Yellow Workbook Study"
 msgstr ""
 
-#: includes/variables.php:715
+#: includes/variables.php:714
 msgid "Young Adult (Ages 18 to 26)"
 msgstr ""
 
-#: includes/variables.php:719
-#: includes/variables.php:721
+#: includes/variables.php:718
+#: includes/variables.php:720
 msgid "Al-Anon"
 msgstr ""
 
-#: includes/variables.php:723
+#: includes/variables.php:722
 msgid "Closed Meetings are limited to members and prospective members. These are persons who feel their lives have been or are being affected by alcoholism in a family member or friend."
 msgstr ""
 
-#: includes/variables.php:724
+#: includes/variables.php:723
 msgid "Open to anyone interested in the family disease of alcoholism. Some groups invite members of the professional community to hear how the Al-Anon program aids in recovery."
 msgstr ""
 
-#: includes/variables.php:727
+#: includes/variables.php:726
 msgid "Adult Child Focus"
 msgstr ""
 
-#: includes/variables.php:728
+#: includes/variables.php:727
 msgid "Alateen"
 msgstr ""
 
-#: includes/variables.php:729
-#: includes/variables.php:864
-#: includes/variables.php:917
+#: includes/variables.php:728
+#: includes/variables.php:848
+#: includes/variables.php:900
 msgid "Atheist / Agnostic"
 msgstr ""
 
-#: includes/variables.php:730
-#: includes/variables.php:768
-#: includes/variables.php:865
-#: includes/variables.php:918
-#: includes/variables.php:1021
-#: includes/variables.php:1042
-#: includes/variables.php:1089
+#: includes/variables.php:729
+#: includes/variables.php:765
+#: includes/variables.php:849
+#: includes/variables.php:901
+#: includes/variables.php:995
+#: includes/variables.php:1016
+#: includes/variables.php:1055
 msgid "Babysitting Available"
 msgstr ""
 
-#: includes/variables.php:731
-#: includes/variables.php:866
-#: includes/variables.php:1357
-#: includes/variables.php:1377
+#: includes/variables.php:730
+#: includes/variables.php:850
+#: includes/variables.php:1296
+#: includes/variables.php:1316
 msgid "Beginner"
 msgstr ""
 
-#: includes/variables.php:732
+#: includes/variables.php:731
 msgid "Concurrent with AA Meeting"
 msgstr ""
 
-#: includes/variables.php:733
+#: includes/variables.php:732
 msgid "Concurrent with Alateen Meeting"
 msgstr ""
 
-#: includes/variables.php:734
-#: includes/variables.php:782
-#: includes/variables.php:932
-#: includes/variables.php:1049
-#: includes/variables.php:1099
-#: includes/variables.php:1280
-#: includes/variables.php:1317
-#: includes/variables.php:1437
-msgid "English"
-msgstr ""
-
-#: includes/variables.php:735
+#: includes/variables.php:733
 msgid "Families Friends and Observers Welcome"
 msgstr ""
 
-#: includes/variables.php:736
+#: includes/variables.php:734
 msgid "Families and Friends Only"
 msgstr ""
 
-#: includes/variables.php:738
-#: includes/variables.php:786
-#: includes/variables.php:877
-#: includes/variables.php:935
+#: includes/variables.php:736
+#: includes/variables.php:780
+#: includes/variables.php:861
+#: includes/variables.php:916
 msgid "Gay"
 msgstr ""
 
-#: includes/variables.php:739
-#: includes/variables.php:793
-#: includes/variables.php:879
-#: includes/variables.php:939
+#: includes/variables.php:737
+#: includes/variables.php:783
+#: includes/variables.php:863
+#: includes/variables.php:918
 msgid "Lesbian"
 msgstr ""
 
-#: includes/variables.php:740
+#: includes/variables.php:738
 msgid "LGBTQIA+"
 msgstr ""
 
-#: includes/variables.php:744
+#: includes/variables.php:742
 msgid "Parents of Alcoholics"
 msgstr ""
 
-#: includes/variables.php:745
-#: includes/variables.php:806
-#: includes/variables.php:846
-#: includes/variables.php:1063
-#: includes/variables.php:1456
+#: includes/variables.php:743
+#: includes/variables.php:796
+#: includes/variables.php:831
+#: includes/variables.php:1030
+#: includes/variables.php:1384
 msgid "People of Color"
 msgstr ""
 
-#: includes/variables.php:749
-#: includes/variables.php:819
-#: includes/variables.php:850
-#: includes/variables.php:894
-#: includes/variables.php:958
-#: includes/variables.php:1029
-#: includes/variables.php:1121
-#: includes/variables.php:1346
+#: includes/variables.php:746
+#: includes/variables.php:804
+#: includes/variables.php:834
+#: includes/variables.php:877
+#: includes/variables.php:932
+#: includes/variables.php:1003
+#: includes/variables.php:1078
+#: includes/variables.php:1285
 msgid "Step Meeting"
 msgstr ""
 
-#: includes/variables.php:750
-#: includes/variables.php:821
-#: includes/variables.php:851
-#: includes/variables.php:898
-#: includes/variables.php:960
-#: includes/variables.php:1072
-#: includes/variables.php:1469
+#: includes/variables.php:747
+#: includes/variables.php:806
+#: includes/variables.php:835
+#: includes/variables.php:881
+#: includes/variables.php:934
+#: includes/variables.php:1038
+#: includes/variables.php:1389
 msgid "Transgender"
 msgstr ""
 
-#: includes/variables.php:751
-#: includes/variables.php:899
-#: includes/variables.php:1011
-#: includes/variables.php:1162
-#: includes/variables.php:1201
+#: includes/variables.php:748
+#: includes/variables.php:882
+#: includes/variables.php:985
+#: includes/variables.php:1119
+#: includes/variables.php:1158
 msgid "Wheelchair Accessible"
 msgstr ""
 
-#: includes/variables.php:753
+#: includes/variables.php:750
 msgid "Young Adults"
 msgstr ""
 
-#: includes/variables.php:757
+#: includes/variables.php:754
 msgid "AA"
 msgstr ""
 
-#: includes/variables.php:759
+#: includes/variables.php:756
 msgid "Alcoholics Anonymous"
 msgstr ""
 
-#: includes/variables.php:761
+#: includes/variables.php:758
 msgid "Closed meetings are for A.A. members only, or for those who have a drinking problem and “have a desire to stop drinking.”"
 msgstr ""
 
-#: includes/variables.php:762
+#: includes/variables.php:759
 msgid "Open meetings are available to anyone interested in Alcoholics Anonymous’ program of recovery from alcoholism. Nonalcoholics may attend open meetings as observers."
 msgstr ""
 
-#: includes/variables.php:765
-#: includes/variables.php:914
-#: includes/variables.php:1040
+#: includes/variables.php:762
+#: includes/variables.php:897
+#: includes/variables.php:1014
 msgid "11th Step Meditation"
 msgstr ""
 
-#: includes/variables.php:766
-#: includes/variables.php:915
-#: includes/variables.php:971
-#: includes/variables.php:1020
-#: includes/variables.php:1041
-#: includes/variables.php:1430
-#: includes/variables.php:1495
+#: includes/variables.php:763
+#: includes/variables.php:898
+#: includes/variables.php:945
+#: includes/variables.php:994
+#: includes/variables.php:1015
+#: includes/variables.php:1368
+#: includes/variables.php:1412
 msgid "12 Steps & 12 Traditions"
 msgstr ""
 
-#: includes/variables.php:767
-#: includes/variables.php:916
-#: includes/variables.php:973
+#: includes/variables.php:764
+#: includes/variables.php:899
+#: includes/variables.php:947
 msgid "As Bill Sees It"
 msgstr ""
 
-#: includes/variables.php:769
-#: includes/variables.php:919
-#: includes/variables.php:974
-#: includes/variables.php:1044
-#: includes/variables.php:1090
-#: includes/variables.php:1215
-#: includes/variables.php:1434
+#: includes/variables.php:766
+#: includes/variables.php:902
+#: includes/variables.php:948
+#: includes/variables.php:1018
+#: includes/variables.php:1056
+#: includes/variables.php:1172
+#: includes/variables.php:1370
 msgid "Big Book"
 msgstr ""
 
-#: includes/variables.php:770
-#: includes/variables.php:920
+#: includes/variables.php:767
+#: includes/variables.php:903
 msgid "Birthday"
 msgstr ""
 
-#: includes/variables.php:771
-#: includes/variables.php:921
+#: includes/variables.php:768
+#: includes/variables.php:904
 msgid "Breakfast"
 msgstr ""
 
-#: includes/variables.php:772
-#: includes/variables.php:871
-#: includes/variables.php:925
-#: includes/variables.php:1091
-#: includes/variables.php:1137
-#: includes/variables.php:1175
+#: includes/variables.php:769
+#: includes/variables.php:855
+#: includes/variables.php:908
+#: includes/variables.php:1057
+#: includes/variables.php:1094
+#: includes/variables.php:1132
 msgid "Candlelight"
 msgstr ""
 
-#: includes/variables.php:773
-#: includes/variables.php:868
-#: includes/variables.php:923
-#: includes/variables.php:1046
-#: includes/variables.php:1092
+#: includes/variables.php:770
+#: includes/variables.php:852
+#: includes/variables.php:906
+#: includes/variables.php:1020
+#: includes/variables.php:1058
 msgid "Child-Friendly"
 msgstr ""
 
-#: includes/variables.php:775
-#: includes/variables.php:872
-#: includes/variables.php:926
+#: includes/variables.php:772
+#: includes/variables.php:856
+#: includes/variables.php:909
 msgid "Concurrent with Al-Anon"
 msgstr ""
 
-#: includes/variables.php:776
-#: includes/variables.php:873
-#: includes/variables.php:927
+#: includes/variables.php:773
+#: includes/variables.php:857
+#: includes/variables.php:910
 msgid "Concurrent with Alateen"
 msgstr ""
 
-#: includes/variables.php:777
-#: includes/variables.php:874
-#: includes/variables.php:928
+#: includes/variables.php:774
+#: includes/variables.php:858
+#: includes/variables.php:911
 msgid "Cross Talk Permitted"
 msgstr ""
 
-#: includes/variables.php:778
-#: includes/variables.php:929
-#: includes/variables.php:978
-#: includes/variables.php:1097
+#: includes/variables.php:775
+#: includes/variables.php:912
+#: includes/variables.php:952
+#: includes/variables.php:1063
 msgid "Daily Reflections"
 msgstr ""
 
-#: includes/variables.php:779
+#: includes/variables.php:776
 msgid "Digital Basket"
 msgstr ""
 
-#: includes/variables.php:781
-#: includes/variables.php:931
+#: includes/variables.php:778
+#: includes/variables.php:914
 msgid "Dual Diagnosis"
 msgstr ""
 
-#: includes/variables.php:783
-#: includes/variables.php:1281
-#: includes/variables.php:1318
-#: includes/variables.php:1438
-msgid "Finnish"
-msgstr ""
-
-#: includes/variables.php:785
-#: includes/variables.php:934
-#: includes/variables.php:1100
-#: includes/variables.php:1282
-#: includes/variables.php:1319
-#: includes/variables.php:1440
-msgid "French"
-msgstr ""
-
-#: includes/variables.php:787
-#: includes/variables.php:878
-#: includes/variables.php:936
+#: includes/variables.php:781
+#: includes/variables.php:862
+#: includes/variables.php:917
 msgid "Grapevine"
 msgstr ""
 
-#: includes/variables.php:788
-#: includes/variables.php:1442
-msgid "Hebrew"
-msgstr ""
-
-#: includes/variables.php:789
-#: includes/variables.php:1053
-#: includes/variables.php:1443
+#: includes/variables.php:782
+#: includes/variables.php:1022
+#: includes/variables.php:1374
 msgid "Indigenous"
 msgstr ""
 
-#: includes/variables.php:790
-#: includes/variables.php:937
-#: includes/variables.php:1055
-#: includes/variables.php:1102
-#: includes/variables.php:1444
-msgid "Italian"
-msgstr ""
-
-#: includes/variables.php:791
-#: includes/variables.php:1445
-msgid "Japanese"
-msgstr ""
-
-#: includes/variables.php:792
-#: includes/variables.php:938
-#: includes/variables.php:1103
-#: includes/variables.php:1446
-msgid "Korean"
-msgstr ""
-
-#: includes/variables.php:794
-#: includes/variables.php:840
-#: includes/variables.php:880
-#: includes/variables.php:940
-#: includes/variables.php:1056
-#: includes/variables.php:1104
-#: includes/variables.php:1448
+#: includes/variables.php:784
+#: includes/variables.php:825
+#: includes/variables.php:864
+#: includes/variables.php:919
+#: includes/variables.php:1023
+#: includes/variables.php:1066
+#: includes/variables.php:1376
 msgid "Literature"
 msgstr ""
 
-#: includes/variables.php:795
-#: includes/variables.php:941
-#: includes/variables.php:980
+#: includes/variables.php:785
+#: includes/variables.php:920
+#: includes/variables.php:954
 msgid "Living Sober"
 msgstr ""
 
-#: includes/variables.php:796
-#: includes/variables.php:839
-#: includes/variables.php:881
-#: includes/variables.php:942
-#: includes/variables.php:1105
+#: includes/variables.php:786
+#: includes/variables.php:824
+#: includes/variables.php:865
+#: includes/variables.php:921
+#: includes/variables.php:1067
+#: includes/variables.php:1237
+#: includes/variables.php:1265
 #: includes/variables.php:1286
-#: includes/variables.php:1323
-#: includes/variables.php:1347
-#: includes/variables.php:1447
+#: includes/variables.php:1375
 msgid "LGBTQ"
 msgstr ""
 
-#: includes/variables.php:798
-#: includes/variables.php:883
-#: includes/variables.php:944
-#: includes/variables.php:982
-#: includes/variables.php:1058
-#: includes/variables.php:1107
-#: includes/variables.php:1149
-#: includes/variables.php:1187
-#: includes/variables.php:1223
-#: includes/variables.php:1361
-#: includes/variables.php:1406
+#: includes/variables.php:788
+#: includes/variables.php:867
+#: includes/variables.php:923
+#: includes/variables.php:956
+#: includes/variables.php:1025
+#: includes/variables.php:1069
+#: includes/variables.php:1106
+#: includes/variables.php:1144
+#: includes/variables.php:1180
+#: includes/variables.php:1300
+#: includes/variables.php:1345
 msgid "Meditation"
 msgstr ""
 
-#: includes/variables.php:800
-#: includes/variables.php:946
-#: includes/variables.php:1451
+#: includes/variables.php:790
+#: includes/variables.php:925
+#: includes/variables.php:1379
 msgid "Native American"
 msgstr ""
 
-#: includes/variables.php:801
-#: includes/variables.php:842
-#: includes/variables.php:947
-#: includes/variables.php:1109
-#: includes/variables.php:1225
-#: includes/variables.php:1452
-#: includes/variables.php:1497
+#: includes/variables.php:791
+#: includes/variables.php:827
+#: includes/variables.php:926
+#: includes/variables.php:1071
+#: includes/variables.php:1182
+#: includes/variables.php:1380
+#: includes/variables.php:1414
 msgid "Newcomer"
 msgstr ""
 
-#: includes/variables.php:802
+#: includes/variables.php:792
 msgid "Non-Binary"
 msgstr ""
 
-#: includes/variables.php:805
-#: includes/variables.php:845
+#: includes/variables.php:795
+#: includes/variables.php:830
 msgid "Outdoor Meeting"
 msgstr ""
 
-#: includes/variables.php:807
-#: includes/variables.php:950
-#: includes/variables.php:1113
-#: includes/variables.php:1458
-msgid "Polish"
-msgstr ""
-
-#: includes/variables.php:808
-#: includes/variables.php:951
-#: includes/variables.php:1114
-#: includes/variables.php:1459
-msgid "Portuguese"
-msgstr ""
-
-#: includes/variables.php:809
+#: includes/variables.php:797
 msgid "Professionals"
 msgstr ""
 
-#: includes/variables.php:810
+#: includes/variables.php:798
 msgid "Proof of Attendance"
 msgstr ""
 
-#: includes/variables.php:811
-#: includes/variables.php:952
-#: includes/variables.php:1115
-#: includes/variables.php:1460
-msgid "Punjabi"
-msgstr ""
-
-#: includes/variables.php:812
-#: includes/variables.php:953
-#: includes/variables.php:1116
-#: includes/variables.php:1462
-msgid "Russian"
-msgstr ""
-
-#: includes/variables.php:813
-#: includes/variables.php:1065
+#: includes/variables.php:799
+#: includes/variables.php:1032
 msgid "Secular"
 msgstr ""
 
-#: includes/variables.php:814
-#: includes/variables.php:1066
+#: includes/variables.php:800
+#: includes/variables.php:1033
 msgid "Seniors"
 msgstr ""
 
-#: includes/variables.php:815
-#: includes/variables.php:837
-#: includes/variables.php:890
-#: includes/variables.php:954
-#: includes/variables.php:1117
+#: includes/variables.php:801
+#: includes/variables.php:822
+#: includes/variables.php:874
+#: includes/variables.php:929
+#: includes/variables.php:1075
 msgid "Sign Language"
 msgstr ""
 
-#: includes/variables.php:820
-#: includes/variables.php:959
-#: includes/variables.php:1071
-#: includes/variables.php:1123
-#: includes/variables.php:1416
+#: includes/variables.php:805
+#: includes/variables.php:933
+#: includes/variables.php:1037
+#: includes/variables.php:1080
+#: includes/variables.php:1354
 msgid "Tradition Study"
 msgstr ""
 
-#: includes/variables.php:823
-#: includes/variables.php:856
-#: includes/variables.php:1074
-#: includes/variables.php:1473
+#: includes/variables.php:808
+#: includes/variables.php:840
+#: includes/variables.php:1040
+#: includes/variables.php:1391
 msgid "Wheelchair-Accessible Bathroom"
 msgstr ""
 
-#: includes/variables.php:825
-#: includes/variables.php:854
-#: includes/variables.php:902
-#: includes/variables.php:963
-#: includes/variables.php:1032
-#: includes/variables.php:1077
-#: includes/variables.php:1126
-#: includes/variables.php:1164
-#: includes/variables.php:1203
+#: includes/variables.php:810
+#: includes/variables.php:838
+#: includes/variables.php:885
+#: includes/variables.php:937
+#: includes/variables.php:1006
+#: includes/variables.php:1043
+#: includes/variables.php:1083
+#: includes/variables.php:1121
+#: includes/variables.php:1160
 msgid "Young People"
 msgstr ""
 
-#: includes/variables.php:829
+#: includes/variables.php:814
 msgid "CMA"
 msgstr ""
 
-#: includes/variables.php:831
+#: includes/variables.php:816
 msgid "Crystal Meth Anonymous"
 msgstr ""
 
-#: includes/variables.php:833
+#: includes/variables.php:818
 msgid "Closed meetings are for C.M.A members only, or for those who have a using problem and “have a desire to stop using.”"
 msgstr ""
 
-#: includes/variables.php:834
+#: includes/variables.php:819
 msgid "Open meetings are available to anyone interested in Crystal Meth Anonymous’ program of recovery from using. Non users may attend open meetings as observers."
 msgstr ""
 
-#: includes/variables.php:843
+#: includes/variables.php:828
 msgid "Online (only)"
 msgstr ""
 
-#: includes/variables.php:860
+#: includes/variables.php:844
 msgid "CoDA"
 msgstr ""
 
-#: includes/variables.php:862
+#: includes/variables.php:846
 msgid "Co-Dependents Anonymous"
 msgstr ""
 
-#: includes/variables.php:869
-#: includes/variables.php:1397
+#: includes/variables.php:853
+#: includes/variables.php:1336
 msgid "Chips"
 msgstr ""
 
-#: includes/variables.php:875
+#: includes/variables.php:859
 msgid "Daily"
 msgstr ""
 
-#: includes/variables.php:887
+#: includes/variables.php:871
 msgid "Q & A"
 msgstr ""
 
-#: includes/variables.php:888
+#: includes/variables.php:872
 msgid "Reading"
 msgstr ""
 
-#: includes/variables.php:889
+#: includes/variables.php:873
 msgid "Sharing"
 msgstr ""
 
-#: includes/variables.php:895
+#: includes/variables.php:878
 msgid "Teens"
 msgstr ""
 
-#: includes/variables.php:896
-#: includes/variables.php:1415
+#: includes/variables.php:879
+#: includes/variables.php:1353
 msgid "Topic Discussion"
 msgstr ""
 
-#: includes/variables.php:897
-#: includes/variables.php:1160
-#: includes/variables.php:1199
+#: includes/variables.php:880
+#: includes/variables.php:1117
+#: includes/variables.php:1156
 msgid "Tradition"
 msgstr ""
 
-#: includes/variables.php:901
-#: includes/variables.php:1076
-#: includes/variables.php:1242
+#: includes/variables.php:884
+#: includes/variables.php:1042
+#: includes/variables.php:1199
 msgid "Writing"
 msgstr ""
 
-#: includes/variables.php:906
+#: includes/variables.php:889
 msgid "CA"
 msgstr ""
 
-#: includes/variables.php:908
+#: includes/variables.php:891
 msgid "Cocaine Anonymous"
 msgstr ""
 
-#: includes/variables.php:910
+#: includes/variables.php:893
 msgid "This meeting is closed; only those who have a desire to stop using may attend."
 msgstr ""
 
-#: includes/variables.php:922
+#: includes/variables.php:905
 msgid "Business"
 msgstr ""
 
-#: includes/variables.php:967
+#: includes/variables.php:941
 msgid "CEA-HOW"
 msgstr ""
 
-#: includes/variables.php:969
+#: includes/variables.php:943
 msgid "Compulsive Eaters Anonymous-HOW"
 msgstr ""
 
-#: includes/variables.php:972
+#: includes/variables.php:946
 msgid "AA Comes of Age"
 msgstr ""
 
-#: includes/variables.php:976
+#: includes/variables.php:950
 msgid "Came to Believe"
 msgstr ""
 
-#: includes/variables.php:977
+#: includes/variables.php:951
 msgid "CEA-HOW Concept/Tools"
 msgstr ""
 
-#: includes/variables.php:979
+#: includes/variables.php:953
 msgid "Happy Joyous and Free"
 msgstr ""
 
-#: includes/variables.php:981
-#: includes/variables.php:1222
+#: includes/variables.php:955
+#: includes/variables.php:1179
 msgid "Maintenance"
 msgstr ""
 
-#: includes/variables.php:983
+#: includes/variables.php:957
 msgid "Pitch/Speaker"
 msgstr ""
 
-#: includes/variables.php:984
+#: includes/variables.php:958
 msgid "Promises"
 msgstr ""
 
-#: includes/variables.php:985
+#: includes/variables.php:959
 msgid "Relapse and Recovery"
 msgstr ""
 
-#: includes/variables.php:986
+#: includes/variables.php:960
 msgid "Steps/Traditions"
 msgstr ""
 
-#: includes/variables.php:987
-#: includes/variables.php:1070
+#: includes/variables.php:961
+#: includes/variables.php:1036
 msgid "Topic/Discussion"
 msgstr ""
 
-#: includes/variables.php:991
+#: includes/variables.php:965
 msgid "DA"
 msgstr ""
 
-#: includes/variables.php:993
+#: includes/variables.php:967
 msgid "Debtors Anonymous"
 msgstr ""
 
-#: includes/variables.php:995
+#: includes/variables.php:969
 msgid "Abundance"
 msgstr ""
 
-#: includes/variables.php:996
+#: includes/variables.php:970
 msgid "Artist"
 msgstr ""
 
-#: includes/variables.php:997
+#: includes/variables.php:971
 msgid "Business Owner"
 msgstr ""
 
-#: includes/variables.php:999
+#: includes/variables.php:973
 msgid "Clutter"
 msgstr ""
 
-#: includes/variables.php:1002
+#: includes/variables.php:976
 msgid "Numbers"
 msgstr ""
 
-#: includes/variables.php:1005
+#: includes/variables.php:979
 msgid "Prosperity"
 msgstr ""
 
-#: includes/variables.php:1007
-#: includes/variables.php:1368
-#: includes/variables.php:1414
-#: includes/variables.php:1466
+#: includes/variables.php:981
+#: includes/variables.php:1307
+#: includes/variables.php:1352
+#: includes/variables.php:1387
 msgid "Step Study"
 msgstr ""
 
-#: includes/variables.php:1009
+#: includes/variables.php:983
 msgid "Toolkit"
 msgstr ""
 
-#: includes/variables.php:1010
+#: includes/variables.php:984
 msgid "Vision"
 msgstr ""
 
-#: includes/variables.php:1016
+#: includes/variables.php:990
 msgid "DAA"
 msgstr ""
 
-#: includes/variables.php:1018
+#: includes/variables.php:992
 msgid "Drug Addicts Anonymous"
 msgstr ""
 
-#: includes/variables.php:1022
+#: includes/variables.php:996
 msgid "Big Book Study"
 msgstr ""
 
-#: includes/variables.php:1030
+#: includes/variables.php:1004
 msgid "Step Speaker"
 msgstr ""
 
-#: includes/variables.php:1036
+#: includes/variables.php:1010
 msgid "EDA"
 msgstr ""
 
-#: includes/variables.php:1038
+#: includes/variables.php:1012
 msgid "Eating Disorders Anonymous"
 msgstr ""
 
-#: includes/variables.php:1043
+#: includes/variables.php:1017
 msgid "Beginners'"
 msgstr ""
 
-#: includes/variables.php:1045
+#: includes/variables.php:1019
 msgid "Chair's Choice"
 msgstr ""
 
-#: includes/variables.php:1048
-#: includes/variables.php:1278
-#: includes/variables.php:1315
-#: includes/variables.php:1436
-msgid "Dutch"
-msgstr ""
-
-#: includes/variables.php:1050
-#: includes/variables.php:1283
-#: includes/variables.php:1320
-msgid "German"
-msgstr ""
-
-#: includes/variables.php:1051
-msgid "Georgian"
-msgstr ""
-
-#: includes/variables.php:1052
-msgid "Greek"
-msgstr ""
-
-#: includes/variables.php:1054
-msgid "Icelandic"
-msgstr ""
-
-#: includes/variables.php:1062
+#: includes/variables.php:1029
 msgid "Outdoor"
 msgstr ""
 
-#: includes/variables.php:1064
+#: includes/variables.php:1031
 msgid "Rotating Format"
 msgstr ""
 
-#: includes/variables.php:1069
-#: includes/variables.php:1157
-#: includes/variables.php:1196
-#: includes/variables.php:1387
+#: includes/variables.php:1035
+#: includes/variables.php:1114
+#: includes/variables.php:1153
+#: includes/variables.php:1326
 msgid "Step"
 msgstr ""
 
-#: includes/variables.php:1081
+#: includes/variables.php:1047
 msgid "GA"
 msgstr ""
 
-#: includes/variables.php:1083
+#: includes/variables.php:1049
 msgid "Gamblers Anonymous"
 msgstr ""
 
-#: includes/variables.php:1085
+#: includes/variables.php:1051
 msgid "This meeting is closed; only those who have a desire to stop gambling may attend."
 msgstr ""
 
-#: includes/variables.php:1088
+#: includes/variables.php:1054
 msgid "20 Questions/Beginner Focus"
 msgstr ""
 
-#: includes/variables.php:1094
+#: includes/variables.php:1060
 msgid "Combined GA/Gam Anon"
 msgstr ""
 
-#: includes/variables.php:1095
+#: includes/variables.php:1061
 msgid "Comment"
 msgstr ""
 
-#: includes/variables.php:1096
+#: includes/variables.php:1062
 msgid "Cross Comment"
 msgstr ""
 
-#: includes/variables.php:1101
+#: includes/variables.php:1065
 msgid "Gam Anon"
 msgstr ""
 
-#: includes/variables.php:1112
+#: includes/variables.php:1074
 msgid "Parking Meters Available"
 msgstr ""
 
-#: includes/variables.php:1122
-#: includes/variables.php:1159
-#: includes/variables.php:1198
-#: includes/variables.php:1238
+#: includes/variables.php:1079
+#: includes/variables.php:1116
+#: includes/variables.php:1155
+#: includes/variables.php:1195
 msgid "Topic"
 msgstr ""
 
-#: includes/variables.php:1130
+#: includes/variables.php:1087
 msgid "HA"
 msgstr ""
 
-#: includes/variables.php:1132
+#: includes/variables.php:1089
 msgid "Heroin Anonymous"
 msgstr ""
 
-#: includes/variables.php:1134
-#: includes/variables.php:1172
+#: includes/variables.php:1091
+#: includes/variables.php:1129
 msgid "12 Concepts"
 msgstr ""
 
-#: includes/variables.php:1135
-#: includes/variables.php:1173
+#: includes/variables.php:1092
+#: includes/variables.php:1130
 msgid "Basic Text"
 msgstr ""
 
-#: includes/variables.php:1136
-#: includes/variables.php:1174
+#: includes/variables.php:1093
+#: includes/variables.php:1131
 msgid "Beginner/Newcomer"
 msgstr ""
 
-#: includes/variables.php:1138
-#: includes/variables.php:1176
+#: includes/variables.php:1095
+#: includes/variables.php:1133
 msgid "Children Welcome"
 msgstr ""
 
-#: includes/variables.php:1140
-#: includes/variables.php:1178
+#: includes/variables.php:1097
+#: includes/variables.php:1135
 msgid "Discussion/Participation"
 msgstr ""
 
-#: includes/variables.php:1142
-#: includes/variables.php:1180
+#: includes/variables.php:1099
+#: includes/variables.php:1137
 msgid "IP Study"
 msgstr ""
 
-#: includes/variables.php:1143
-#: includes/variables.php:1181
+#: includes/variables.php:1100
+#: includes/variables.php:1138
 msgid "It Works Study"
 msgstr ""
 
-#: includes/variables.php:1144
-#: includes/variables.php:1182
+#: includes/variables.php:1101
+#: includes/variables.php:1139
 msgid "Just For Today Study"
 msgstr ""
 
-#: includes/variables.php:1145
-#: includes/variables.php:1183
-#: includes/variables.php:1220
+#: includes/variables.php:1102
+#: includes/variables.php:1140
+#: includes/variables.php:1177
 msgid "Literature Study"
 msgstr ""
 
-#: includes/variables.php:1146
-#: includes/variables.php:1184
+#: includes/variables.php:1103
+#: includes/variables.php:1141
 msgid "Living Clean"
 msgstr ""
 
-#: includes/variables.php:1150
-#: includes/variables.php:1188
+#: includes/variables.php:1107
+#: includes/variables.php:1145
 msgid "Non-Smoking"
 msgstr ""
 
-#: includes/variables.php:1153
-#: includes/variables.php:1191
+#: includes/variables.php:1110
+#: includes/variables.php:1148
 msgid "Questions & Answers"
 msgstr ""
 
-#: includes/variables.php:1154
-#: includes/variables.php:1192
+#: includes/variables.php:1111
+#: includes/variables.php:1149
 msgid "Restricted Access"
 msgstr ""
 
-#: includes/variables.php:1155
-#: includes/variables.php:1193
+#: includes/variables.php:1112
+#: includes/variables.php:1150
 msgid "Smoking"
 msgstr ""
 
-#: includes/variables.php:1158
-#: includes/variables.php:1197
+#: includes/variables.php:1115
+#: includes/variables.php:1154
 msgid "Step Working Guide Study"
 msgstr ""
 
-#: includes/variables.php:1161
-#: includes/variables.php:1200
+#: includes/variables.php:1118
+#: includes/variables.php:1157
 msgid "Format Varies"
 msgstr ""
 
-#: includes/variables.php:1168
+#: includes/variables.php:1125
 msgid "NA"
 msgstr ""
 
-#: includes/variables.php:1170
+#: includes/variables.php:1127
 msgid "Narcotics Anonymous"
 msgstr ""
 
-#: includes/variables.php:1194
+#: includes/variables.php:1151
 msgid "Spiritual Principle a Day"
 msgstr ""
 
-#: includes/variables.php:1207
+#: includes/variables.php:1164
 msgid "OA"
 msgstr ""
 
-#: includes/variables.php:1209
+#: includes/variables.php:1166
 msgid "Overeaters Anonymous"
 msgstr ""
 
-#: includes/variables.php:1211
+#: includes/variables.php:1168
 msgid "11th Step"
 msgstr ""
 
-#: includes/variables.php:1212
+#: includes/variables.php:1169
 msgid "90 Day"
 msgstr ""
 
-#: includes/variables.php:1213
+#: includes/variables.php:1170
 msgid "AA 12/12"
 msgstr ""
 
-#: includes/variables.php:1214
+#: includes/variables.php:1171
 msgid "Ask-It-Basket"
 msgstr ""
 
-#: includes/variables.php:1216
+#: includes/variables.php:1173
 msgid "Dignity of Choice"
 msgstr ""
 
-#: includes/variables.php:1217
+#: includes/variables.php:1174
 msgid "For Today"
 msgstr ""
 
-#: includes/variables.php:1218
+#: includes/variables.php:1175
 msgid "Lifeline"
 msgstr ""
 
-#: includes/variables.php:1219
+#: includes/variables.php:1176
 msgid "Lifeline Sampler"
 msgstr ""
 
-#: includes/variables.php:1224
+#: includes/variables.php:1181
 msgid "New Beginnings"
 msgstr ""
 
-#: includes/variables.php:1226
+#: includes/variables.php:1183
 msgid "OA H.O.W."
 msgstr ""
 
-#: includes/variables.php:1227
+#: includes/variables.php:1184
 msgid "OA Second and/or Third Edition"
 msgstr ""
 
-#: includes/variables.php:1228
+#: includes/variables.php:1185
 msgid "OA Steps and/or Traditions Study"
 msgstr ""
 
-#: includes/variables.php:1230
+#: includes/variables.php:1187
 msgid "Relapse/12th Step Within"
 msgstr ""
 
-#: includes/variables.php:1231
+#: includes/variables.php:1188
 msgid "Seeking the Spiritual Path"
 msgstr ""
 
-#: includes/variables.php:1233
+#: includes/variables.php:1190
 msgid "Speaker/Discussion"
 msgstr ""
 
-#: includes/variables.php:1234
+#: includes/variables.php:1191
 msgid "Spirituality"
 msgstr ""
 
-#: includes/variables.php:1235
+#: includes/variables.php:1192
 msgid "Teen Friendly"
 msgstr ""
 
-#: includes/variables.php:1236
+#: includes/variables.php:1193
 msgid "The Promises"
 msgstr ""
 
-#: includes/variables.php:1237
-#: includes/variables.php:1486
+#: includes/variables.php:1194
+#: includes/variables.php:1403
 msgid "Tools"
 msgstr ""
 
-#: includes/variables.php:1239
+#: includes/variables.php:1196
 msgid "Varies"
 msgstr ""
 
-#: includes/variables.php:1240
+#: includes/variables.php:1197
 msgid "Voices of Recovery"
 msgstr ""
 
-#: includes/variables.php:1241
+#: includes/variables.php:1198
 msgid "Work Book Study"
 msgstr ""
 
-#: includes/variables.php:1252
+#: includes/variables.php:1209
 msgid "RCA"
 msgstr ""
 
-#: includes/variables.php:1254
+#: includes/variables.php:1211
 msgid "Recovering Couples Anonymous"
 msgstr ""
 
-#: includes/variables.php:1264
-#: includes/variables.php:1266
+#: includes/variables.php:1221
+#: includes/variables.php:1223
 msgid "Recovery Dharma"
 msgstr ""
 
-#: includes/variables.php:1268
-#: includes/variables.php:1305
+#: includes/variables.php:1225
+#: includes/variables.php:1253
 msgid "Men’s meetings are for anyone who identifies as male."
 msgstr ""
 
-#: includes/variables.php:1269
-#: includes/variables.php:1306
+#: includes/variables.php:1226
+#: includes/variables.php:1254
 msgid "Women’s meetings are for anyone who identifies as female."
 msgstr ""
 
-#: includes/variables.php:1276
-#: includes/variables.php:1313
-msgid "Danish"
-msgstr ""
-
-#: includes/variables.php:1277
-#: includes/variables.php:1314
+#: includes/variables.php:1233
+#: includes/variables.php:1261
 msgid "Dog Friendly"
 msgstr ""
 
-#: includes/variables.php:1279
-#: includes/variables.php:1316
+#: includes/variables.php:1234
+#: includes/variables.php:1262
 msgid "Eightfold Path Study"
 msgstr ""
 
-#: includes/variables.php:1284
+#: includes/variables.php:1235
 msgid "Inquiry Study"
 msgstr ""
 
-#: includes/variables.php:1285
+#: includes/variables.php:1236
 msgid "Inquiry Writing"
 msgstr ""
 
-#: includes/variables.php:1289
-#: includes/variables.php:1326
+#: includes/variables.php:1240
+#: includes/variables.php:1268
 msgid "Mindfulness Practice"
 msgstr ""
 
-#: includes/variables.php:1292
-#: includes/variables.php:1329
+#: includes/variables.php:1243
+#: includes/variables.php:1271
 msgid "Process Addictions"
 msgstr ""
 
-#: includes/variables.php:1294
-#: includes/variables.php:1331
-msgid "Swedish"
-msgstr ""
-
-#: includes/variables.php:1295
-#: includes/variables.php:1332
-#: includes/variables.php:1468
-msgid "Thai"
-msgstr ""
-
-#: includes/variables.php:1301
-#: includes/variables.php:1303
+#: includes/variables.php:1249
+#: includes/variables.php:1251
 msgid "Refuge Recovery"
 msgstr ""
 
-#: includes/variables.php:1321
+#: includes/variables.php:1263
 msgid "Inventory Study"
 msgstr ""
 
-#: includes/variables.php:1322
+#: includes/variables.php:1264
 msgid "Inventory Writing"
 msgstr ""
 
-#: includes/variables.php:1338
+#: includes/variables.php:1277
 msgid "SAA"
 msgstr ""
 
-#: includes/variables.php:1340
+#: includes/variables.php:1279
 msgid "Sex Addicts Anonymous"
 msgstr ""
 
-#: includes/variables.php:1353
+#: includes/variables.php:1292
 msgid "SA"
 msgstr ""
 
-#: includes/variables.php:1355
+#: includes/variables.php:1294
 msgid "Sexaholics Anonymous"
 msgstr ""
 
-#: includes/variables.php:1363
+#: includes/variables.php:1302
 msgid "Mixed"
 msgstr ""
 
-#: includes/variables.php:1366
+#: includes/variables.php:1305
 msgid "Primary Purpose"
 msgstr ""
 
-#: includes/variables.php:1373
+#: includes/variables.php:1312
 msgid "SCA"
 msgstr ""
 
-#: includes/variables.php:1375
+#: includes/variables.php:1314
 msgid "Sexual Compulsives Anonymous"
 msgstr ""
 
-#: includes/variables.php:1378
+#: includes/variables.php:1317
 msgid "Chip"
 msgstr ""
 
-#: includes/variables.php:1380
+#: includes/variables.php:1319
 msgid "Court"
 msgstr ""
 
-#: includes/variables.php:1382
+#: includes/variables.php:1321
 msgid "Graphic Language"
 msgstr ""
 
-#: includes/variables.php:1391
+#: includes/variables.php:1330
 msgid "SLAA"
 msgstr ""
 
-#: includes/variables.php:1393
+#: includes/variables.php:1332
 msgid "Sex and Love Addicts Anonymous"
 msgstr ""
 
-#: includes/variables.php:1395
+#: includes/variables.php:1334
 msgid "Anorexia Focus"
 msgstr ""
 
-#: includes/variables.php:1401
+#: includes/variables.php:1340
 msgid "Getting Current"
 msgstr ""
 
-#: includes/variables.php:1402
+#: includes/variables.php:1341
 msgid "Handicapped Accessible"
 msgstr ""
 
-#: includes/variables.php:1403
+#: includes/variables.php:1342
 msgid "Healthy Relationships"
 msgstr ""
 
-#: includes/variables.php:1404
+#: includes/variables.php:1343
 msgid "Literature Reading"
 msgstr ""
 
-#: includes/variables.php:1408
+#: includes/variables.php:1347
 msgid "Newcomers"
 msgstr ""
 
-#: includes/variables.php:1411
+#: includes/variables.php:1350
 msgid "Prison"
 msgstr ""
 
-#: includes/variables.php:1426
+#: includes/variables.php:1364
 msgid "SIA"
 msgstr ""
 
-#: includes/variables.php:1428
+#: includes/variables.php:1366
 msgid "Survivors of Incest Anonymous"
 msgstr ""
 
-#: includes/variables.php:1431
-msgid "Afrikaans"
-msgstr ""
-
-#: includes/variables.php:1432
+#: includes/variables.php:1369
 msgid "American Sign Language"
 msgstr ""
 
-#: includes/variables.php:1433
-msgid "Arabic"
-msgstr ""
-
-#: includes/variables.php:1441
+#: includes/variables.php:1373
 msgid "Genderqueer"
 msgstr ""
 
-#: includes/variables.php:1455
+#: includes/variables.php:1383
 msgid "Open Share Format"
 msgstr ""
 
-#: includes/variables.php:1457
-msgid "Persian"
-msgstr ""
-
-#: includes/variables.php:1461
+#: includes/variables.php:1385
 msgid "Ritual Abuse"
 msgstr ""
 
-#: includes/variables.php:1463
-msgid "Slovenian"
-msgstr ""
-
-#: includes/variables.php:1467
+#: includes/variables.php:1388
 msgid "Steps Workshop"
 msgstr ""
 
-#: includes/variables.php:1470
-msgid "Turkish"
-msgstr ""
-
-#: includes/variables.php:1471
-msgid "Ukrainian"
-msgstr ""
-
-#: includes/variables.php:1478
+#: includes/variables.php:1396
 msgid "UA"
 msgstr ""
 
-#: includes/variables.php:1480
+#: includes/variables.php:1398
 msgid "Underearners Anonymous"
 msgstr ""
 
-#: includes/variables.php:1491
+#: includes/variables.php:1408
 msgid "VA"
 msgstr ""
 
-#: includes/variables.php:1493
+#: includes/variables.php:1410
 msgid "Violence Anonymous"
 msgstr ""
 
-#: includes/variables.php:1520
+#: includes/variables.php:1437
 msgid "Got an improper response from the server, try refreshing the page."
 msgstr ""
 
-#: includes/variables.php:1521
+#: includes/variables.php:1438
 msgid "Email was not sent."
 msgstr ""
 
-#: includes/variables.php:1522
+#: includes/variables.php:1439
 msgid "Enter a location in the field above."
 msgstr ""
 
-#: includes/variables.php:1523
+#: includes/variables.php:1440
 msgid "Google could not find that location."
 msgstr ""
 
-#: includes/variables.php:1524
+#: includes/variables.php:1441
 msgid "Looking up address…"
 msgstr ""
 
-#: includes/variables.php:1525
+#: includes/variables.php:1442
 msgid "There was an error getting your location."
 msgstr ""
 
-#: includes/variables.php:1526
+#: includes/variables.php:1443
 msgid "Your browser does not appear to support geolocation."
 msgstr ""
 
-#: includes/variables.php:1527
+#: includes/variables.php:1444
 msgid "Finding you…"
 msgstr ""
 
-#: includes/variables.php:1532
+#: includes/variables.php:1449
 msgid "No meetings were found matching the selected criteria."
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 7.2
 Tested up to: 6.7
-Stable tag: 3.16.16
+Stable tag: 3.16.17
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -301,8 +301,11 @@ Yes, you will need to know the key name of the field. Then include an array in y
 
 == Changelog ==
 
+= 3.16.17 =
+* Add standardized list of languages for all programs with backward compatibility [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1252)
+
 = 3.16.16 =
-* Add Types for ACA [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1650)
+* Add types for ACA [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1650)
 * Fix Legacy UI search bookmarking [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1655)
 * Bump dependencies
 


### PR DESCRIPTION
close #1252

* add standardized list of 49 languages for all programs, and override per-program as needed to maintain backward compatibility
* new ui section on the edit meeting screen
* json is unchanged from before

<img width="1728" alt="Screenshot 2025-04-05 at 9 48 06 PM" src="https://github.com/user-attachments/assets/9579ce8f-61f8-4159-8c3b-84e0a1b3dfc8" />

<img width="1728" alt="Screenshot 2025-04-05 at 9 48 17 PM" src="https://github.com/user-attachments/assets/5d6de7a4-f8f7-4943-be29-3578786ccbdd" />
