### PR TITLE
fix: don't let an unreachable data source block the auto-import queue

### DIFF
--- a/includes/admin_import.php
+++ b/includes/admin_import.php
@@ -314,7 +314,17 @@ if (!function_exists('tsml_import_page')) {
                                         </td>
 
                                         <td class="align-right">
-                                            <?php echo esc_html(date(get_option('date_format') . ' ' . get_option('time_format'), $properties['last_import'])) ?>
+                                            <?php
+                                            echo esc_html(date(get_option('date_format') . ' ' . get_option('time_format'), $properties['last_import']));
+
+                                            // a feed can keep failing for days while the timestamp above still reads OK, so say so here
+                                            if (!empty($properties['status']) && $properties['status'] === 'error') {
+                                                $last_error = isset($properties['last_error']) ? wp_strip_all_tags($properties['last_error']) : '';
+                                                ?>
+                                                <span class="dashicons dashicons-warning" title="<?php echo esc_attr($last_error) ?>"></span>
+                                                <?php
+                                            }
+                                            ?>
                                         </td>
 
                                         <td class="small">

--- a/includes/functions_import.php
+++ b/includes/functions_import.php
@@ -156,6 +156,7 @@ function tsml_import_data_source($data_source_url, $data_source_name = '', $data
             $current_data_source = [
                 'status' => 'OK',
                 'last_import' => current_time('timestamp'),
+                'last_attempt' => current_time('timestamp'),
                 'count_meetings' => 0,
                 'name' => $data_source_name,
                 'parent_region_id' => $data_source_parent_region_id,
@@ -222,8 +223,11 @@ function tsml_import_data_source($data_source_url, $data_source_name = '', $data
                 tsml_alert(__('Your meeting list is already in sync with the feed.', '12-step-meeting-list'), 'success');
             }
 
-            // update data source timestamp
+            // update data source timestamp, and clear any error recorded by a previous attempt
             $current_data_source['last_import'] = current_time('timestamp');
+            $current_data_source['last_attempt'] = $current_data_source['last_import'];
+            $current_data_source['status'] = 'OK';
+            unset($current_data_source['last_error']);
         }
 
         // import feed
@@ -263,6 +267,16 @@ function tsml_import_data_source($data_source_url, $data_source_name = '', $data
         }
         tsml_log('data_source_error', __('Import failed', '12-step-meeting-list') . ' - ' . $data_source_name, $error_msg);
         tsml_alert($error_msg, 'error');
+
+        // record the failed attempt, otherwise last_import stays frozen at the last success and
+        // tsml_auto_import_check() picks this same feed on every run, starving the other feeds
+        if ($current_data_source) {
+            $current_data_source['status'] = 'error';
+            $current_data_source['last_error'] = $error_msg;
+            $current_data_source['last_attempt'] = current_time('timestamp');
+            $tsml_data_sources[$data_source_url] = $current_data_source;
+            update_option('tsml_data_sources', $tsml_data_sources);
+        }
     }
 
 }
@@ -1300,8 +1314,14 @@ function tsml_auto_import_check()
 
         foreach ($tsml_data_sources as $data_source_url => $data_source) {
             $last_import = intval(isset($data_source['last_import']) ? $data_source['last_import'] : 0);
-            if ($cutoff > $last_import && (!$oldest_data_source_last_import || $last_import < $oldest_data_source_last_import)) {
-                $oldest_data_source_last_import = $last_import;
+            $last_attempt = intval(isset($data_source['last_attempt']) ? $data_source['last_attempt'] : 0);
+
+            // rotate on the last attempt rather than the last success, so an unreachable feed
+            // waits its turn like every other feed instead of blocking the queue
+            $last_try = max($last_import, $last_attempt);
+
+            if ($cutoff > $last_try && (!$oldest_data_source_last_import || $last_try < $oldest_data_source_last_import)) {
+                $oldest_data_source_last_import = $last_try;
                 $oldest_data_source_url = $data_source_url;
             }
         }


### PR DESCRIPTION
This bubbled up from https://github.com/code4recovery/12-step-meeting-list/discussions/1989. `tsml_auto_import_check()` refreshes one data source per run, choosing the one with the oldest last_import. last_import is only written on success, so a feed  that cannot be fetched keeps the oldest timestamp forever, gets selected on  every run, and the remaining feeds are never refreshed.

Record last_attempt on both success and failure, and rotate on the later of `last_import` and `last_attempt`. A failing feed is now retried once per 24 hours  like every other feed while last_import continues to report the last successful  sync. The failure is also stored on the data source and shown on the import  screen, since the timestamp alone gives no hint that the feed has been down.