### PR TITLE
Add rest endpoint for meeting feed

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -5,7 +5,7 @@
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Description: Manage a list of recovery meetings
- * Version: 3.18.1
+ * Version: 3.18.2
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -31,7 +31,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 define('TSML_PATH', plugin_dir_path(__FILE__));
 define('TSML_SETTINGS_PERMISSION', 'manage_options');
-define('TSML_VERSION', '3.18.1');
+define('TSML_VERSION', '3.18.2');
 
 // include these files first
 include TSML_PATH . '/includes/filter_meetings.php';
@@ -47,6 +47,7 @@ include TSML_PATH . '/includes/variables.php';
 // include public files
 include TSML_PATH . '/includes/ajax.php';
 include TSML_PATH . '/includes/init.php';
+include TSML_PATH . '/includes/rest.php';
 include TSML_PATH . '/includes/shortcodes.php';
 include TSML_PATH . '/includes/widgets.php';
 include TSML_PATH . '/includes/widgets_init.php';

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1,0 +1,27 @@
+<?php
+
+// rest api functions
+
+add_action('rest_api_init', function () {
+    register_rest_route('tsml', '/meetings', [
+        'methods' => 'GET',
+        'callback' => 'tsml_rest_feed_endpoint',
+        'args' => [
+            'key' => [
+                'required' => false,
+                'type' => 'string',
+            ],
+        ],
+    ]);
+});
+
+function tsml_rest_feed_endpoint($wp_rest_request)
+{
+    global $tsml_sharing, $tsml_sharing_keys;
+    $key = $wp_rest_request->get_param('key');
+    if ($tsml_sharing === 'open' || (is_string($key) && array_key_exists($key, (array) $tsml_sharing_keys))) {
+        $meetings = tsml_get_meetings();
+        return rest_ensure_response($meetings);
+    }
+    return new WP_Error('feed_restricted', __('This meeting list is restricted.', '12-step-meeting-list'), ['status' => 403]);
+}

--- a/languages/12-step-meeting-list.pot
+++ b/languages/12-step-meeting-list.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: 12 Step Meeting List 3.18\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/trunk\n"
+"Project-Id-Version: 12 Step Meeting List 3.18.2\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/12-step-meeting-list\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-07-27T16:49:58+00:00\n"
+"POT-Creation-Date: 2025-08-03T15:36:17+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: 12-step-meeting-list\n"
@@ -466,13 +466,13 @@ msgstr ""
 #: includes/functions.php:535
 #: includes/shortcodes.php:81
 #: includes/variables.php:668
-#: templates/archive-locations.php:116
+#: templates/archive-locations.php:128
 msgid "Meeting"
 msgstr ""
 
 #: includes/admin_lists.php:114
 #: includes/admin_meeting.php:75
-#: templates/archive-locations.php:114
+#: templates/archive-locations.php:126
 msgid "Day"
 msgstr ""
 
@@ -481,7 +481,7 @@ msgstr ""
 #: includes/shortcodes.php:80
 #: includes/variables.php:666
 #: includes/variables.php:995
-#: templates/archive-locations.php:115
+#: templates/archive-locations.php:127
 msgid "Time"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 #: includes/functions.php:489
 #: includes/shortcodes.php:83
 #: includes/variables.php:671
-#: templates/archive-locations.php:119
+#: templates/archive-locations.php:131
 msgid "Region"
 msgstr ""
 
@@ -591,7 +591,7 @@ msgstr ""
 #: includes/admin_meeting.php:101
 #: includes/ajax.php:228
 #: includes/variables.php:673
-#: templates/archive-locations.php:121
+#: templates/archive-locations.php:133
 msgid "Types"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 #: includes/ajax.php:236
 #: includes/functions.php:556
 #: includes/shortcodes.php:82
-#: templates/archive-locations.php:117
+#: templates/archive-locations.php:129
 msgid "Location"
 msgstr ""
 
@@ -1862,6 +1862,10 @@ msgstr ""
 
 #: includes/functions_log.php:10
 msgid "Geocoding connection error"
+msgstr ""
+
+#: includes/rest.php:26
+msgid "This meeting list is restricted."
 msgstr ""
 
 #: includes/save.php:13
@@ -3336,24 +3340,24 @@ msgstr ""
 msgid "Index of %s Meetings"
 msgstr ""
 
-#: templates/archive-locations.php:107
+#: templates/archive-locations.php:119
 #, php-format
 msgid "This page is intended for web crawlers. To find a meeting, please visit our <a href=\"%s\">meetings page</a>."
 msgstr ""
 
-#: templates/archive-locations.php:118
+#: templates/archive-locations.php:130
 msgid "Formatted Address"
 msgstr ""
 
-#: templates/archive-locations.php:120
+#: templates/archive-locations.php:132
 msgid "Sub-Region"
 msgstr ""
 
-#: templates/archive-locations.php:122
+#: templates/archive-locations.php:134
 msgid "Latitude"
 msgstr ""
 
-#: templates/archive-locations.php:123
+#: templates/archive-locations.php:135
 msgid "Longitude"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 7.2
 Tested up to: 6.8
-Stable tag: 3.18.1
+Stable tag: 3.18.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -300,6 +300,9 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.18.2 =
+* Adding alternate wp-json path for meeting feed
 
 = 3.18.1 =
 * Add startDate property to JSON-LD schema


### PR DESCRIPTION
Adding the rest endpoint for now without announcing in admin. We can discuss next if this replacing the standard path or is shared in the admin as an alternate path.

```
/wp-json/tsml/meetings
/wp-json/tsml/meetings?key={key}
```