### PR TITLE
fix warnings on meeting admin page

### DIFF
--- a/includes/admin_lists.php
+++ b/includes/admin_lists.php
@@ -20,6 +20,9 @@ add_action('restrict_manage_posts', function ($post_type) {
 
     $types = [];
     foreach ($tsml_types_in_use as $type) {
+        if (!isset($tsml_programs[$tsml_program]['types'][$type])) {
+            continue;
+        }
         $types[$type] = $tsml_programs[$tsml_program]['types'][$type];
     }
     asort($types);
@@ -54,7 +57,7 @@ add_filter(
         global $post_type, $pagenow, $wpdb, $tsml_data_sources;
 
         if ($pagenow === 'edit.php' && $post_type === 'tsml_meeting' && $query->is_main_query()) {
-            
+
             $meta_query = [];
 
             if (!empty($_GET['region'])) {
@@ -98,7 +101,7 @@ add_filter(
             }
 
             if (!empty($meta_query)) {
-                $query->set('meta_query', $meta_query);            
+                $query->set('meta_query', $meta_query);
             }
         }
     }


### PR DESCRIPTION
if you switch programs you can be in a situation where the `$types_in_use` array contains types that are not part of the current program. that can lead to warnings on the meetings admin page

this PR fixes them

<img width="1728" height="1083" alt="Screenshot 2025-11-16 at 8 56 31 PM" src="https://github.com/user-attachments/assets/fb64d882-a928-4605-bac2-5a1d4734c75d" />
