### PR TITLE
Normalize location info on import

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1632,6 +1632,26 @@ function tsml_compare_imported_meeting($local_meeting, $import_meeting, $transla
     return count($diff_fields) ? $diff_fields : null;
 }
 
+/**
+ * Return hash for imported meeting, for later comparison
+ *
+ * @param [array] $meeting
+ * @return string
+ */
+function tsml_get_import_hash($meeting)
+{
+    $remove_fields = explode(',', ',row,import_hash');
+    if (is_array($meeting)) {
+        foreach ($meeting as $field => $value) {
+            if (in_array(strtolower($field), $remove_fields)) {
+                unset($meeting[$field]);
+            }
+        }
+
+    }
+    return md5(serialize($meeting));
+}
+
 function tsml_header()
 {
     if (function_exists('wp_is_block_theme') && wp_is_block_theme()) {

--- a/includes/functions_get.php
+++ b/includes/functions_get.php
@@ -428,7 +428,7 @@ function tsml_feedback_url($meeting)
  */
 function tsml_get_meetings($arguments = [], $from_cache = true, $full_export = false)
 {
-    global $tsml_cache, $tsml_cache_writable, $tsml_contact_fields, $tsml_contact_display, $tsml_data_sources, $tsml_custom_meeting_fields, $tsml_source_fields_map, $tsml_entity_fields, $tsml_array_fields;
+    global $tsml_cache, $tsml_cache_writable, $tsml_contact_fields, $tsml_contact_display, $tsml_data_sources, $tsml_custom_meeting_fields, $tsml_source_fields_map, $tsml_import_fields, $tsml_entity_fields, $tsml_array_fields;
 
     $tsml_entity = tsml_get_entity();
 
@@ -550,6 +550,12 @@ function tsml_get_meetings($arguments = [], $from_cache = true, $full_export = f
             // add feedback_url only if present
             if ($feedback_url = tsml_feedback_url($meeting)) {
                 $meeting['feedback_url'] = $feedback_url;
+            }
+
+            foreach ($tsml_import_fields as $field) {
+                if (!empty($meeting_meta[$post->ID][$field])) {
+                    $meeting[$field] = $meeting_meta[$post->ID][$field];
+                }
             }
 
             // add entity fields
@@ -686,7 +692,7 @@ function tsml_get_meetings($arguments = [], $from_cache = true, $full_export = f
  */
 function tsml_get_meta($type, $id = null)
 {
-    global $wpdb, $tsml_custom_meeting_fields, $tsml_contact_fields, $tsml_source_fields_map, $tsml_entity_fields, $tsml_array_fields;
+    global $wpdb, $tsml_custom_meeting_fields, $tsml_contact_fields, $tsml_source_fields_map, $tsml_import_fields, $tsml_entity_fields, $tsml_array_fields;
     $keys = [
         'tsml_group' => array_keys($tsml_contact_fields),
         'tsml_location' => ['formatted_address', 'latitude', 'longitude', 'approximate', 'timezone'],
@@ -705,6 +711,7 @@ function tsml_get_meta($type, $id = null)
             ],
             array_keys($tsml_contact_fields),
             array_keys($tsml_source_fields_map),
+            $tsml_import_fields,
             $tsml_entity_fields,
             empty($tsml_custom_meeting_fields) ? [] : array_keys($tsml_custom_meeting_fields)
         ),

--- a/includes/functions_import.php
+++ b/includes/functions_import.php
@@ -179,7 +179,7 @@ function tsml_import_data_source($data_source_url, $data_source_name = '', $data
  */
 function tsml_import_buffer_next($limit = 25)
 {
-    global $tsml_data_sources, $tsml_custom_meeting_fields, $tsml_source_fields_map, $tsml_contact_fields, $tsml_entity_fields, $tsml_array_fields;
+    global $tsml_data_sources, $tsml_custom_meeting_fields, $tsml_source_fields_map, $tsml_contact_fields, $tsml_import_fields, $tsml_entity_fields, $tsml_array_fields;
 
     $meetings = tsml_get_option_array('tsml_import_buffer');
     $errors = $remaining = [];
@@ -384,6 +384,7 @@ function tsml_import_buffer_next($limit = 25)
         $custom_meeting_fields = array_merge(
             ['types', 'data_source', 'conference_url', 'conference_url_notes', 'conference_phone', 'conference_phone_notes'],
             array_keys($tsml_source_fields_map),
+            $tsml_import_fields,
             $tsml_entity_fields
         );
         if (!empty($tsml_custom_meeting_fields)) {
@@ -614,6 +615,7 @@ function tsml_import_get_changed_meetings($feed_meetings, $data_source_url)
     // list changed and new meetings found in the data source feed
     foreach ($feed_meetings as $index => $feed_meeting) {
         $feed_meeting_slug = $source_meeting = $source_meeting_id = null;
+        $feed_meeting['import_hash'] = tsml_get_import_hash($feed_meeting);
 
         if (empty($feed_meeting) || !is_array($feed_meeting)) {
             continue;
@@ -632,6 +634,11 @@ function tsml_import_get_changed_meetings($feed_meetings, $data_source_url)
         if ($source_meeting) {
             $source_meeting = (array) $source_meeting;
             $found_meeting_ids[] = $source_meeting['id'];
+
+            if (!empty($source_meeting['import_hash']) && $source_meeting['import_hash'] === $feed_meeting['import_hash']) {
+                continue;
+            }
+
             $changed_fields = tsml_compare_imported_meeting($source_meeting, $feed_meeting);
 
             if (!empty($changed_fields)) {

--- a/includes/functions_import.php
+++ b/includes/functions_import.php
@@ -762,9 +762,6 @@ function tsml_import_sanitize_meetings($meetings, $data_source_url = null, $data
         'region',
     ];
 
-    // for sanitizing timezone values
-    $all_timezones = DateTimeZone::listIdentifiers();
-
     // track sanitized meeting slug counts
     $meeting_slugs = array();
 
@@ -1082,17 +1079,12 @@ function tsml_import_sanitize_meetings($meetings, $data_source_url = null, $data
 
         // sanitize timezone if present
         if (!empty($meetings[$i]['timezone'])) {
-            if (!in_array($meetings[$i]['timezone'], $all_timezones)) {
-                // make an attempt to find timezone
-                $timezone = str_replace(' ', '_', $meetings[$i]['timezone']);
-                $matches = array_values(array_filter($all_timezones, function($tz) use ($timezone) {
-                    return false !== stripos($tz, $timezone);
-                }));
-                if (count($matches)) {
-                    $meetings[$i]['timezone'] = $matches[0];
-                } else {
-                    unset($meetings[$i]['timezone']);
-                }
+            // make an attempt to find timezone
+            $timezone = tsml_timezone_parse($meetings[$i]['timezone']);
+            if ($timezone) {
+                $meetings[$i]['timezone'] = $timezone;
+            } else {
+                unset($meetings[$i]['timezone']);
             }
         }
 

--- a/includes/functions_timezone.php
+++ b/includes/functions_timezone.php
@@ -49,3 +49,56 @@ function tsml_timezone_select($selected = null)
     </select>
     <?php
 }
+
+/**
+ * Given a string, attempt to return a supported DateTime timezone
+ *
+ * @param string $value
+ * @return string|null Accepted DateTime timezone, or null if none matching
+ */
+function tsml_timezone_parse($value = null)
+{
+    global $tsml_timezone_aliases, $_tsml_timezone_matches;
+
+    $_tsml_timezone_matches = (array) $_tsml_timezone_matches;
+    if (isset($_tsml_timezone_matches[$value])) {
+        return $_tsml_timezone_matches[$value];
+    }
+
+    $timezone = null;
+    $all_timezones = DateTimeZone::listIdentifiers();
+   
+    // first look for exact match
+    if (in_array($value, $all_timezones)) {
+        $timezone = $value;
+    }
+
+    // next look for a single case-insensitive match
+    if (!$timezone) {
+        $value_match = strtolower(trim(strval($value)));
+        $value_underscore = str_replace(' ', '_', $value_match);
+        $matches = array_values(array_filter($all_timezones, function($tz) use ($value_underscore) {
+            return false !== stripos($tz, $value_underscore);
+        }));
+        if (1 === count($matches)) {
+            $timezone = $matches[0];
+        }
+    }
+
+    // if we still don't have a match, check TZ aliases
+    if (!$timezone) {
+        foreach ($tsml_timezone_aliases as $tz_value => $tz_aliases) {
+            $match = array_filter($tz_aliases, function($alias) use ($value_match) {
+                return $value_match === strtolower($alias);
+            });
+            if (count($match)) {
+                $timezone = $tz_value;
+                break;
+            }
+        }
+    }
+
+    // cache result, less looping later
+    $_tsml_timezone_matches[$value] = $timezone;
+    return $timezone;
+}

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -75,6 +75,11 @@ for ($i = 1; $i <= TSML_GROUP_CONTACT_COUNT; $i++) {
     }
 }
 
+// define additional import metadata fields
+$tsml_import_fields = [
+    'import_hash',
+];
+
 // define entity fields (stored in option tsml_entity)
 $tsml_entity_fields = [
     'entity',
@@ -177,6 +182,7 @@ $tsml_source_fields_map = [
     'source_region' => 'region',
     'source_sub_region' => 'sub_region',
     'source_slug' => 'slug',
+    'source_location' => 'location',
 ];
 
 // load email addresses to send user feedback about meetings

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -182,7 +182,6 @@ $tsml_source_fields_map = [
     'source_region' => 'region',
     'source_sub_region' => 'sub_region',
     'source_slug' => 'slug',
-    'source_location' => 'location',
 ];
 
 // load email addresses to send user feedback about meetings

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -619,6 +619,13 @@ $tsml_timestamp = microtime(true);
 // timezone
 $default_tz = tsml_timezone_is_valid(wp_timezone_string()) ? wp_timezone_string() : null;
 $tsml_timezone = get_option('tsml_timezone', $default_tz);
+// common timezone aliases
+$tsml_timezone_aliases = [
+    'America/New_York' => ['ET', 'EST', 'EDT', 'Eastern'],
+    'America/Chicago' => ['CT', 'CST', 'CDT', 'Central'],
+    'America/Denver' => ['MT', 'MST', 'MDT', 'Mountain'],
+    'America/Los_Angeles' => ['PT', 'PST', 'PDT', 'Pacific', 'West_Coast'],
+];
 
 // for customizing TSML-UI
 $tsml_ui_config = [];


### PR DESCRIPTION
As we do with Group info, this also loops through Locations by Formatted Address and makes sure each Location / `tsml_location` gets the same values. This avoids the issue from Google Sheets where you have the same location with 2 or more values for a field

![image](https://github.com/user-attachments/assets/31729c1a-7c5a-4e48-a816-8b97916caf19)

Also moved the timezone sanitization to the same import sanitize function, and tried making it a little more forgiving. I noticed any timezone value in Google Sheets, unless it's exactly an accepted value, causes change notifications.