### PR TITLE
prepare for 3.9.1 release

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -5,7 +5,7 @@
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Description: Manage a list of recovery meetings
- * Version: 3.19
+ * Version: 3.19.1
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -34,7 +34,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 define('TSML_PATH', plugin_dir_path(__FILE__));
 define('TSML_SETTINGS_PERMISSION', 'manage_options');
-define('TSML_VERSION', '3.19');
+define('TSML_VERSION', '3.19.1');
 
 // include these files first
 include TSML_PATH . '/includes/filter_meetings.php';

--- a/includes/admin_meeting.php
+++ b/includes/admin_meeting.php
@@ -57,6 +57,7 @@ add_action('admin_init', function () {
         if (!empty($meeting->data_source)) {
             $data_source_name = property_exists($meeting, 'data_source_name') ? $meeting->data_source_name : $meeting->data_source;
             $message = sprintf(
+                // translators: %s is the data source name
                 __('This meeting was imported from an external feed %s. Any changes you make here will be overwritten when you refresh the data.', '12-step-meeting-list'),
                 "<strong>$data_source_name</strong>"
             );

--- a/includes/functions_email.php
+++ b/includes/functions_email.php
@@ -42,6 +42,7 @@ function tsml_email_meeting_change($email_to, $meeting, $old_meeting)
     if ('publish' === $update_type) {
         $subject = __('Meeting Published', '12-step-meeting-list');
         $message .= sprintf(
+            // translators: 1: user display name, 2: meeting permalink, 3: site name
             __('This is to notify you that %1$s published a <a href="%2$s">meeting</a> on the %3$s site.', '12-step-meeting-list'),
             $user->display_name,
             get_permalink($meeting->ID),
@@ -50,6 +51,7 @@ function tsml_email_meeting_change($email_to, $meeting, $old_meeting)
     } elseif ('draft' === $update_type) {
         $subject = __('Meeting moved to Draft', '12-step-meeting-list');
         $message .= sprintf(
+            // translators: 1: user display name, 2: meeting permalink, 3: site name
             __('This is to notify you that %1$s saved a <a href="%2$s">meeting</a> as a draft on the %3$s site.', '12-step-meeting-list'),
             $user->display_name,
             get_permalink($meeting->ID),
@@ -58,6 +60,7 @@ function tsml_email_meeting_change($email_to, $meeting, $old_meeting)
     } else {
         $subject = __('Meeting Updated', '12-step-meeting-list');
         $message .= sprintf(
+            // translators: 1: user display name, 2: meeting permalink, 3: site name
             __('This is to notify you that %1$s updated a <a href="%2$s">meeting</a> on the %3$s site.', '12-step-meeting-list'),
             $user->display_name,
             get_permalink($meeting->ID),

--- a/includes/functions_import.php
+++ b/includes/functions_import.php
@@ -73,6 +73,7 @@ function tsml_import_data_source($data_source_url, $data_source_name = '', $data
             tsml_log(
                 'data_source',
                 __('Added', '12-step-meeting-list') . ' - ' . $data_source_name,
+                // translators: %s is the number of meetings
                 sprintf(__('%s meetings', '12-step-meeting-list'), count($import_meetings))
             );
 
@@ -83,6 +84,7 @@ function tsml_import_data_source($data_source_url, $data_source_name = '', $data
             tsml_log(
                 'data_source',
                 __('Updates queued', '12-step-meeting-list') . ' - ' . $data_source_name,
+                // translators: %s is the number of updates
                 sprintf(__('%s updates', '12-step-meeting-list'), count($change_log))
             );
 

--- a/languages/12-step-meeting-list.pot
+++ b/languages/12-step-meeting-list.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: 12 Step Meeting List 3.19\n"
+"Project-Id-Version: 12 Step Meeting List 3.19.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/trunk\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-09-12T14:16:07+00:00\n"
+"POT-Creation-Date: 2025-10-08T15:10:05+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: 12-step-meeting-list\n"
@@ -125,10 +125,10 @@ msgstr ""
 
 #: includes/admin_import.php:255
 #: includes/admin_lists.php:373
-#: includes/admin_meeting.php:348
-#: includes/admin_meeting.php:405
+#: includes/admin_meeting.php:349
+#: includes/admin_meeting.php:406
 #: includes/functions.php:526
-#: includes/variables.php:1450
+#: includes/variables.php:1452
 #: templates/archive-meetings.php:190
 #: templates/archive-meetings.php:206
 msgid "Meetings"
@@ -359,7 +359,7 @@ msgstr ""
 
 #. translators: %s is the number of meetings
 #: includes/admin_import.php:556
-#: includes/functions_import.php:482
+#: includes/functions_import.php:484
 #, php-format
 msgid "%s meeting"
 msgid_plural "%s meetings"
@@ -368,7 +368,7 @@ msgstr[1] ""
 
 #. translators: %s is the number of locations
 #: includes/admin_import.php:563
-#: includes/functions_import.php:484
+#: includes/functions_import.php:486
 #, php-format
 msgid "%s location"
 msgid_plural "%s locations"
@@ -377,7 +377,7 @@ msgstr[1] ""
 
 #. translators: %s is the number of groups
 #: includes/admin_import.php:570
-#: includes/functions_import.php:486
+#: includes/functions_import.php:488
 #, php-format
 msgid "%s group"
 msgid_plural "%s groups"
@@ -386,7 +386,7 @@ msgstr[1] ""
 
 #. translators: %s is the number of regions
 #: includes/admin_import.php:577
-#: includes/functions_import.php:488
+#: includes/functions_import.php:490
 #, php-format
 msgid "%s region"
 msgid_plural "%s regions"
@@ -452,7 +452,7 @@ msgid "Type"
 msgstr ""
 
 #: includes/admin_lists.php:35
-#: includes/admin_meeting.php:422
+#: includes/admin_meeting.php:423
 msgid "None"
 msgstr ""
 
@@ -466,43 +466,43 @@ msgstr ""
 #: includes/functions.php:527
 #: includes/shortcodes.php:81
 #: includes/variables.php:652
-#: templates/archive-locations.php:128
+#: templates/archive-locations.php:131
 msgid "Meeting"
 msgstr ""
 
 #: includes/admin_lists.php:114
-#: includes/admin_meeting.php:75
-#: templates/archive-locations.php:126
+#: includes/admin_meeting.php:76
+#: templates/archive-locations.php:129
 msgid "Day"
 msgstr ""
 
 #: includes/admin_lists.php:115
-#: includes/admin_meeting.php:91
+#: includes/admin_meeting.php:92
 #: includes/shortcodes.php:80
 #: includes/variables.php:650
-#: includes/variables.php:979
-#: templates/archive-locations.php:127
+#: includes/variables.php:981
+#: templates/archive-locations.php:130
 msgid "Time"
 msgstr ""
 
 #: includes/admin_lists.php:116
-#: includes/admin_meeting.php:309
-#: includes/admin_meeting.php:318
+#: includes/admin_meeting.php:310
+#: includes/admin_meeting.php:319
 #: includes/ajax.php:244
 #: includes/functions.php:481
 #: includes/shortcodes.php:83
 #: includes/variables.php:655
-#: templates/archive-locations.php:131
+#: templates/archive-locations.php:134
 msgid "Region"
 msgstr ""
 
 #: includes/admin_lists.php:140
-#: includes/admin_meeting.php:85
-#: includes/functions_email.php:78
-#: includes/functions_email.php:79
+#: includes/admin_meeting.php:86
+#: includes/functions_email.php:81
+#: includes/functions_email.php:82
 #: includes/functions_format.php:43
 #: includes/functions_format.php:128
-#: includes/variables.php:1439
+#: includes/variables.php:1441
 #: templates/archive-meetings.php:639
 msgid "Appointment"
 msgstr ""
@@ -575,227 +575,228 @@ msgid "Editor"
 msgstr ""
 
 #: includes/admin_meeting.php:41
-#: templates/single-meetings.php:90
+#: templates/single-meetings.php:89
 msgid "Meeting Information"
 msgstr ""
 
-#: includes/admin_meeting.php:60
+#. translators: %s is the data source name
+#: includes/admin_meeting.php:61
 #, php-format
 msgid "This meeting was imported from an external feed %s. Any changes you make here will be overwritten when you refresh the data."
 msgstr ""
 
-#: includes/admin_meeting.php:70
+#: includes/admin_meeting.php:71
 msgid "Your meeting has errors that need attention"
 msgstr ""
 
-#: includes/admin_meeting.php:101
+#: includes/admin_meeting.php:102
 #: includes/ajax.php:228
 #: includes/variables.php:657
-#: templates/archive-locations.php:133
+#: templates/archive-locations.php:136
 msgid "Types"
 msgstr ""
 
-#: includes/admin_meeting.php:117
-#: includes/admin_meeting.php:146
+#: includes/admin_meeting.php:118
+#: includes/admin_meeting.php:147
 msgid "View all"
 msgstr ""
 
-#: includes/admin_meeting.php:122
+#: includes/admin_meeting.php:123
 msgid "Hide types not in use"
 msgstr ""
 
-#: includes/admin_meeting.php:131
+#: includes/admin_meeting.php:132
 msgid "Languages"
 msgstr ""
 
-#: includes/admin_meeting.php:151
+#: includes/admin_meeting.php:152
 msgid "Hide languages not in use"
 msgstr ""
 
-#: includes/admin_meeting.php:159
+#: includes/admin_meeting.php:160
 #: includes/ajax.php:232
 msgid "Notes"
 msgstr ""
 
-#: includes/admin_meeting.php:162
+#: includes/admin_meeting.php:163
 msgid "eg. Birthday speaker meeting last Saturday of the month"
 msgstr ""
 
-#: includes/admin_meeting.php:166
+#: includes/admin_meeting.php:167
 msgid "Online Meeting Details"
 msgstr ""
 
 #. translators: %s is the list of supported conference providers
-#: includes/admin_meeting.php:172
+#: includes/admin_meeting.php:173
 #, php-format
 msgid "If this meeting has videoconference information, please enter the full valid URL here. Currently supported providers: %s. If other details are required, such as a password, they can be included in the Notes field above, but a ‘one tap’ experience is ideal. Passwords can be appended to phone numbers using this format <code>+12125551212,,123456789#,,#,,444444#</code>"
 msgstr ""
 
-#: includes/admin_meeting.php:181
+#: includes/admin_meeting.php:182
 msgid "URL"
 msgstr ""
 
-#: includes/admin_meeting.php:185
+#: includes/admin_meeting.php:186
 msgid "Zoom conference urls must be valid to join or register for a meeting. Example: https://zoom.us/j/1234567890"
 msgstr ""
 
-#: includes/admin_meeting.php:188
+#: includes/admin_meeting.php:189
 msgid "Your conference url has been updated to follow the Zoom url standard."
 msgstr ""
 
-#: includes/admin_meeting.php:193
+#: includes/admin_meeting.php:194
 msgid "URL Notes"
 msgstr ""
 
-#: includes/admin_meeting.php:199
-#: includes/admin_meeting.php:453
-#: includes/admin_meeting.php:510
+#: includes/admin_meeting.php:200
+#: includes/admin_meeting.php:454
+#: includes/admin_meeting.php:511
 msgid "Phone"
 msgstr ""
 
-#: includes/admin_meeting.php:205
+#: includes/admin_meeting.php:206
 msgid "Phone Notes"
 msgstr ""
 
-#: includes/admin_meeting.php:214
+#: includes/admin_meeting.php:215
 msgid "Location Information"
 msgstr ""
 
-#: includes/admin_meeting.php:227
+#: includes/admin_meeting.php:228
 msgid "Can I currently attend this meeting in person?"
 msgstr ""
 
-#: includes/admin_meeting.php:231
+#: includes/admin_meeting.php:232
 msgid "Yes"
 msgstr ""
 
-#: includes/admin_meeting.php:235
+#: includes/admin_meeting.php:236
 msgid "No"
 msgstr ""
 
-#: includes/admin_meeting.php:239
+#: includes/admin_meeting.php:240
 msgid "Select Yes for in-person or hybrid meetings."
 msgstr ""
 
-#: includes/admin_meeting.php:240
+#: includes/admin_meeting.php:241
 msgid "Select No for online-only meetings, or meetings that are temporarily inactive."
 msgstr ""
 
-#: includes/admin_meeting.php:242
+#: includes/admin_meeting.php:243
 msgid "For meetings I can attend in person:"
 msgstr ""
 
-#: includes/admin_meeting.php:245
+#: includes/admin_meeting.php:246
 msgid "A specific address is required"
 msgstr ""
 
-#: includes/admin_meeting.php:249
+#: includes/admin_meeting.php:250
 msgid "For online or hybrid meetings:"
 msgstr ""
 
-#: includes/admin_meeting.php:252
+#: includes/admin_meeting.php:253
 msgid "Fill in the \"Online Meeting Details\" above"
 msgstr ""
 
-#: includes/admin_meeting.php:256
+#: includes/admin_meeting.php:257
 msgid "For online-only meetings:"
 msgstr ""
 
-#: includes/admin_meeting.php:259
+#: includes/admin_meeting.php:260
 msgid "Use an approximate address, example: Philadelphia, PA, USA. It may help to think of it as the meeting's origin. The Meeting Guide app uses this information to infer the meeting's time zone."
 msgstr ""
 
-#: includes/admin_meeting.php:267
+#: includes/admin_meeting.php:268
 #: includes/ajax.php:236
 #: includes/functions.php:548
 #: includes/shortcodes.php:82
-#: templates/archive-locations.php:129
+#: templates/archive-locations.php:132
 msgid "Location"
 msgstr ""
 
-#: includes/admin_meeting.php:273
+#: includes/admin_meeting.php:274
 #: includes/ajax.php:240
 #: includes/variables.php:654
 msgid "Address"
 msgstr ""
 
-#: includes/admin_meeting.php:282
+#: includes/admin_meeting.php:283
 msgid "Error: In person meetings must have a specific address."
 msgstr ""
 
-#: includes/admin_meeting.php:285
+#: includes/admin_meeting.php:286
 msgid "Error: Unable to process this address for exact location."
 msgstr ""
 
-#: includes/admin_meeting.php:288
+#: includes/admin_meeting.php:289
 msgid "Online meetings must have a approximate address, like the nearest city or town."
 msgstr ""
 
-#: includes/admin_meeting.php:291
+#: includes/admin_meeting.php:292
 msgid "Warning: Online meetings with a specific address will appear that the location temporarily closed. Meetings that are Online only should use appoximate addresses."
 msgstr ""
 
-#: includes/admin_meeting.php:292
+#: includes/admin_meeting.php:293
 msgid "Example:"
 msgstr ""
 
-#: includes/admin_meeting.php:293
+#: includes/admin_meeting.php:294
 msgid "Location: Online-Philadelphia"
 msgstr ""
 
-#: includes/admin_meeting.php:294
+#: includes/admin_meeting.php:295
 msgid "Address: Philadelphia, PA, USA"
 msgstr ""
 
-#: includes/admin_meeting.php:301
+#: includes/admin_meeting.php:302
 msgid "Apply this updated address to all meetings at this location"
 msgstr ""
 
-#: includes/admin_meeting.php:325
+#: includes/admin_meeting.php:326
 #: templates/archive-meetings.php:369
 msgid "Map"
 msgstr ""
 
-#: includes/admin_meeting.php:332
+#: includes/admin_meeting.php:333
 #: includes/admin_settings.php:468
 msgid "Timezone"
 msgstr ""
 
-#: includes/admin_meeting.php:340
+#: includes/admin_meeting.php:341
 msgid "Because your site does not have a default timezone set, a timezone must be selected here for the meeting to appear on the meeting finder page."
 msgstr ""
 
-#: includes/admin_meeting.php:355
+#: includes/admin_meeting.php:356
 #: includes/ajax.php:248
 msgid "Location Notes"
 msgstr ""
 
-#: includes/admin_meeting.php:358
+#: includes/admin_meeting.php:359
 msgid "eg. Around back, basement, ring buzzer"
 msgstr ""
 
-#: includes/admin_meeting.php:367
+#: includes/admin_meeting.php:368
 msgid "Contact Information <small>Optional</small>"
 msgstr ""
 
-#: includes/admin_meeting.php:384
+#: includes/admin_meeting.php:385
 msgid "Individual meeting"
 msgstr ""
 
-#: includes/admin_meeting.php:388
+#: includes/admin_meeting.php:389
 msgid "Part of a group"
 msgstr ""
 
-#: includes/admin_meeting.php:393
+#: includes/admin_meeting.php:394
 #: includes/functions.php:577
 msgid "Group"
 msgstr ""
 
-#: includes/admin_meeting.php:400
+#: includes/admin_meeting.php:401
 msgid "Apply this group to all meetings at this location"
 msgstr ""
 
-#: includes/admin_meeting.php:413
+#: includes/admin_meeting.php:414
 #: includes/functions.php:502
 #: includes/functions.php:503
 #: includes/functions.php:504
@@ -803,74 +804,74 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: includes/admin_meeting.php:428
+#: includes/admin_meeting.php:429
 msgid "Group Notes"
 msgstr ""
 
-#: includes/admin_meeting.php:431
+#: includes/admin_meeting.php:432
 msgid "eg. Group history, when the business meeting is, etc."
 msgstr ""
 
-#: includes/admin_meeting.php:435
+#: includes/admin_meeting.php:436
 msgid "Website"
 msgstr ""
 
-#: includes/admin_meeting.php:441
+#: includes/admin_meeting.php:442
 msgid "Website 2"
 msgstr ""
 
-#: includes/admin_meeting.php:447
-#: includes/admin_meeting.php:510
+#: includes/admin_meeting.php:448
+#: includes/admin_meeting.php:511
 msgid "Email"
 msgstr ""
 
-#: includes/admin_meeting.php:459
+#: includes/admin_meeting.php:460
 msgid "Mailing Address"
 msgstr ""
 
-#: includes/admin_meeting.php:465
+#: includes/admin_meeting.php:466
 msgid "Venmo"
 msgstr ""
 
-#: includes/admin_meeting.php:471
+#: includes/admin_meeting.php:472
 msgid "Square Cash"
 msgstr ""
 
-#: includes/admin_meeting.php:477
+#: includes/admin_meeting.php:478
 msgid "PayPal"
 msgstr ""
 
-#: includes/admin_meeting.php:481
+#: includes/admin_meeting.php:482
 msgid "A valid PayPal username can only contain letters and numbers, and be less than 20 characters."
 msgstr ""
 
-#: includes/admin_meeting.php:486
+#: includes/admin_meeting.php:487
 msgid "Homegroup Online"
 msgstr ""
 
-#: includes/admin_meeting.php:490
+#: includes/admin_meeting.php:491
 msgid "A valid Homegroup Online group code can only contain letters and numbers."
 msgstr ""
 
-#: includes/admin_meeting.php:495
+#: includes/admin_meeting.php:496
 msgid "Contacts"
 msgstr ""
 
-#: includes/admin_meeting.php:499
+#: includes/admin_meeting.php:500
 #: includes/admin_settings.php:281
 msgid "Public"
 msgstr ""
 
-#: includes/admin_meeting.php:501
+#: includes/admin_meeting.php:502
 #: includes/admin_settings.php:281
 msgid "Private"
 msgstr ""
 
-#: includes/admin_meeting.php:510
+#: includes/admin_meeting.php:511
 msgid "Name"
 msgstr ""
 
-#: includes/admin_meeting.php:523
+#: includes/admin_meeting.php:524
 msgid "Last Contact"
 msgstr ""
 
@@ -878,7 +879,7 @@ msgstr ""
 #: includes/admin_menu.php:17
 #: includes/functions.php:480
 #: includes/functions.php:482
-#: includes/variables.php:1453
+#: includes/variables.php:1455
 msgid "Regions"
 msgstr ""
 
@@ -1074,25 +1075,25 @@ msgstr ""
 
 #: includes/admin_settings.php:367
 #: includes/variables.php:711
-#: includes/variables.php:799
-#: includes/variables.php:833
-#: includes/variables.php:871
-#: includes/variables.php:927
-#: includes/variables.php:975
-#: includes/variables.php:997
-#: includes/variables.php:1022
-#: includes/variables.php:1065
-#: includes/variables.php:1099
-#: includes/variables.php:1163
-#: includes/variables.php:1228
-#: includes/variables.php:1252
-#: includes/variables.php:1278
-#: includes/variables.php:1291
-#: includes/variables.php:1308
-#: includes/variables.php:1326
-#: includes/variables.php:1349
-#: includes/variables.php:1380
-#: includes/variables.php:1413
+#: includes/variables.php:801
+#: includes/variables.php:835
+#: includes/variables.php:873
+#: includes/variables.php:929
+#: includes/variables.php:977
+#: includes/variables.php:999
+#: includes/variables.php:1024
+#: includes/variables.php:1067
+#: includes/variables.php:1101
+#: includes/variables.php:1165
+#: includes/variables.php:1230
+#: includes/variables.php:1254
+#: includes/variables.php:1280
+#: includes/variables.php:1293
+#: includes/variables.php:1310
+#: includes/variables.php:1328
+#: includes/variables.php:1351
+#: includes/variables.php:1382
+#: includes/variables.php:1415
 msgid "Open"
 msgstr ""
 
@@ -1244,43 +1245,43 @@ msgstr ""
 
 #: includes/functions.php:114
 #: includes/variables.php:663
-#: templates/archive-locations.php:12
+#: templates/archive-locations.php:14
 msgid "Sunday"
 msgstr ""
 
 #: includes/functions.php:115
 #: includes/variables.php:664
-#: templates/archive-locations.php:13
+#: templates/archive-locations.php:15
 msgid "Monday"
 msgstr ""
 
 #: includes/functions.php:116
 #: includes/variables.php:665
-#: templates/archive-locations.php:14
+#: templates/archive-locations.php:16
 msgid "Tuesday"
 msgstr ""
 
 #: includes/functions.php:117
 #: includes/variables.php:666
-#: templates/archive-locations.php:15
+#: templates/archive-locations.php:17
 msgid "Wednesday"
 msgstr ""
 
 #: includes/functions.php:118
 #: includes/variables.php:667
-#: templates/archive-locations.php:16
+#: templates/archive-locations.php:18
 msgid "Thursday"
 msgstr ""
 
 #: includes/functions.php:119
 #: includes/variables.php:668
-#: templates/archive-locations.php:17
+#: templates/archive-locations.php:19
 msgid "Friday"
 msgstr ""
 
 #: includes/functions.php:120
 #: includes/variables.php:669
-#: templates/archive-locations.php:18
+#: templates/archive-locations.php:20
 msgid "Saturday"
 msgstr ""
 
@@ -1390,7 +1391,7 @@ msgstr ""
 
 #: includes/functions.php:547
 #: includes/functions.php:549
-#: includes/variables.php:1449
+#: includes/variables.php:1451
 msgid "Locations"
 msgstr ""
 
@@ -1440,7 +1441,7 @@ msgstr ""
 
 #: includes/functions.php:576
 #: includes/functions.php:578
-#: includes/variables.php:1448
+#: includes/variables.php:1450
 msgid "Groups"
 msgstr ""
 
@@ -1589,23 +1590,23 @@ msgid "Nepali"
 msgstr ""
 
 #: includes/functions.php:1019
-msgid "Norwegian"
-msgstr ""
-
-#: includes/functions.php:1020
 msgid "Dutch"
 msgstr ""
 
+#: includes/functions.php:1020
+msgid "Norwegian"
+msgstr ""
+
 #: includes/functions.php:1021
-msgid "Polish"
+msgid "Punjabi"
 msgstr ""
 
 #: includes/functions.php:1022
-msgid "Portuguese"
+msgid "Polish"
 msgstr ""
 
 #: includes/functions.php:1023
-msgid "Punjabi"
+msgid "Portuguese"
 msgstr ""
 
 #: includes/functions.php:1024
@@ -1641,23 +1642,23 @@ msgid "Ukrainian"
 msgstr ""
 
 #. translators: %s is the permission required
-#: includes/functions.php:1213
-#: includes/functions.php:1226
+#: includes/functions.php:1218
+#: includes/functions.php:1231
 #, php-format
 msgid "You do not have sufficient permissions to access this page (<code>%s</code>)."
 msgstr ""
 
 #. translators: %s is the name of the data source
-#: includes/functions.php:1443
+#: includes/functions.php:1448
 #, php-format
 msgid "Please sign in to your website and refresh the <strong>%s</strong> feed on the Import & Export page."
 msgstr ""
 
-#: includes/functions.php:1446
+#: includes/functions.php:1451
 msgid "Go to Import & Export page"
 msgstr ""
 
-#: includes/functions.php:1448
+#: includes/functions.php:1453
 msgid "Data Source Changes Detected"
 msgstr ""
 
@@ -1665,25 +1666,28 @@ msgstr ""
 msgid "Meeting Published"
 msgstr ""
 
-#: includes/functions_email.php:45
+#. translators: 1: user display name, 2: meeting permalink, 3: site name
+#: includes/functions_email.php:46
 #, php-format
 msgid "This is to notify you that %1$s published a <a href=\"%2$s\">meeting</a> on the %3$s site."
 msgstr ""
 
-#: includes/functions_email.php:51
+#: includes/functions_email.php:52
 msgid "Meeting moved to Draft"
 msgstr ""
 
-#: includes/functions_email.php:53
+#. translators: 1: user display name, 2: meeting permalink, 3: site name
+#: includes/functions_email.php:55
 #, php-format
 msgid "This is to notify you that %1$s saved a <a href=\"%2$s\">meeting</a> as a draft on the %3$s site."
 msgstr ""
 
-#: includes/functions_email.php:59
+#: includes/functions_email.php:61
 msgid "Meeting Updated"
 msgstr ""
 
-#: includes/functions_email.php:61
+#. translators: 1: user display name, 2: meeting permalink, 3: site name
+#: includes/functions_email.php:64
 #, php-format
 msgid "This is to notify you that %1$s updated a <a href=\"%2$s\">meeting</a> on the %3$s site."
 msgstr ""
@@ -1704,106 +1708,108 @@ msgstr ""
 msgid "Added"
 msgstr ""
 
-#: includes/functions_import.php:76
+#. translators: %s is the number of meetings
+#: includes/functions_import.php:77
 #, php-format
 msgid "%s meetings"
 msgstr ""
 
-#: includes/functions_import.php:85
+#: includes/functions_import.php:86
 msgid "Updates queued"
 msgstr ""
 
-#: includes/functions_import.php:86
+#. translators: %s is the number of updates
+#: includes/functions_import.php:88
 #, php-format
 msgid "%s updates"
 msgstr ""
 
-#: includes/functions_import.php:122
+#: includes/functions_import.php:124
 msgid "Your meeting list is already in sync with the feed."
 msgstr ""
 
 #. translators: %s is the invalid response from the data source
-#: includes/functions_import.php:140
+#: includes/functions_import.php:142
 #, php-format
 msgid "Invalid response: <pre>%s</pre>."
 msgstr ""
 
-#: includes/functions_import.php:142
+#: includes/functions_import.php:144
 msgid "Data source gave an empty response, you might need to try again."
 msgstr ""
 
-#: includes/functions_import.php:146
+#: includes/functions_import.php:148
 msgid "JSON: no errors."
 msgstr ""
 
-#: includes/functions_import.php:149
+#: includes/functions_import.php:151
 msgid "JSON: Maximum stack depth exceeded."
 msgstr ""
 
-#: includes/functions_import.php:152
+#: includes/functions_import.php:154
 msgid "JSON: Underflow or the modes mismatch."
 msgstr ""
 
-#: includes/functions_import.php:155
+#: includes/functions_import.php:157
 msgid "JSON: Unexpected control character found."
 msgstr ""
 
-#: includes/functions_import.php:158
+#: includes/functions_import.php:160
 msgid "JSON: Syntax error, malformed JSON."
 msgstr ""
 
-#: includes/functions_import.php:161
+#: includes/functions_import.php:163
 msgid "JSON: Malformed UTF-8 characters, possibly incorrectly encoded."
 msgstr ""
 
-#: includes/functions_import.php:164
+#: includes/functions_import.php:166
 msgid "JSON: Unknown error."
 msgstr ""
 
-#: includes/functions_import.php:168
+#: includes/functions_import.php:170
 msgid "Import failed"
 msgstr ""
 
 #. translators: %s is the meeting name
-#: includes/functions_import.php:227
+#: includes/functions_import.php:229
 #, php-format
 msgid "No location information provided for <code>%s</code>."
 msgstr ""
 
-#: includes/functions_import.php:369
-#: includes/functions_import.php:658
+#: includes/functions_import.php:371
+#: includes/functions_import.php:660
 msgid "Meeting added"
 msgstr ""
 
-#: includes/functions_import.php:369
-#: includes/functions_import.php:646
+#: includes/functions_import.php:371
+#: includes/functions_import.php:648
 msgid "Meeting updated"
 msgstr ""
 
-#: includes/functions_import.php:677
+#: includes/functions_import.php:679
 msgid "Meeting removed"
 msgstr ""
 
-#: includes/functions_import.php:777
+#: includes/functions_import.php:779
 msgid "You can now add a Google Sheet directly to TSML. Please replace this feed with the Sheet URL. We will be dropping support for the Google Sheets API in a future release."
 msgstr ""
 
-#: includes/functions_import.php:784
+#: includes/functions_import.php:786
 msgid "The following issues were detected with this Google Sheet:"
 msgstr ""
 
-#: includes/functions_import.php:924
+#: includes/functions_import.php:935
 msgid "Meeting Location"
 msgstr ""
 
 #. translators: %s is the location name
-#: includes/functions_import.php:939
+#: includes/functions_import.php:950
 #, php-format
 msgid "%s by Appointment"
 msgstr ""
 
 #. translators: %1s is the location name, %2s is the day, %3s is the time
-#: includes/functions_import.php:945
+#: includes/functions_import.php:956
 #, php-format
 msgid "%1$1s %2$2s at %3$3s"
 msgstr ""
@@ -1877,7 +1883,7 @@ msgid "This meeting is closed; only those who have a desire to recover from the 
 msgstr ""
 
 #: includes/variables.php:689
-#: includes/variables.php:895
+#: includes/variables.php:897
 msgid "This meeting is open and anyone may attend."
 msgstr ""
 
@@ -1894,25 +1900,25 @@ msgid "Audio / Visual"
 msgstr ""
 
 #: includes/variables.php:695
-#: includes/variables.php:854
-#: includes/variables.php:948
-#: includes/variables.php:1123
-#: includes/variables.php:1242
-#: includes/variables.php:1268
-#: includes/variables.php:1303
-#: includes/variables.php:1337
+#: includes/variables.php:856
+#: includes/variables.php:950
+#: includes/variables.php:1125
+#: includes/variables.php:1244
+#: includes/variables.php:1270
+#: includes/variables.php:1305
+#: includes/variables.php:1339
 msgid "Book Study"
 msgstr ""
 
 #: includes/variables.php:696
-#: includes/variables.php:1124
-#: includes/variables.php:1241
-#: includes/variables.php:1267
+#: includes/variables.php:1126
+#: includes/variables.php:1243
+#: includes/variables.php:1269
 msgid "Beginners"
 msgstr ""
 
 #: includes/variables.php:697
-#: includes/variables.php:1398
+#: includes/variables.php:1400
 msgid "BIPOC"
 msgstr ""
 
@@ -1921,32 +1927,32 @@ msgid "Captions"
 msgstr ""
 
 #: includes/variables.php:699
-#: includes/variables.php:1243
-#: includes/variables.php:1269
-#: includes/variables.php:1339
+#: includes/variables.php:1245
+#: includes/variables.php:1271
+#: includes/variables.php:1341
 msgid "Child Care Available"
 msgstr ""
 
 #: includes/variables.php:700
-#: includes/variables.php:778
-#: includes/variables.php:828
-#: includes/variables.php:857
-#: includes/variables.php:908
-#: includes/variables.php:971
-#: includes/variables.php:994
-#: includes/variables.php:1016
-#: includes/variables.php:1053
-#: includes/variables.php:1088
-#: includes/variables.php:1152
-#: includes/variables.php:1227
-#: includes/variables.php:1244
-#: includes/variables.php:1270
-#: includes/variables.php:1289
-#: includes/variables.php:1304
-#: includes/variables.php:1322
-#: includes/variables.php:1340
-#: includes/variables.php:1371
-#: includes/variables.php:1411
+#: includes/variables.php:781
+#: includes/variables.php:830
+#: includes/variables.php:859
+#: includes/variables.php:910
+#: includes/variables.php:973
+#: includes/variables.php:996
+#: includes/variables.php:1018
+#: includes/variables.php:1055
+#: includes/variables.php:1090
+#: includes/variables.php:1154
+#: includes/variables.php:1229
+#: includes/variables.php:1246
+#: includes/variables.php:1272
+#: includes/variables.php:1291
+#: includes/variables.php:1306
+#: includes/variables.php:1324
+#: includes/variables.php:1342
+#: includes/variables.php:1373
+#: includes/variables.php:1413
 msgid "Closed"
 msgstr ""
 
@@ -1956,11 +1962,11 @@ msgstr ""
 
 #: includes/variables.php:702
 #: includes/variables.php:784
-#: includes/variables.php:914
-#: includes/variables.php:995
-#: includes/variables.php:1058
-#: includes/variables.php:1126
-#: includes/variables.php:1324
+#: includes/variables.php:916
+#: includes/variables.php:997
+#: includes/variables.php:1060
+#: includes/variables.php:1128
+#: includes/variables.php:1326
 msgid "Discussion"
 msgstr ""
 
@@ -1970,17 +1976,17 @@ msgstr ""
 
 #: includes/variables.php:704
 #: includes/variables.php:744
-#: includes/variables.php:786
-#: includes/variables.php:863
-#: includes/variables.php:916
-#: includes/variables.php:1341
-#: includes/variables.php:1372
+#: includes/variables.php:788
+#: includes/variables.php:865
+#: includes/variables.php:918
+#: includes/variables.php:1343
+#: includes/variables.php:1374
 msgid "Fragrance Free"
 msgstr ""
 
 #: includes/variables.php:705
-#: includes/variables.php:1090
-#: includes/variables.php:1154
+#: includes/variables.php:1092
+#: includes/variables.php:1156
 msgid "Gay/Lesbian"
 msgstr ""
 
@@ -1989,7 +1995,7 @@ msgid "Laundry Lists Workbook"
 msgstr ""
 
 #: includes/variables.php:707
-#: includes/variables.php:1019
+#: includes/variables.php:1021
 msgid "LGBTQ+"
 msgstr ""
 
@@ -1999,25 +2005,25 @@ msgstr ""
 
 #: includes/variables.php:709
 #: includes/variables.php:748
-#: includes/variables.php:795
-#: includes/variables.php:831
-#: includes/variables.php:870
-#: includes/variables.php:924
-#: includes/variables.php:973
-#: includes/variables.php:996
-#: includes/variables.php:1021
-#: includes/variables.php:1063
-#: includes/variables.php:1096
-#: includes/variables.php:1129
-#: includes/variables.php:1160
-#: includes/variables.php:1250
-#: includes/variables.php:1276
-#: includes/variables.php:1290
-#: includes/variables.php:1306
-#: includes/variables.php:1347
-#: includes/variables.php:1377
-#: includes/variables.php:1399
-#: includes/variables.php:1451
+#: includes/variables.php:796
+#: includes/variables.php:833
+#: includes/variables.php:872
+#: includes/variables.php:926
+#: includes/variables.php:975
+#: includes/variables.php:998
+#: includes/variables.php:1023
+#: includes/variables.php:1065
+#: includes/variables.php:1098
+#: includes/variables.php:1131
+#: includes/variables.php:1162
+#: includes/variables.php:1252
+#: includes/variables.php:1278
+#: includes/variables.php:1292
+#: includes/variables.php:1308
+#: includes/variables.php:1349
+#: includes/variables.php:1379
+#: includes/variables.php:1401
+#: includes/variables.php:1453
 msgid "Men"
 msgstr ""
 
@@ -2032,36 +2038,36 @@ msgstr ""
 #: includes/variables.php:713
 #: includes/variables.php:751
 #: includes/variables.php:807
-#: includes/variables.php:836
-#: includes/variables.php:876
-#: includes/variables.php:929
-#: includes/variables.php:1068
+#: includes/variables.php:838
+#: includes/variables.php:878
+#: includes/variables.php:931
+#: includes/variables.php:1070
 msgid "Smoking Permitted"
 msgstr ""
 
 #: includes/variables.php:714
 #: includes/variables.php:752
 #: includes/variables.php:808
-#: includes/variables.php:837
-#: includes/variables.php:877
-#: includes/variables.php:930
-#: includes/variables.php:977
-#: includes/variables.php:1028
-#: includes/variables.php:1069
-#: includes/variables.php:1103
-#: includes/variables.php:1135
-#: includes/variables.php:1168
-#: includes/variables.php:1203
-#: includes/variables.php:1229
-#: includes/variables.php:1310
-#: includes/variables.php:1327
-#: includes/variables.php:1351
-#: includes/variables.php:1384
+#: includes/variables.php:839
+#: includes/variables.php:879
+#: includes/variables.php:932
+#: includes/variables.php:979
+#: includes/variables.php:1030
+#: includes/variables.php:1071
+#: includes/variables.php:1105
+#: includes/variables.php:1137
+#: includes/variables.php:1170
+#: includes/variables.php:1205
+#: includes/variables.php:1231
+#: includes/variables.php:1312
+#: includes/variables.php:1329
+#: includes/variables.php:1353
+#: includes/variables.php:1386
 msgid "Speaker"
 msgstr ""
 
 #: includes/variables.php:715
-#: includes/variables.php:1400
+#: includes/variables.php:1402
 msgid "Steps"
 msgstr ""
 
@@ -2078,38 +2084,38 @@ msgid "Traditions"
 msgstr ""
 
 #: includes/variables.php:719
-#: includes/variables.php:812
-#: includes/variables.php:842
-#: includes/variables.php:934
-#: includes/variables.php:1033
-#: includes/variables.php:1073
-#: includes/variables.php:1254
-#: includes/variables.php:1280
-#: includes/variables.php:1388
+#: includes/variables.php:814
+#: includes/variables.php:844
+#: includes/variables.php:936
+#: includes/variables.php:1035
+#: includes/variables.php:1075
+#: includes/variables.php:1256
+#: includes/variables.php:1282
+#: includes/variables.php:1390
 msgid "Wheelchair Access"
 msgstr ""
 
 #: includes/variables.php:720
 #: includes/variables.php:756
-#: includes/variables.php:814
-#: includes/variables.php:840
-#: includes/variables.php:884
-#: includes/variables.php:935
-#: includes/variables.php:983
-#: includes/variables.php:1000
-#: includes/variables.php:1035
-#: includes/variables.php:1074
-#: includes/variables.php:1110
-#: includes/variables.php:1137
-#: includes/variables.php:1175
-#: includes/variables.php:1255
-#: includes/variables.php:1281
-#: includes/variables.php:1294
-#: includes/variables.php:1312
-#: includes/variables.php:1355
-#: includes/variables.php:1390
-#: includes/variables.php:1402
-#: includes/variables.php:1454
+#: includes/variables.php:813
+#: includes/variables.php:842
+#: includes/variables.php:886
+#: includes/variables.php:937
+#: includes/variables.php:985
+#: includes/variables.php:1002
+#: includes/variables.php:1037
+#: includes/variables.php:1076
+#: includes/variables.php:1112
+#: includes/variables.php:1139
+#: includes/variables.php:1177
+#: includes/variables.php:1257
+#: includes/variables.php:1283
+#: includes/variables.php:1296
+#: includes/variables.php:1314
+#: includes/variables.php:1357
+#: includes/variables.php:1392
+#: includes/variables.php:1404
+#: includes/variables.php:1456
 msgid "Women"
 msgstr ""
 
@@ -2147,25 +2153,25 @@ msgid "Alateen"
 msgstr ""
 
 #: includes/variables.php:737
-#: includes/variables.php:851
-#: includes/variables.php:901
+#: includes/variables.php:853
+#: includes/variables.php:903
 msgid "Atheist / Agnostic"
 msgstr ""
 
 #: includes/variables.php:738
-#: includes/variables.php:772
-#: includes/variables.php:852
-#: includes/variables.php:902
-#: includes/variables.php:992
-#: includes/variables.php:1011
-#: includes/variables.php:1049
+#: includes/variables.php:777
+#: includes/variables.php:854
+#: includes/variables.php:904
+#: includes/variables.php:994
+#: includes/variables.php:1013
+#: includes/variables.php:1051
 msgid "Babysitting Available"
 msgstr ""
 
 #: includes/variables.php:739
-#: includes/variables.php:853
-#: includes/variables.php:1302
-#: includes/variables.php:1320
+#: includes/variables.php:855
+#: includes/variables.php:1304
+#: includes/variables.php:1322
 msgid "Beginner"
 msgstr ""
 
@@ -2186,21 +2192,21 @@ msgid "Families and Friends Only"
 msgstr ""
 
 #: includes/variables.php:745
-#: includes/variables.php:787
-#: includes/variables.php:864
-#: includes/variables.php:917
+#: includes/variables.php:789
+#: includes/variables.php:866
+#: includes/variables.php:919
 msgid "Gay"
 msgstr ""
 
 #: includes/variables.php:746
-#: includes/variables.php:790
-#: includes/variables.php:866
-#: includes/variables.php:919
+#: includes/variables.php:792
+#: includes/variables.php:868
+#: includes/variables.php:921
 msgid "Lesbian"
 msgstr ""
 
 #: includes/variables.php:747
-#: includes/variables.php:1128
+#: includes/variables.php:1130
 msgid "LGBTQIA+"
 msgstr ""
 
@@ -2209,41 +2215,40 @@ msgid "Parents of Alcoholics"
 msgstr ""
 
 #: includes/variables.php:750
-#: includes/variables.php:801
-#: includes/variables.php:835
-#: includes/variables.php:1024
-#: includes/variables.php:1382
+#: includes/variables.php:805
+#: includes/variables.php:837
+#: includes/variables.php:1026
+#: includes/variables.php:1384
 msgid "People of Color"
 msgstr ""
 
 #: includes/variables.php:753
-#: includes/variables.php:809
-#: includes/variables.php:838
-#: includes/variables.php:878
-#: includes/variables.php:931
-#: includes/variables.php:998
-#: includes/variables.php:1070
-#: includes/variables.php:1292
+#: includes/variables.php:840
+#: includes/variables.php:880
+#: includes/variables.php:933
+#: includes/variables.php:1000
+#: includes/variables.php:1072
+#: includes/variables.php:1294
 msgid "Step Meeting"
 msgstr ""
 
 #: includes/variables.php:754
-#: includes/variables.php:811
-#: includes/variables.php:839
-#: includes/variables.php:882
-#: includes/variables.php:933
-#: includes/variables.php:1032
-#: includes/variables.php:1136
-#: includes/variables.php:1387
+#: includes/variables.php:810
+#: includes/variables.php:841
+#: includes/variables.php:884
+#: includes/variables.php:935
+#: includes/variables.php:1034
+#: includes/variables.php:1138
+#: includes/variables.php:1389
 msgid "Transgender"
 msgstr ""
 
 #: includes/variables.php:755
-#: includes/variables.php:883
-#: includes/variables.php:982
-#: includes/variables.php:1109
-#: includes/variables.php:1138
-#: includes/variables.php:1174
+#: includes/variables.php:885
+#: includes/variables.php:984
+#: includes/variables.php:1111
+#: includes/variables.php:1140
+#: includes/variables.php:1176
 msgid "Wheelchair Accessible"
 msgstr ""
 
@@ -2268,965 +2273,970 @@ msgid "Open meetings are available to anyone interested in Alcoholics Anonymous�
 msgstr ""
 
 #: includes/variables.php:769
-#: includes/variables.php:898
-#: includes/variables.php:1009
+#: includes/variables.php:900
+#: includes/variables.php:1011
 msgid "11th Step Meditation"
 msgstr ""
 
 #: includes/variables.php:770
-#: includes/variables.php:899
-#: includes/variables.php:944
-#: includes/variables.php:991
-#: includes/variables.php:1010
-#: includes/variables.php:1368
-#: includes/variables.php:1410
+#: includes/variables.php:901
+#: includes/variables.php:946
+#: includes/variables.php:993
+#: includes/variables.php:1012
+#: includes/variables.php:1370
+#: includes/variables.php:1412
 msgid "12 Steps & 12 Traditions"
 msgstr ""
 
 #: includes/variables.php:771
-#: includes/variables.php:900
-#: includes/variables.php:946
+#: includes/variables.php:1028
+msgid "Secular"
+msgstr ""
+
+#: includes/variables.php:772
+#: includes/variables.php:902
+#: includes/variables.php:948
 msgid "As Bill Sees It"
 msgstr ""
 
 #: includes/variables.php:773
-#: includes/variables.php:903
-#: includes/variables.php:947
-#: includes/variables.php:1013
-#: includes/variables.php:1050
-#: includes/variables.php:1188
-#: includes/variables.php:1370
-msgid "Big Book"
-msgstr ""
-
-#: includes/variables.php:774
-#: includes/variables.php:904
-msgid "Birthday"
-msgstr ""
-
-#: includes/variables.php:775
-#: includes/variables.php:905
-msgid "Breakfast"
-msgstr ""
-
-#: includes/variables.php:776
-#: includes/variables.php:858
-#: includes/variables.php:909
-#: includes/variables.php:1051
-#: includes/variables.php:1086
-#: includes/variables.php:1150
-msgid "Candlelight"
-msgstr ""
-
-#: includes/variables.php:777
-#: includes/variables.php:855
-#: includes/variables.php:907
-#: includes/variables.php:1015
-#: includes/variables.php:1052
-msgid "Child-Friendly"
-msgstr ""
-
-#: includes/variables.php:779
-#: includes/variables.php:859
-#: includes/variables.php:910
-msgid "Concurrent with Al-Anon"
-msgstr ""
-
-#: includes/variables.php:780
-#: includes/variables.php:860
-#: includes/variables.php:911
+#: includes/variables.php:862
+#: includes/variables.php:913
 msgid "Concurrent with Alateen"
 msgstr ""
 
-#: includes/variables.php:781
+#: includes/variables.php:774
 #: includes/variables.php:861
 #: includes/variables.php:912
-msgid "Cross Talk Permitted"
+msgid "Concurrent with Al-Anon"
+msgstr ""
+
+#: includes/variables.php:775
+#: includes/variables.php:1371
+msgid "American Sign Language"
+msgstr ""
+
+#: includes/variables.php:776
+#: includes/variables.php:905
+#: includes/variables.php:949
+#: includes/variables.php:1015
+#: includes/variables.php:1052
+#: includes/variables.php:1190
+#: includes/variables.php:1372
+msgid "Big Book"
+msgstr ""
+
+#: includes/variables.php:778
+#: includes/variables.php:834
+#: includes/variables.php:928
+#: includes/variables.php:1066
+#: includes/variables.php:1199
+#: includes/variables.php:1381
+#: includes/variables.php:1414
+msgid "Newcomer"
+msgstr ""
+
+#: includes/variables.php:779
+msgid "Bisexual"
+msgstr ""
+
+#: includes/variables.php:780
+#: includes/variables.php:907
+msgid "Breakfast"
 msgstr ""
 
 #: includes/variables.php:782
-#: includes/variables.php:913
-#: includes/variables.php:951
-#: includes/variables.php:1057
-msgid "Daily Reflections"
+#: includes/variables.php:860
+#: includes/variables.php:911
+#: includes/variables.php:1053
+#: includes/variables.php:1088
+#: includes/variables.php:1152
+msgid "Candlelight"
 msgstr ""
 
 #: includes/variables.php:783
-msgid "Digital Basket"
+#: includes/variables.php:857
+#: includes/variables.php:909
+#: includes/variables.php:1017
+#: includes/variables.php:1054
+msgid "Child-Friendly"
 msgstr ""
 
 #: includes/variables.php:785
-#: includes/variables.php:915
+msgid "Digital Basket"
+msgstr ""
+
+#: includes/variables.php:786
+#: includes/variables.php:917
 msgid "Dual Diagnosis"
 msgstr ""
 
-#: includes/variables.php:788
-#: includes/variables.php:865
-#: includes/variables.php:918
+#: includes/variables.php:787
+#: includes/variables.php:915
+#: includes/variables.php:953
+#: includes/variables.php:1059
+msgid "Daily Reflections"
+msgstr ""
+
+#: includes/variables.php:790
+#: includes/variables.php:867
+#: includes/variables.php:920
 msgid "Grapevine"
 msgstr ""
 
-#: includes/variables.php:789
-#: includes/variables.php:1017
-#: includes/variables.php:1374
-msgid "Indigenous"
-msgstr ""
-
 #: includes/variables.php:791
-#: includes/variables.php:830
-#: includes/variables.php:867
-#: includes/variables.php:920
-#: includes/variables.php:1018
-#: includes/variables.php:1060
-#: includes/variables.php:1376
-msgid "Literature"
-msgstr ""
-
-#: includes/variables.php:792
-#: includes/variables.php:921
-#: includes/variables.php:953
-msgid "Living Sober"
+#: includes/variables.php:906
+msgid "Birthday"
 msgstr ""
 
 #: includes/variables.php:793
-#: includes/variables.php:829
-#: includes/variables.php:868
-#: includes/variables.php:922
-#: includes/variables.php:1061
-#: includes/variables.php:1249
-#: includes/variables.php:1275
-#: includes/variables.php:1293
-#: includes/variables.php:1375
+#: includes/variables.php:831
+#: includes/variables.php:870
+#: includes/variables.php:924
+#: includes/variables.php:1063
+#: includes/variables.php:1251
+#: includes/variables.php:1277
+#: includes/variables.php:1295
+#: includes/variables.php:1377
 msgid "LGBTQ"
 msgstr ""
 
 #: includes/variables.php:794
+#: includes/variables.php:832
 #: includes/variables.php:869
-#: includes/variables.php:923
-#: includes/variables.php:955
+#: includes/variables.php:922
 #: includes/variables.php:1020
 #: includes/variables.php:1062
-#: includes/variables.php:1097
-#: includes/variables.php:1130
-#: includes/variables.php:1161
-#: includes/variables.php:1195
-#: includes/variables.php:1305
-#: includes/variables.php:1346
-msgid "Meditation"
+#: includes/variables.php:1378
+msgid "Literature"
 msgstr ""
 
-#: includes/variables.php:796
-#: includes/variables.php:925
-#: includes/variables.php:1378
-msgid "Native American"
+#: includes/variables.php:795
+#: includes/variables.php:923
+#: includes/variables.php:955
+msgid "Living Sober"
 msgstr ""
 
 #: includes/variables.php:797
-#: includes/variables.php:832
-#: includes/variables.php:926
+#: includes/variables.php:871
+#: includes/variables.php:925
+#: includes/variables.php:957
+#: includes/variables.php:1022
 #: includes/variables.php:1064
+#: includes/variables.php:1099
+#: includes/variables.php:1132
+#: includes/variables.php:1163
 #: includes/variables.php:1197
-#: includes/variables.php:1379
-#: includes/variables.php:1412
-msgid "Newcomer"
+#: includes/variables.php:1307
+#: includes/variables.php:1348
+msgid "Meditation"
 msgstr ""
 
 #: includes/variables.php:798
-#: includes/variables.php:1131
+#: includes/variables.php:927
+#: includes/variables.php:1380
+msgid "Native American"
+msgstr ""
+
+#: includes/variables.php:799
+#: includes/variables.php:1133
 msgid "Non-Binary"
 msgstr ""
 
 #: includes/variables.php:800
-#: includes/variables.php:834
-msgid "Outdoor Meeting"
+#: includes/variables.php:1019
+#: includes/variables.php:1376
+msgid "Indigenous"
 msgstr ""
 
 #: includes/variables.php:802
-msgid "Professionals"
-msgstr ""
-
-#: includes/variables.php:803
-msgid "Proof of Attendance"
-msgstr ""
-
-#: includes/variables.php:804
-#: includes/variables.php:1026
-msgid "Secular"
-msgstr ""
-
-#: includes/variables.php:805
-#: includes/variables.php:1027
-msgid "Seniors"
-msgstr ""
-
-#: includes/variables.php:806
-#: includes/variables.php:827
-#: includes/variables.php:875
-#: includes/variables.php:928
-#: includes/variables.php:1067
-msgid "Sign Language"
-msgstr ""
-
-#: includes/variables.php:810
-#: includes/variables.php:932
-#: includes/variables.php:1031
-#: includes/variables.php:1072
-#: includes/variables.php:1354
-msgid "Tradition Study"
-msgstr ""
-
-#: includes/variables.php:813
-#: includes/variables.php:843
-#: includes/variables.php:1034
-#: includes/variables.php:1389
-msgid "Wheelchair-Accessible Bathroom"
-msgstr ""
-
-#: includes/variables.php:815
-#: includes/variables.php:841
-#: includes/variables.php:886
-#: includes/variables.php:936
-#: includes/variables.php:1001
-#: includes/variables.php:1037
-#: includes/variables.php:1075
-#: includes/variables.php:1111
-#: includes/variables.php:1139
-#: includes/variables.php:1176
-msgid "Young People"
-msgstr ""
-
-#: includes/variables.php:819
-msgid "CMA"
-msgstr ""
-
-#: includes/variables.php:821
-msgid "Crystal Meth Anonymous"
-msgstr ""
-
-#: includes/variables.php:823
-msgid "Closed meetings are for C.M.A members only, or for those who have a using problem and “have a desire to stop using.”"
-msgstr ""
-
-#: includes/variables.php:824
-msgid "Open meetings are available to anyone interested in Crystal Meth Anonymous’ program of recovery from using. Non users may attend open meetings as observers."
-msgstr ""
-
-#: includes/variables.php:847
-msgid "CoDA"
-msgstr ""
-
-#: includes/variables.php:849
-msgid "Co-Dependents Anonymous"
-msgstr ""
-
-#: includes/variables.php:856
-#: includes/variables.php:1338
-msgid "Chips"
-msgstr ""
-
-#: includes/variables.php:862
-msgid "Daily"
-msgstr ""
-
-#: includes/variables.php:872
-msgid "Q & A"
-msgstr ""
-
-#: includes/variables.php:873
-msgid "Reading"
-msgstr ""
-
-#: includes/variables.php:874
-msgid "Sharing"
-msgstr ""
-
-#: includes/variables.php:879
-msgid "Teens"
-msgstr ""
-
-#: includes/variables.php:880
-#: includes/variables.php:1353
-msgid "Topic Discussion"
-msgstr ""
-
-#: includes/variables.php:881
-#: includes/variables.php:1107
-#: includes/variables.php:1172
-msgid "Tradition"
-msgstr ""
-
-#: includes/variables.php:885
-#: includes/variables.php:1036
-#: includes/variables.php:1213
-msgid "Writing"
-msgstr ""
-
-#: includes/variables.php:890
-msgid "CA"
-msgstr ""
-
-#: includes/variables.php:892
-msgid "Cocaine Anonymous"
-msgstr ""
-
-#: includes/variables.php:894
-msgid "This meeting is closed; only those who have a desire to stop using may attend."
-msgstr ""
-
-#: includes/variables.php:906
-msgid "Business"
-msgstr ""
-
-#: includes/variables.php:940
-msgid "CEA-HOW"
-msgstr ""
-
-#: includes/variables.php:942
-msgid "Compulsive Eaters Anonymous-HOW"
-msgstr ""
-
-#: includes/variables.php:945
-msgid "AA Comes of Age"
-msgstr ""
-
-#: includes/variables.php:949
-msgid "Came to Believe"
-msgstr ""
-
-#: includes/variables.php:950
-msgid "CEA-HOW Concept/Tools"
-msgstr ""
-
-#: includes/variables.php:952
-msgid "Happy Joyous and Free"
-msgstr ""
-
-#: includes/variables.php:954
-#: includes/variables.php:1194
-msgid "Maintenance"
-msgstr ""
-
-#: includes/variables.php:956
-msgid "Pitch/Speaker"
-msgstr ""
-
-#: includes/variables.php:957
-msgid "Promises"
-msgstr ""
-
-#: includes/variables.php:958
-msgid "Relapse and Recovery"
-msgstr ""
-
-#: includes/variables.php:959
-msgid "Steps/Traditions"
-msgstr ""
-
-#: includes/variables.php:960
-#: includes/variables.php:1030
-msgid "Topic/Discussion"
-msgstr ""
-
-#: includes/variables.php:964
-msgid "DA"
-msgstr ""
-
-#: includes/variables.php:966
-msgid "Debtors Anonymous"
-msgstr ""
-
-#: includes/variables.php:968
-msgid "Abundance"
-msgstr ""
-
-#: includes/variables.php:969
-msgid "Artist"
-msgstr ""
-
-#: includes/variables.php:970
-msgid "Business Owner"
-msgstr ""
-
-#: includes/variables.php:972
-msgid "Clutter"
-msgstr ""
-
-#: includes/variables.php:974
-msgid "Numbers"
-msgstr ""
-
-#: includes/variables.php:976
-msgid "Prosperity"
-msgstr ""
-
-#: includes/variables.php:978
-#: includes/variables.php:1311
-#: includes/variables.php:1352
-#: includes/variables.php:1385
-msgid "Step Study"
-msgstr ""
-
-#: includes/variables.php:980
-msgid "Toolkit"
-msgstr ""
-
-#: includes/variables.php:981
-msgid "Vision"
-msgstr ""
-
-#: includes/variables.php:987
-msgid "DAA"
-msgstr ""
-
-#: includes/variables.php:989
-msgid "Drug Addicts Anonymous"
-msgstr ""
-
-#: includes/variables.php:993
-msgid "Big Book Study"
-msgstr ""
-
-#: includes/variables.php:999
-msgid "Step Speaker"
-msgstr ""
-
-#: includes/variables.php:1005
-msgid "EDA"
-msgstr ""
-
-#: includes/variables.php:1007
-msgid "Eating Disorders Anonymous"
-msgstr ""
-
-#: includes/variables.php:1012
-msgid "Beginners'"
-msgstr ""
-
-#: includes/variables.php:1014
-msgid "Chair's Choice"
-msgstr ""
-
-#: includes/variables.php:1023
-#: includes/variables.php:1133
+#: includes/variables.php:1025
+#: includes/variables.php:1135
 msgid "Outdoor"
 msgstr ""
 
-#: includes/variables.php:1025
+#: includes/variables.php:803
+msgid "Professionals"
+msgstr ""
+
+#: includes/variables.php:804
+msgid "Proof of Attendance"
+msgstr ""
+
+#: includes/variables.php:806
+#: includes/variables.php:1029
+msgid "Seniors"
+msgstr ""
+
+#: includes/variables.php:809
+#: includes/variables.php:980
+#: includes/variables.php:1313
+#: includes/variables.php:1354
+#: includes/variables.php:1387
+msgid "Step Study"
+msgstr ""
+
+#: includes/variables.php:812
+#: includes/variables.php:934
+#: includes/variables.php:1033
+#: includes/variables.php:1074
+#: includes/variables.php:1356
+msgid "Tradition Study"
+msgstr ""
+
+#: includes/variables.php:815
+#: includes/variables.php:845
+#: includes/variables.php:1036
+#: includes/variables.php:1391
+msgid "Wheelchair-Accessible Bathroom"
+msgstr ""
+
+#: includes/variables.php:816
+#: includes/variables.php:863
+#: includes/variables.php:914
+msgid "Cross Talk Permitted"
+msgstr ""
+
+#: includes/variables.php:817
+#: includes/variables.php:843
+#: includes/variables.php:888
+#: includes/variables.php:938
+#: includes/variables.php:1003
+#: includes/variables.php:1039
+#: includes/variables.php:1077
+#: includes/variables.php:1113
+#: includes/variables.php:1141
+#: includes/variables.php:1178
+msgid "Young People"
+msgstr ""
+
+#: includes/variables.php:821
+msgid "CMA"
+msgstr ""
+
+#: includes/variables.php:823
+msgid "Crystal Meth Anonymous"
+msgstr ""
+
+#: includes/variables.php:825
+msgid "Closed meetings are for C.M.A members only, or for those who have a using problem and “have a desire to stop using.”"
+msgstr ""
+
+#: includes/variables.php:826
+msgid "Open meetings are available to anyone interested in Crystal Meth Anonymous’ program of recovery from using. Non users may attend open meetings as observers."
+msgstr ""
+
+#: includes/variables.php:829
+#: includes/variables.php:877
+#: includes/variables.php:930
+#: includes/variables.php:1069
+msgid "Sign Language"
+msgstr ""
+
+#: includes/variables.php:836
+msgid "Outdoor Meeting"
+msgstr ""
+
+#: includes/variables.php:849
+msgid "CoDA"
+msgstr ""
+
+#: includes/variables.php:851
+msgid "Co-Dependents Anonymous"
+msgstr ""
+
+#: includes/variables.php:858
+#: includes/variables.php:1340
+msgid "Chips"
+msgstr ""
+
+#: includes/variables.php:864
+msgid "Daily"
+msgstr ""
+
+#: includes/variables.php:874
+msgid "Q & A"
+msgstr ""
+
+#: includes/variables.php:875
+msgid "Reading"
+msgstr ""
+
+#: includes/variables.php:876
+msgid "Sharing"
+msgstr ""
+
+#: includes/variables.php:881
+msgid "Teens"
+msgstr ""
+
+#: includes/variables.php:882
+#: includes/variables.php:1355
+msgid "Topic Discussion"
+msgstr ""
+
+#: includes/variables.php:883
+#: includes/variables.php:1109
+#: includes/variables.php:1174
+msgid "Tradition"
+msgstr ""
+
+#: includes/variables.php:887
+#: includes/variables.php:1038
+#: includes/variables.php:1215
+msgid "Writing"
+msgstr ""
+
+#: includes/variables.php:892
+msgid "CA"
+msgstr ""
+
+#: includes/variables.php:894
+msgid "Cocaine Anonymous"
+msgstr ""
+
+#: includes/variables.php:896
+msgid "This meeting is closed; only those who have a desire to stop using may attend."
+msgstr ""
+
+#: includes/variables.php:908
+msgid "Business"
+msgstr ""
+
+#: includes/variables.php:942
+msgid "CEA-HOW"
+msgstr ""
+
+#: includes/variables.php:944
+msgid "Compulsive Eaters Anonymous-HOW"
+msgstr ""
+
+#: includes/variables.php:947
+msgid "AA Comes of Age"
+msgstr ""
+
+#: includes/variables.php:951
+msgid "Came to Believe"
+msgstr ""
+
+#: includes/variables.php:952
+msgid "CEA-HOW Concept/Tools"
+msgstr ""
+
+#: includes/variables.php:954
+msgid "Happy Joyous and Free"
+msgstr ""
+
+#: includes/variables.php:956
+#: includes/variables.php:1196
+msgid "Maintenance"
+msgstr ""
+
+#: includes/variables.php:958
+msgid "Pitch/Speaker"
+msgstr ""
+
+#: includes/variables.php:959
+msgid "Promises"
+msgstr ""
+
+#: includes/variables.php:960
+msgid "Relapse and Recovery"
+msgstr ""
+
+#: includes/variables.php:961
+msgid "Steps/Traditions"
+msgstr ""
+
+#: includes/variables.php:962
+#: includes/variables.php:1032
+msgid "Topic/Discussion"
+msgstr ""
+
+#: includes/variables.php:966
+msgid "DA"
+msgstr ""
+
+#: includes/variables.php:968
+msgid "Debtors Anonymous"
+msgstr ""
+
+#: includes/variables.php:970
+msgid "Abundance"
+msgstr ""
+
+#: includes/variables.php:971
+msgid "Artist"
+msgstr ""
+
+#: includes/variables.php:972
+msgid "Business Owner"
+msgstr ""
+
+#: includes/variables.php:974
+msgid "Clutter"
+msgstr ""
+
+#: includes/variables.php:976
+msgid "Numbers"
+msgstr ""
+
+#: includes/variables.php:978
+msgid "Prosperity"
+msgstr ""
+
+#: includes/variables.php:982
+msgid "Toolkit"
+msgstr ""
+
+#: includes/variables.php:983
+msgid "Vision"
+msgstr ""
+
+#: includes/variables.php:989
+msgid "DAA"
+msgstr ""
+
+#: includes/variables.php:991
+msgid "Drug Addicts Anonymous"
+msgstr ""
+
+#: includes/variables.php:995
+msgid "Big Book Study"
+msgstr ""
+
+#: includes/variables.php:1001
+msgid "Step Speaker"
+msgstr ""
+
+#: includes/variables.php:1007
+msgid "EDA"
+msgstr ""
+
+#: includes/variables.php:1009
+msgid "Eating Disorders Anonymous"
+msgstr ""
+
+#: includes/variables.php:1014
+msgid "Beginners'"
+msgstr ""
+
+#: includes/variables.php:1016
+msgid "Chair's Choice"
+msgstr ""
+
+#: includes/variables.php:1027
 msgid "Rotating Format"
 msgstr ""
 
-#: includes/variables.php:1029
-#: includes/variables.php:1104
-#: includes/variables.php:1169
-#: includes/variables.php:1328
+#: includes/variables.php:1031
+#: includes/variables.php:1106
+#: includes/variables.php:1171
+#: includes/variables.php:1330
 msgid "Step"
 msgstr ""
 
-#: includes/variables.php:1041
+#: includes/variables.php:1043
 msgid "GA"
 msgstr ""
 
-#: includes/variables.php:1043
+#: includes/variables.php:1045
 msgid "Gamblers Anonymous"
 msgstr ""
 
-#: includes/variables.php:1045
+#: includes/variables.php:1047
 msgid "This meeting is closed; only those who have a desire to stop gambling may attend."
 msgstr ""
 
-#: includes/variables.php:1048
+#: includes/variables.php:1050
 msgid "20 Questions/Beginner Focus"
 msgstr ""
 
-#: includes/variables.php:1054
+#: includes/variables.php:1056
 msgid "Combined GA/Gam Anon"
 msgstr ""
 
-#: includes/variables.php:1055
+#: includes/variables.php:1057
 msgid "Comment"
 msgstr ""
 
-#: includes/variables.php:1056
+#: includes/variables.php:1058
 msgid "Cross Comment"
 msgstr ""
 
-#: includes/variables.php:1059
+#: includes/variables.php:1061
 msgid "Gam Anon"
 msgstr ""
 
-#: includes/variables.php:1066
+#: includes/variables.php:1068
 msgid "Parking Meters Available"
 msgstr ""
 
-#: includes/variables.php:1071
-#: includes/variables.php:1106
-#: includes/variables.php:1171
-#: includes/variables.php:1209
+#: includes/variables.php:1073
+#: includes/variables.php:1108
+#: includes/variables.php:1173
+#: includes/variables.php:1211
 msgid "Topic"
 msgstr ""
 
-#: includes/variables.php:1079
+#: includes/variables.php:1081
 msgid "HA"
 msgstr ""
 
-#: includes/variables.php:1081
-msgid "Heroin Anonymous"
-msgstr ""
-
 #: includes/variables.php:1083
-#: includes/variables.php:1147
-msgid "12 Concepts"
-msgstr ""
-
-#: includes/variables.php:1084
-#: includes/variables.php:1148
-msgid "Basic Text"
+msgid "Heroin Anonymous"
 msgstr ""
 
 #: includes/variables.php:1085
 #: includes/variables.php:1149
-msgid "Beginner/Newcomer"
+msgid "12 Concepts"
+msgstr ""
+
+#: includes/variables.php:1086
+#: includes/variables.php:1150
+msgid "Basic Text"
 msgstr ""
 
 #: includes/variables.php:1087
 #: includes/variables.php:1151
-msgid "Children Welcome"
+msgid "Beginner/Newcomer"
 msgstr ""
 
 #: includes/variables.php:1089
 #: includes/variables.php:1153
-msgid "Discussion/Participation"
+msgid "Children Welcome"
 msgstr ""
 
 #: includes/variables.php:1091
 #: includes/variables.php:1155
-msgid "IP Study"
-msgstr ""
-
-#: includes/variables.php:1092
-#: includes/variables.php:1156
-msgid "It Works Study"
+msgid "Discussion/Participation"
 msgstr ""
 
 #: includes/variables.php:1093
 #: includes/variables.php:1157
-msgid "Just For Today Study"
+msgid "IP Study"
 msgstr ""
 
 #: includes/variables.php:1094
 #: includes/variables.php:1158
-#: includes/variables.php:1193
-msgid "Literature Study"
+msgid "It Works Study"
 msgstr ""
 
 #: includes/variables.php:1095
 #: includes/variables.php:1159
-msgid "Living Clean"
+msgid "Just For Today Study"
 msgstr ""
 
-#: includes/variables.php:1098
-#: includes/variables.php:1162
-msgid "Non-Smoking"
+#: includes/variables.php:1096
+#: includes/variables.php:1160
+#: includes/variables.php:1195
+msgid "Literature Study"
+msgstr ""
+
+#: includes/variables.php:1097
+#: includes/variables.php:1161
+msgid "Living Clean"
 msgstr ""
 
 #: includes/variables.php:1100
 #: includes/variables.php:1164
-msgid "Questions & Answers"
-msgstr ""
-
-#: includes/variables.php:1101
-#: includes/variables.php:1165
-msgid "Restricted Access"
+msgid "Non-Smoking"
 msgstr ""
 
 #: includes/variables.php:1102
 #: includes/variables.php:1166
+msgid "Questions & Answers"
+msgstr ""
+
+#: includes/variables.php:1103
+#: includes/variables.php:1167
+msgid "Restricted Access"
+msgstr ""
+
+#: includes/variables.php:1104
+#: includes/variables.php:1168
 msgid "Smoking"
 msgstr ""
 
-#: includes/variables.php:1105
-#: includes/variables.php:1170
+#: includes/variables.php:1107
+#: includes/variables.php:1172
 msgid "Step Working Guide Study"
 msgstr ""
 
-#: includes/variables.php:1108
-#: includes/variables.php:1173
+#: includes/variables.php:1110
+#: includes/variables.php:1175
 msgid "Format Varies"
 msgstr ""
 
-#: includes/variables.php:1115
+#: includes/variables.php:1117
 msgid "MA"
 msgstr ""
 
-#: includes/variables.php:1117
+#: includes/variables.php:1119
 msgid "Marijuana Anonymous"
 msgstr ""
 
-#: includes/variables.php:1119
+#: includes/variables.php:1121
 msgid "Closed meetings are for MA members only, or for those who have a desire to stop using marijuana."
 msgstr ""
 
-#: includes/variables.php:1120
+#: includes/variables.php:1122
 msgid "Open meetings are available to anyone interested in Marijuana Anonymous’ program of recovery from marijuana. Non-addicts may attend open meetings as observers."
 msgstr ""
 
-#: includes/variables.php:1125
+#: includes/variables.php:1127
 msgid "Closed Captions"
 msgstr ""
 
-#: includes/variables.php:1127
-#: includes/variables.php:1321
+#: includes/variables.php:1129
+#: includes/variables.php:1323
 msgid "Chip"
 msgstr ""
 
-#: includes/variables.php:1132
+#: includes/variables.php:1134
 msgid "Open to Non-Addicts"
 msgstr ""
 
-#: includes/variables.php:1134
+#: includes/variables.php:1136
 msgid "Persons of Color"
 msgstr ""
 
-#: includes/variables.php:1143
+#: includes/variables.php:1145
 msgid "NA"
 msgstr ""
 
-#: includes/variables.php:1145
+#: includes/variables.php:1147
 msgid "Narcotics Anonymous"
 msgstr ""
 
-#: includes/variables.php:1167
+#: includes/variables.php:1169
 msgid "Spiritual Principle a Day"
 msgstr ""
 
-#: includes/variables.php:1180
+#: includes/variables.php:1182
 msgid "OA"
 msgstr ""
 
-#: includes/variables.php:1182
+#: includes/variables.php:1184
 msgid "Overeaters Anonymous"
 msgstr ""
 
-#: includes/variables.php:1184
+#: includes/variables.php:1186
 msgid "11th Step"
 msgstr ""
 
-#: includes/variables.php:1185
+#: includes/variables.php:1187
 msgid "90 Day"
 msgstr ""
 
-#: includes/variables.php:1186
+#: includes/variables.php:1188
 msgid "AA 12/12"
 msgstr ""
 
-#: includes/variables.php:1187
+#: includes/variables.php:1189
 msgid "Ask-It-Basket"
 msgstr ""
 
-#: includes/variables.php:1189
+#: includes/variables.php:1191
 msgid "Dignity of Choice"
 msgstr ""
 
-#: includes/variables.php:1190
+#: includes/variables.php:1192
 msgid "For Today"
 msgstr ""
 
-#: includes/variables.php:1191
+#: includes/variables.php:1193
 msgid "Lifeline"
 msgstr ""
 
-#: includes/variables.php:1192
+#: includes/variables.php:1194
 msgid "Lifeline Sampler"
 msgstr ""
 
-#: includes/variables.php:1196
+#: includes/variables.php:1198
 msgid "New Beginnings"
 msgstr ""
 
-#: includes/variables.php:1198
+#: includes/variables.php:1200
 msgid "OA H.O.W."
 msgstr ""
 
-#: includes/variables.php:1199
+#: includes/variables.php:1201
 msgid "OA Second and/or Third Edition"
 msgstr ""
 
-#: includes/variables.php:1200
+#: includes/variables.php:1202
 msgid "OA Steps and/or Traditions Study"
 msgstr ""
 
-#: includes/variables.php:1201
+#: includes/variables.php:1203
 msgid "Relapse/12th Step Within"
 msgstr ""
 
-#: includes/variables.php:1202
+#: includes/variables.php:1204
 msgid "Seeking the Spiritual Path"
 msgstr ""
 
-#: includes/variables.php:1204
+#: includes/variables.php:1206
 msgid "Speaker/Discussion"
 msgstr ""
 
-#: includes/variables.php:1205
+#: includes/variables.php:1207
 msgid "Spirituality"
 msgstr ""
 
-#: includes/variables.php:1206
+#: includes/variables.php:1208
 msgid "Teen Friendly"
 msgstr ""
 
-#: includes/variables.php:1207
+#: includes/variables.php:1209
 msgid "The Promises"
 msgstr ""
 
-#: includes/variables.php:1208
-#: includes/variables.php:1401
+#: includes/variables.php:1210
+#: includes/variables.php:1403
 msgid "Tools"
 msgstr ""
 
-#: includes/variables.php:1210
+#: includes/variables.php:1212
 msgid "Varies"
 msgstr ""
 
-#: includes/variables.php:1211
+#: includes/variables.php:1213
 msgid "Voices of Recovery"
 msgstr ""
 
-#: includes/variables.php:1212
+#: includes/variables.php:1214
 msgid "Work Book Study"
 msgstr ""
 
-#: includes/variables.php:1223
+#: includes/variables.php:1225
 msgid "RCA"
 msgstr ""
 
-#: includes/variables.php:1225
+#: includes/variables.php:1227
 msgid "Recovering Couples Anonymous"
 msgstr ""
 
-#: includes/variables.php:1233
 #: includes/variables.php:1235
+#: includes/variables.php:1237
 msgid "Recovery Dharma"
 msgstr ""
 
-#: includes/variables.php:1237
-#: includes/variables.php:1263
+#: includes/variables.php:1239
+#: includes/variables.php:1265
 msgid "Men’s meetings are for anyone who identifies as male."
 msgstr ""
 
-#: includes/variables.php:1238
-#: includes/variables.php:1264
+#: includes/variables.php:1240
+#: includes/variables.php:1266
 msgid "Women’s meetings are for anyone who identifies as female."
 msgstr ""
 
-#: includes/variables.php:1245
-#: includes/variables.php:1271
+#: includes/variables.php:1247
+#: includes/variables.php:1273
 msgid "Dog Friendly"
 msgstr ""
 
-#: includes/variables.php:1246
-#: includes/variables.php:1272
+#: includes/variables.php:1248
+#: includes/variables.php:1274
 msgid "Eightfold Path Study"
 msgstr ""
 
-#: includes/variables.php:1247
+#: includes/variables.php:1249
 msgid "Inquiry Study"
 msgstr ""
 
-#: includes/variables.php:1248
+#: includes/variables.php:1250
 msgid "Inquiry Writing"
-msgstr ""
-
-#: includes/variables.php:1251
-#: includes/variables.php:1277
-msgid "Mindfulness Practice"
 msgstr ""
 
 #: includes/variables.php:1253
 #: includes/variables.php:1279
+msgid "Mindfulness Practice"
+msgstr ""
+
+#: includes/variables.php:1255
+#: includes/variables.php:1281
 msgid "Process Addictions"
 msgstr ""
 
-#: includes/variables.php:1259
 #: includes/variables.php:1261
+#: includes/variables.php:1263
 msgid "Refuge Recovery"
 msgstr ""
 
-#: includes/variables.php:1273
+#: includes/variables.php:1275
 msgid "Inventory Study"
 msgstr ""
 
-#: includes/variables.php:1274
+#: includes/variables.php:1276
 msgid "Inventory Writing"
 msgstr ""
 
-#: includes/variables.php:1285
+#: includes/variables.php:1287
 msgid "SAA"
 msgstr ""
 
-#: includes/variables.php:1287
+#: includes/variables.php:1289
 msgid "Sex Addicts Anonymous"
 msgstr ""
 
-#: includes/variables.php:1298
+#: includes/variables.php:1300
 msgid "SA"
 msgstr ""
 
-#: includes/variables.php:1300
+#: includes/variables.php:1302
 msgid "Sexaholics Anonymous"
 msgstr ""
 
-#: includes/variables.php:1307
+#: includes/variables.php:1309
 msgid "Mixed"
 msgstr ""
 
-#: includes/variables.php:1309
+#: includes/variables.php:1311
 msgid "Primary Purpose"
 msgstr ""
 
-#: includes/variables.php:1316
+#: includes/variables.php:1318
 msgid "SCA"
 msgstr ""
 
-#: includes/variables.php:1318
+#: includes/variables.php:1320
 msgid "Sexual Compulsives Anonymous"
 msgstr ""
 
-#: includes/variables.php:1323
+#: includes/variables.php:1325
 msgid "Court"
 msgstr ""
 
-#: includes/variables.php:1325
+#: includes/variables.php:1327
 msgid "Graphic Language"
 msgstr ""
 
-#: includes/variables.php:1332
+#: includes/variables.php:1334
 msgid "SLAA"
 msgstr ""
 
-#: includes/variables.php:1334
+#: includes/variables.php:1336
 msgid "Sex and Love Addicts Anonymous"
 msgstr ""
 
-#: includes/variables.php:1336
+#: includes/variables.php:1338
 msgid "Anorexia Focus"
 msgstr ""
 
-#: includes/variables.php:1342
+#: includes/variables.php:1344
 msgid "Getting Current"
 msgstr ""
 
-#: includes/variables.php:1343
+#: includes/variables.php:1345
 msgid "Handicapped Accessible"
 msgstr ""
 
-#: includes/variables.php:1344
+#: includes/variables.php:1346
 msgid "Healthy Relationships"
 msgstr ""
 
-#: includes/variables.php:1345
+#: includes/variables.php:1347
 msgid "Literature Reading"
 msgstr ""
 
-#: includes/variables.php:1348
+#: includes/variables.php:1350
 msgid "Newcomers"
 msgstr ""
 
-#: includes/variables.php:1350
+#: includes/variables.php:1352
 msgid "Prison"
 msgstr ""
 
-#: includes/variables.php:1364
+#: includes/variables.php:1366
 msgid "SIA"
 msgstr ""
 
-#: includes/variables.php:1366
+#: includes/variables.php:1368
 msgid "Survivors of Incest Anonymous"
 msgstr ""
 
-#: includes/variables.php:1369
-msgid "American Sign Language"
-msgstr ""
-
-#: includes/variables.php:1373
+#: includes/variables.php:1375
 msgid "Genderqueer"
 msgstr ""
 
-#: includes/variables.php:1381
+#: includes/variables.php:1383
 msgid "Open Share Format"
 msgstr ""
 
-#: includes/variables.php:1383
+#: includes/variables.php:1385
 msgid "Ritual Abuse"
 msgstr ""
 
-#: includes/variables.php:1386
+#: includes/variables.php:1388
 msgid "Steps Workshop"
 msgstr ""
 
-#: includes/variables.php:1394
+#: includes/variables.php:1396
 msgid "UA"
 msgstr ""
 
-#: includes/variables.php:1396
+#: includes/variables.php:1398
 msgid "Underearners Anonymous"
 msgstr ""
 
-#: includes/variables.php:1406
+#: includes/variables.php:1408
 msgid "VA"
 msgstr ""
 
-#: includes/variables.php:1408
+#: includes/variables.php:1410
 msgid "Violence Anonymous"
 msgstr ""
 
-#: includes/variables.php:1420
-#: templates/single-meetings.php:133
+#: includes/variables.php:1422
+#: templates/single-meetings.php:132
 msgid "Online Meeting"
 msgstr ""
 
-#: includes/variables.php:1421
+#: includes/variables.php:1423
 msgid "Location Temporarily Closed"
 msgstr ""
 
-#: includes/variables.php:1440
+#: includes/variables.php:1442
 msgid "Got an improper response from the server, try refreshing the page."
 msgstr ""
 
-#: includes/variables.php:1441
+#: includes/variables.php:1443
 msgid "Email was not sent."
 msgstr ""
 
-#: includes/variables.php:1442
+#: includes/variables.php:1444
 msgid "Enter a location in the field above."
 msgstr ""
 
-#: includes/variables.php:1443
+#: includes/variables.php:1445
 msgid "Google could not find that location."
 msgstr ""
 
-#: includes/variables.php:1444
+#: includes/variables.php:1446
 msgid "Looking up address…"
 msgstr ""
 
-#: includes/variables.php:1445
+#: includes/variables.php:1447
 msgid "There was an error getting your location."
 msgstr ""
 
-#: includes/variables.php:1446
+#: includes/variables.php:1448
 msgid "Your browser does not appear to support geolocation."
 msgstr ""
 
-#: includes/variables.php:1447
+#: includes/variables.php:1449
 msgid "Finding you…"
 msgstr ""
 
-#: includes/variables.php:1452
+#: includes/variables.php:1454
 msgid "No meetings were found matching the selected criteria."
 msgstr ""
 
 #: includes/widgets.php:12
-#: includes/widgets.php:144
+#: includes/widgets.php:141
 msgid "Upcoming Meetings"
 msgstr ""
 
@@ -3234,36 +3244,36 @@ msgstr ""
 msgid "Display a table of upcoming meetings."
 msgstr ""
 
-#: includes/widgets.php:120
+#: includes/widgets.php:117
 msgid "View More…"
 msgstr ""
 
-#: includes/widgets.php:150
+#: includes/widgets.php:147
 msgid "Title:"
 msgstr ""
 
-#: includes/widgets.php:158
+#: includes/widgets.php:155
 msgid "Show:"
 msgstr ""
 
-#: includes/widgets.php:171
+#: includes/widgets.php:168
 msgid "Message (displayed if no upcoming meetings, optional):"
 msgstr ""
 
-#: includes/widgets.php:181
-#: includes/widgets.php:232
+#: includes/widgets.php:178
+#: includes/widgets.php:229
 msgid "Style with CSS?"
 msgstr ""
 
-#: includes/widgets.php:208
+#: includes/widgets.php:205
 msgid "App Store"
 msgstr ""
 
-#: includes/widgets.php:210
+#: includes/widgets.php:207
 msgid "Display links to the Meeting Guide app in the Apple and Android app stores."
 msgstr ""
 
-#: includes/widgets.php:222
+#: includes/widgets.php:219
 msgid "Title (optional):"
 msgstr ""
 
@@ -3283,29 +3293,31 @@ msgstr ""
 msgid "Location Detail Bottom"
 msgstr ""
 
-#: templates/archive-locations.php:3
+#. translators: %s is the program name, e.g. "AA"
+#: templates/archive-locations.php:4
 #, php-format
 msgid "Index of %s Meetings"
 msgstr ""
 
-#: templates/archive-locations.php:119
+#. translators: %s is the URL of the meetings page
+#: templates/archive-locations.php:122
 #, php-format
 msgid "This page is intended for web crawlers. To find a meeting, please visit our <a href=\"%s\">meetings page</a>."
 msgstr ""
 
-#: templates/archive-locations.php:130
+#: templates/archive-locations.php:133
 msgid "Formatted Address"
 msgstr ""
 
-#: templates/archive-locations.php:132
+#: templates/archive-locations.php:135
 msgid "Sub-Region"
 msgstr ""
 
-#: templates/archive-locations.php:134
+#: templates/archive-locations.php:137
 msgid "Latitude"
 msgstr ""
 
-#: templates/archive-locations.php:135
+#: templates/archive-locations.php:138
 msgid "Longitude"
 msgstr ""
 
@@ -3399,100 +3411,100 @@ msgstr ""
 msgid "Directions"
 msgstr ""
 
-#: templates/single-locations.php:41
-#: templates/single-meetings.php:63
+#: templates/single-locations.php:40
+#: templates/single-meetings.php:62
 msgid "Back to Meetings"
 msgstr ""
 
-#: templates/single-locations.php:55
-#: templates/single-meetings.php:77
+#: templates/single-locations.php:54
+#: templates/single-meetings.php:76
 msgid "Get Directions"
 msgstr ""
 
-#: templates/single-locations.php:136
-#: templates/single-meetings.php:326
+#: templates/single-locations.php:135
+#: templates/single-meetings.php:325
 msgid "Updated"
 msgstr ""
 
 #. translators: until
-#: templates/single-meetings.php:97
+#: templates/single-meetings.php:96
 msgid " to "
 msgstr ""
 
 #. translators: %s is the name of the conference provider
-#: templates/single-meetings.php:139
+#: templates/single-meetings.php:138
 #, php-format
 msgid "Join with %s"
 msgstr ""
 
-#: templates/single-meetings.php:148
+#: templates/single-meetings.php:147
 msgid "Join by Phone"
 msgstr ""
 
-#: templates/single-meetings.php:186
+#: templates/single-meetings.php:185
 msgid "7th Tradition"
 msgstr ""
 
 #. translators: %s is the name of the contribution service
-#: templates/single-meetings.php:194
+#: templates/single-meetings.php:193
 #, php-format
 msgid "Contribute with %s"
 msgstr ""
 
 #. translators: %d is the number of other meetings at this location
-#: templates/single-meetings.php:214
+#: templates/single-meetings.php:213
 #, php-format
 msgid "%d other meeting at this location"
 msgid_plural "%d other meetings at this location"
 msgstr[0] ""
 msgstr[1] ""
 
-#: templates/single-meetings.php:245
+#: templates/single-meetings.php:244
 msgid "Contact Information"
 msgstr ""
 
 #. translators: %s is the contact's ordinal number
-#: templates/single-meetings.php:274
+#: templates/single-meetings.php:273
 #, php-format
 msgid "Contact %s"
 msgstr ""
 
 #. translators: %s is the contact's name
-#: templates/single-meetings.php:280
+#: templates/single-meetings.php:279
 #, php-format
 msgid "%s’s Email"
 msgstr ""
 
 #. translators: %s is the contact's name
-#: templates/single-meetings.php:287
+#: templates/single-meetings.php:286
 #, php-format
 msgid "%s’s Phone"
 msgstr ""
 
-#: templates/single-meetings.php:302
+#: templates/single-meetings.php:301
 msgid "This listing is provided by:"
 msgstr ""
 
-#: templates/single-meetings.php:342
+#: templates/single-meetings.php:341
 msgid "Request a change to this listing"
 msgstr ""
 
-#: templates/single-meetings.php:350
+#: templates/single-meetings.php:349
 msgid "Use this form to submit a change to the meeting information above."
 msgstr ""
 
-#: templates/single-meetings.php:354
+#: templates/single-meetings.php:353
 msgid "Your Name"
 msgstr ""
 
-#: templates/single-meetings.php:360
+#: templates/single-meetings.php:359
 msgid "Email Address"
 msgstr ""
 
-#: templates/single-meetings.php:366
+#: templates/single-meetings.php:365
 msgid "Message"
 msgstr ""
 
-#: templates/single-meetings.php:371
+#: templates/single-meetings.php:370
 msgid "Submit"
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 7.2
 Tested up to: 6.8
-Stable tag: 3.19
+Stable tag: 3.19.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -293,6 +293,10 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.19.1 =
+* Sync types with spec [more info](https://github.com/code4recovery/12-step-meeting-list/issues/924)
+* Fix issues when `$tsml_slug` is empty
 
 = 3.19 =
 * Replace Google/Mapbox with OSM/Leaflet [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1740)

--- a/templates/archive-locations.php
+++ b/templates/archive-locations.php
@@ -1,11 +1,13 @@
 <?php
 $title = sprintf(
+    // translators: %s is the program name, e.g. "AA"
     __('Index of %s Meetings', '12-step-meeting-list'),
     $tsml_programs[$tsml_program]['name']
 );
 
 $meetings = tsml_get_meetings();
 
+// translators: %s is the program name, e.g. "AA"
 $title = __(sprintf('Index of %s Meetings', $tsml_programs[$tsml_program]['name']), '12-step-meeting-list');
 
 $days = [
@@ -116,6 +118,7 @@ $schema = [
     <h1><?php echo esc_html($title); ?></h1>
     <p>
         <?php echo sprintf(
+            // translators: %s is the URL of the meetings page
             __('This page is intended for web crawlers. To find a meeting, please visit our <a href="%s">meetings page</a>.', '12-step-meeting-list'),
             esc_url(tsml_meetings_url())
         ); ?>


### PR DESCRIPTION
we have two changes that are lurking on main but haven't been released:

1. a fix for an issue @anchovie91471 reported on Slack when the `$tsml_slug` was empty
2. syncing AA meeting types with the spec

this PR bumps the version, runs translations, and adds comments to fix translation warnings

