### PR TITLE
fix/1812-discontinue-appending-unused-types

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -5,7 +5,7 @@
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Description: Manage a list of recovery meetings
- * Version: 3.19.7
+ * Version: 3.19.6
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -34,7 +34,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 define('TSML_PATH', plugin_dir_path(__FILE__));
 define('TSML_SETTINGS_PERMISSION', 'manage_options');
-define('TSML_VERSION', '3.19.7');
+define('TSML_VERSION', '3.19.6');
 
 // include these files first
 include TSML_PATH . '/includes/filter_meetings.php';

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 7.2
 Tested up to: 6.8
-Stable tag: 3.19.7
+Stable tag: 3.19.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -293,9 +293,6 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
-
-= 3.19.7 =
-* Remove code that previously appended unknown meeting type codes to the notes field on import. [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1812)
 
 = 3.19.6 =
 * Add Sign Language type for Al-Anon [more info](https://github.com/code4recovery/12-step-meeting-list/discussions/1807)


### PR DESCRIPTION
remove code in tsml_import_sanitize_meetings() that was appending unused meeting type codes to the end of the notes field