### PR TITLE
fix links when $tsml_slug has been unset

### DIFF
--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -537,7 +537,7 @@ if (!function_exists('tsml_import_page')) {
                                     <?php echo wp_kses(sprintf(
                                         // translators: %s is the link to the public meetings page
                                         __('Your public meetings page is <a href="%s">right here</a>. Link that page from your site\'s nav menu to make it visible to the public.', '12-step-meeting-list'),
-                                        get_post_type_archive_link('tsml_meeting')
+                                        tsml_meetings_url()
                                     ), TSML_ALLOWED_HTML) ?>
                                 </p>
                                 <?php

--- a/includes/admin_settings.php
+++ b/includes/admin_settings.php
@@ -443,7 +443,7 @@ if (!function_exists('tsml_settings_page')) {
                                 <?php echo wp_kses(sprintf(
                                     // translators: %s is a link to the meeting finder page
                                     __('Please select the user interface that is right for your <a href="%s" target="_blank">meeting finder page</a>. Choose between our latest design that we call <b>TSML UI</b> or stay with the standard <b>Legacy UI</b>.', '12-step-meeting-list'),
-                                    get_post_type_archive_link('tsml_meeting')
+                                    tsml_meetings_url()
                                 ), TSML_ALLOWED_HTML) ?>
                             </p>
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1171,9 +1171,7 @@ function tsml_meetings_url($parameters = [])
         $url = get_home_url();
     }
 
-    foreach ($parameters as $key => $value) {
-        $url = add_query_arg($key, $value, $url);
-    }
+    $url = add_query_arg($parameters, $url);
 
     return $url;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -856,7 +856,7 @@ function tsml_geocode_google($address)
     $options = [
         'application' => 'tsml',
         'language' => $tsml_language,
-        'referrer' => get_post_type_archive_link('tsml_meeting'),
+        'referrer' => tsml_meetings_url(),
         'search' => $address,
     ];
 
@@ -1157,17 +1157,24 @@ function tsml_link_url($url, $exclude = '')
 }
 
 /**
- * link to meetings page with parameters (added to link dropdown menus for SEO)
- * used: archive-meetings.php
+ * link to meetings page with parameters
+ * used: admin_import.php, admin_settings.php, archive-meetings.php, init.php, widgets.php, tsml_geocode_google()
  * 
  * @param mixed $parameters
  * @return string
  */
-function tsml_meetings_url($parameters)
+function tsml_meetings_url($parameters = [])
 {
     $url = get_post_type_archive_link('tsml_meeting');
-    $url .= (strpos($url, '?') === false) ? '?' : '&';
-    $url .= http_build_query($parameters);
+
+    if (empty($url)) {
+        $url = get_home_url();
+    }
+
+    foreach ($parameters as $key => $value) {
+        $url = add_query_arg($key, $value, $url);
+    }
+
     return $url;
 }
 
@@ -1726,12 +1733,6 @@ function tsml_redirect_legacy_query_params()
     }
 
     if (count($replacements) > 0) {
-        $url = get_post_type_archive_link('tsml_meeting');
-
-        foreach ($replacements as $key => $value) {
-            $url = add_query_arg($key, $value, $url);
-        }
-
-        wp_redirect($url);
+        wp_redirect(tsml_meetings_url($replacements));
     }
 }

--- a/includes/init.php
+++ b/includes/init.php
@@ -44,8 +44,8 @@ add_action('init', function () {
 
             // when TSML UI is enabled, redirect legacy meeting detail page to TSML UI detail page
             if ($tsml_user_interface === 'tsml_ui') {
-                $mtg_permalink = get_post_type_archive_link('tsml_meeting');
-                wp_redirect(add_query_arg('meeting', $post->post_name, $mtg_permalink));
+                $url = tsml_meetings_url(['meeting' => $post->post_name]);
+                wp_redirect($url);
                 exit;
             }
 
@@ -61,8 +61,8 @@ add_action('init', function () {
 
             // when TSML UI is enabled, redirect legacy location page to main meetings page
             if ($tsml_user_interface == 'tsml_ui') {
-                $mtg_permalink = get_post_type_archive_link('tsml_meeting');
-                wp_redirect($mtg_permalink);
+                $url = tsml_meetings_url();
+                wp_redirect($url);
                 exit;
             }
 

--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -111,12 +111,9 @@ class TSML_Widget_Upcoming extends WP_Widget
         }
         $output .= $table;
         $meetings = tsml_get_meetings(['day' => intval(current_time('w')), 'time' => 'upcoming']);
-        $meetings_link = get_post_type_archive_link('tsml_meeting');
-        if ($tsml_user_interface == 'tsml_ui' || (!count($meetings) && !empty($instance['message']))) {
-            $link = $meetings_link;
-        } else {
-            $link = $meetings_link . ((strpos($meetings_link, '?') === false) ? '?' : '&') . 'tsml-time=upcoming';
-        }
+        $link = ($tsml_user_interface == 'tsml_ui' || (!count($meetings) && !empty($instance['message'])))
+            ? tsml_meetings_url()
+            : tsml_meetings_url(['tsml-time' => 'upcoming']);
         $output .= '<p><a href="' . $link . '">' . __('View More…', '12-step-meeting-list') . '</a></p>';
         $output .= $args['after_widget'];
 

--- a/templates/archive-locations.php
+++ b/templates/archive-locations.php
@@ -117,7 +117,7 @@ $schema = [
     <p>
         <?php echo sprintf(
             __('This page is intended for web crawlers. To find a meeting, please visit our <a href="%s">meetings page</a>.', '12-step-meeting-list'),
-            esc_url(get_post_type_archive_link('tsml_meeting'))
+            esc_url(tsml_meetings_url())
         ); ?>
     </p>
     <table border="1" cellpadding="5" cellspacing="0">

--- a/templates/single-locations.php
+++ b/templates/single-locations.php
@@ -35,8 +35,7 @@ tsml_header();
                         <?php echo esc_html($location->post_title) ?>
                     </h1>
                     <div>
-                        <a
-                            href="<?php echo esc_url(tsml_link_url(get_post_type_archive_link('tsml_meeting'), 'tsml_location')) ?>">
+                        <a href="<?php echo esc_url(tsml_link_url(tsml_meetings_url(), 'tsml_location')) ?>">
                             <em class="glyphicon glyphicon-chevron-right"></em>
                             <?php esc_html_e('Back to Meetings', '12-step-meeting-list') ?>
                         </a>

--- a/templates/single-meetings.php
+++ b/templates/single-meetings.php
@@ -57,8 +57,7 @@ tsml_header();
                     <div class="attendance-option">
                         <?php echo esc_html($tsml_meeting_attendance_options[$meeting->attendance_option]) ?>
                     </div>
-                    <a
-                        href="<?php echo esc_url(tsml_link_url(get_post_type_archive_link('tsml_meeting'), 'tsml_meeting')) ?>">
+                    <a href="<?php echo esc_url(tsml_link_url(tsml_meetings_url(), 'tsml_meeting')) ?>">
                         <em class="glyphicon glyphicon-chevron-right"></em>
                         <?php esc_html_e('Back to Meetings', '12-step-meeting-list') ?>
                     </a>


### PR DESCRIPTION
in our readme we say about `$tsml_slug`

> You may set it to false to hide the public meeting finder altogether.

when that happens, `get_post_type_archive('tsml_meeting')`, which we use in a lot of places, returns false.

this PR gets the home page as a fallback. it improves and makes better use of the existing `tsml_meetings_url()` function