### PR TITLE
Add `tsml_import_response_error` to improve HTTP response error handling

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1439,7 +1439,20 @@ add_action('tsml_scan_data_source', function ($data_source_url) {
     // try fetching
     $response = wp_safe_remote_get($data_source_url, ['timeout' => 30, 'sslverify' => false]);
 
-    if (empty($response['body']) || !($body = json_decode($response['body'], true))) {
+    // this runs unattended, so a failure has to be logged or it goes unnoticed
+    $response_error = tsml_import_response_error($response);
+
+    if ($response_error) {
+        tsml_log('data_source_error', __('Feed scan failed', '12-step-meeting-list') . ' - ' . $data_source_name, $response_error);
+        return;
+    }
+
+    if (!($body = json_decode($response['body'], true))) {
+        tsml_log(
+            'data_source_error',
+            __('Feed scan failed', '12-step-meeting-list') . ' - ' . $data_source_name,
+            __('JSON: Syntax error, malformed JSON.', '12-step-meeting-list')
+        );
         return;
     }
 

--- a/includes/functions_import.php
+++ b/includes/functions_import.php
@@ -1,6 +1,47 @@
 <?php
 
 /**
+ * inspect a data source HTTP response for transport and status errors
+ *
+ * Runs before any JSON parsing so that a security challenge or an error page
+ * is reported as such, rather than surfacing as malformed JSON.
+ *
+ * @param mixed $response return value of wp_safe_remote_get()
+ * @return string|null error message, or null when the body is worth parsing
+ */
+function tsml_import_response_error($response)
+{
+    if (is_wp_error($response)) {
+        // translators: %s is the error reported by WordPress
+        return sprintf(__('Could not reach the data source: %s.', '12-step-meeting-list'), $response->get_error_message());
+    }
+
+    if (!is_array($response)) {
+        // translators: %s is the invalid response from the data source
+        return sprintf(__('Invalid response: <pre>%s</pre>.', '12-step-meeting-list'), print_r($response, true));
+    }
+
+    $response_code = (int) wp_remote_retrieve_response_code($response);
+
+    if ($response_code < 200 || $response_code > 299) {
+        // security services answer automated requests with an HTML challenge instead of the feed
+        if (wp_remote_retrieve_header($response, 'cf-ray') || stripos(wp_remote_retrieve_body($response), 'please enable cookies') !== false) {
+            // translators: %s is the HTTP status code
+            return sprintf(__('The data source returned HTTP %s because a security service challenged the request. Whoever hosts the feed will need to allow requests from this server.', '12-step-meeting-list'), $response_code);
+        }
+
+        // translators: %1$s is the HTTP status code, %2$s is the HTTP status message
+        return sprintf(__('The data source returned HTTP %1$s %2$s.', '12-step-meeting-list'), $response_code, wp_remote_retrieve_response_message($response));
+    }
+
+    if (empty($response['body'])) {
+        return __('Data source gave an empty response, you might need to try again.', '12-step-meeting-list');
+    }
+
+    return null;
+}
+
+/**
  * trigger import of a data source to the import buffer
  *
  * @param mixed $data_source_url
@@ -46,7 +87,9 @@ function tsml_import_data_source($data_source_url, $data_source_name = '', $data
         'sslverify' => false,
     ]);
 
-    if (is_array($response) && !empty($response['body']) && ($meetings = json_decode($response['body'], true))) {
+    $response_error = tsml_import_response_error($response);
+
+    if (!$response_error && ($meetings = json_decode($response['body'], true))) {
 
         // allow reformatting as necessary
         $meetings = tsml_import_sanitize_meetings($meetings, $imported_data_source_url, $data_source_parent_region_id);
@@ -138,13 +181,9 @@ function tsml_import_data_source($data_source_url, $data_source_name = '', $data
         update_option('tsml_data_sources', $tsml_data_sources);
 
     } else {
-        $error_msg = '';
-        if (!is_array($response)) {
-            // translators: %s is the invalid response from the data source
-            $error_msg = sprintf(__('Invalid response: <pre>%s</pre>.', '12-step-meeting-list'), print_r($response, true));
-        } elseif (empty($response['body'])) {
-            $error_msg = __('Data source gave an empty response, you might need to try again.', '12-step-meeting-list');
-        } else {
+        // a usable response that failed to parse is the only case left to describe
+        $error_msg = $response_error;
+        if (!$error_msg) {
             switch (json_last_error()) {
                 case JSON_ERROR_NONE:
                     $error_msg = __('JSON: no errors.', '12-step-meeting-list');

--- a/includes/functions_import.php
+++ b/includes/functions_import.php
@@ -1,6 +1,59 @@
 <?php
 
 /**
+ * detect likely security challenge/interstitial responses
+ *
+ * Combines multiple signals (Cloudflare's cf-mitigated header, HTML content,
+ * known challenge-page markers) rather than any single one, because headers
+ * like cf-ray appear on ordinary error responses from proxied origins.
+ *
+ * @param array $response response array from wp_safe_remote_get()
+ * @return bool
+ */
+function tsml_import_is_security_challenge_response($response)
+{
+    $status_code = (int) wp_remote_retrieve_response_code($response);
+    if ($status_code >= 200 && $status_code <= 299) {
+        return false;
+    }
+
+    $body = strtolower((string) wp_remote_retrieve_body($response));
+    $content_type = strtolower((string) wp_remote_retrieve_header($response, 'content-type'));
+    $cf_mitigated = strtolower((string) wp_remote_retrieve_header($response, 'cf-mitigated'));
+
+    // explicit Cloudflare challenge signal
+    if ($cf_mitigated === 'challenge') {
+        return true;
+    }
+
+    // challenges are usually HTML interstitials, not feed payloads
+    $is_html = (strpos($content_type, 'text/html') !== false)
+        || (strpos($body, '<!doctype html') !== false)
+        || (strpos($body, '<html') !== false);
+
+    if (!$is_html) {
+        return false;
+    }
+
+    // keep this list short and high-confidence
+    $markers = [
+        '/cdn-cgi/challenge-platform/',
+        'cf-browser-verification',
+        'checking your browser before accessing',
+        'enable javascript and cookies to continue',
+        'please enable cookies',
+    ];
+
+    foreach ($markers as $marker) {
+        if (strpos($body, $marker) !== false) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * inspect a data source HTTP response for transport and status errors
  *
  * Runs before any JSON parsing so that a security challenge or an error page
@@ -25,7 +78,7 @@ function tsml_import_response_error($response)
 
     if ($response_code < 200 || $response_code > 299) {
         // security services answer automated requests with an HTML challenge instead of the feed
-        if (wp_remote_retrieve_header($response, 'cf-ray') || stripos(wp_remote_retrieve_body($response), 'please enable cookies') !== false) {
+        if (tsml_import_is_security_challenge_response($response)) {
             // translators: %s is the HTTP status code
             return sprintf(__('The data source returned HTTP %s because a security service challenged the request. Whoever hosts the feed will need to allow requests from this server.', '12-step-meeting-list'), $response_code);
         }


### PR DESCRIPTION
- Introduced `tsml_import_response_error` function to handle and log transport/status errors from data source responses.
- Replaced redundant error-handling code with centralized function calls.
- Enhanced error logging for feed scan failures, ensuring better visibility of issues such as malformed JSON or security challenges.