### PR TITLE
propagate non-spec meeting types to all tsml-ui languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docker-compose.yml
 .vscode
 .DS_Store
 *.map
+vendor/

--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -36,6 +36,11 @@ define('TSML_PATH', plugin_dir_path(__FILE__));
 define('TSML_SETTINGS_PERMISSION', 'manage_options');
 define('TSML_VERSION', '3.19.12');
 
+// load Composer dependencies (e.g. code4recovery/spec)
+if (file_exists(TSML_PATH . 'vendor/autoload.php')) {
+    require_once TSML_PATH . 'vendor/autoload.php';
+}
+
 // include these files first
 include TSML_PATH . '/includes/filter_meetings.php';
 include TSML_PATH . '/includes/functions.php';

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,24 @@ Follow [WordPress’s official manual installation guide](https://developer.word
 
 ---
 
+## PHP Dependencies
+
+The plugin uses [Composer](https://getcomposer.org/) to manage PHP dependencies (currently `code4recovery/spec`).
+
+**For local development**, install dependencies before starting your environment:
+
+```bash
+composer install
+```
+
+**When packaging a release**, install without dev dependencies so `vendor/` is included in the zip release artifact:
+
+```bash
+composer install --no-dev --optimize-autoloader
+```
+
+---
+
 ## Plugin Configuration
 
 Once WordPress and TSML are running:

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "code4recovery/12-step-meeting-list",
+    "description": "WordPress plugin for displaying and managing 12-step recovery program meetings",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=7.2",
+        "code4recovery/spec": "*"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,61 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "423d03e0f2dd9e32fb98b290b8915ff8",
+    "packages": [
+        {
+            "name": "code4recovery/spec",
+            "version": "v1.1.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/code4recovery/spec.git",
+                "reference": "404117ad6059f9b1cf85e57124367c3223afc255"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/code4recovery/spec/zipball/404117ad6059f9b1cf85e57124367c3223afc255",
+                "reference": "404117ad6059f9b1cf85e57124367c3223afc255",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Code4Recovery\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Code for Recovery"
+                }
+            ],
+            "description": "The goal of the Meeting Guide API is help sync information about AA meetings. It was developed for the Meeting Guide app, but it is non-proprietary and other systems are encouraged to make use of it.",
+            "support": {
+                "issues": "https://github.com/code4recovery/spec/issues",
+                "source": "https://github.com/code4recovery/spec/tree/v1.1.9"
+            },
+            "time": "2026-03-06T23:05:53+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.2"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -169,6 +169,27 @@ function tsml_ui($arguments = [])
         ? $tsml_programs[$tsml_program]['type_descriptions']
         : [];
 
+    // Build strings for the current WordPress language (columns,types,descriptions).
+    // Types absent from the spec have no built-in tsml-ui translations, so also add them to every
+    // other supported language as a fallback so they remain filterable when the browser language
+    // differs from WordPress. Proper translations can be added via $tsml_ui_config['strings'][lang]['types'].
+    $custom_types = array_diff_key($types, \Code4Recovery\Spec::getTypesByLanguage('en'));
+    $strings = [
+        $tsml_language => array_replace_recursive(
+            $tsml_columns,
+            compact('types', 'type_descriptions'),
+            // Get any existing strings for this language if they exist
+            !empty($tsml_ui_config['strings'][$tsml_language]) ? $tsml_ui_config['strings'][$tsml_language] : []
+        ),
+    ];
+    if (!empty($custom_types)) {
+        foreach (array_keys(\Code4Recovery\Spec::getLanguages()) as $lang) {
+            if ($lang !== $tsml_language) {
+                $strings[$lang] = ['types' => $custom_types];
+            }
+        }
+    }
+
     // apply settings
     wp_localize_script(
         'tsml_ui',
@@ -182,14 +203,7 @@ function tsml_ui($arguments = [])
                 'feedback_emails' => array_values($tsml_feedback_addresses),
                 'flags' => $tsml_programs[$tsml_program]['flags'],
                 'language' => $defaults['language'],
-                'strings' => [
-                    $tsml_language => array_replace_recursive(
-                        $tsml_columns,
-                        compact('types', 'type_descriptions'),
-                        // Get any existing strings for this language if they exist
-                        !empty($tsml_ui_config['strings'][$tsml_language]) ? $tsml_ui_config['strings'][$tsml_language] : []
-                    ),
-                ],
+                'strings' => $strings,
             ],
             $tsml_ui_config
         )


### PR DESCRIPTION
fixes custom meeting types (like ES used by MA and other non-AA fellowships) not showing up in the type filter when the browser language differs from WordPress. 

tsml-ui switches to the browser language and looks for type labels there, but we were only outputting types for the current WordPress language. types in the spec are fine since tsml-ui has translations for those already, but anything custom just disappeared.
  
adds `code4recovery/spec` as a composer dependency and uses it to figure out which types are custom, then propagates those to all supported languages in `tsml_react_config`. site admins can still override with proper translations via `$tsml_ui_config['strings'][lang]['types']`.