### PR TITLE
fix: switch default map tiles from Carto to OpenStreetMap

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -5,7 +5,7 @@
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Description: Manage a list of recovery meetings
- * Version: 3.19.17
+ * Version: 3.19.18
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -34,7 +34,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 define('TSML_PATH', plugin_dir_path(__FILE__));
 define('TSML_SETTINGS_PERMISSION', 'manage_options');
-define('TSML_VERSION', '3.19.17');
+define('TSML_VERSION', '3.19.18');
 
 // include these files first
 include TSML_PATH . '/includes/filter_meetings.php';

--- a/includes/variables.php
+++ b/includes/variables.php
@@ -176,8 +176,8 @@ $tsml_export_columns = [
 // define map defaults
 $tsml_map = [
     'tiles' => [
-        'url' => 'https://{s}s.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
-        'attribution' => '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>',
+        'url' => 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+        'attribution' => '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     ]
 ];
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 7.2
 Tested up to: 7.0
-Stable tag: 3.19.17
+Stable tag: 3.19.18
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -280,6 +280,9 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.19.18 =
+* Switch default map tiles from Carto to OpenStreetMap, as Carto now requires an API key [more info](https://github.com/code4recovery/12-step-meeting-list/pull/1994)
 
 = 3.19.17 =
 * Sanitize event log for security [more info](https://github.com/code4recovery/12-step-meeting-list/issues/1979)


### PR DESCRIPTION
Carto now watermarks keyless basemap requests with "API KEY REQUIRED". Use OSM standard tiles, which need no key.

see https://github.com/code4recovery/12-step-meeting-list/discussions/1993

https://austinaa.org/meetings/?view=map
https://aasanjose.org/meetings/?view=map

See TSML UI fix here as well https://github.com/code4recovery/tsml-ui/pull/551