### PR TITLE
Prepare 3.19.18 release

### DIFF
--- a/12-step-meeting-list.php
+++ b/12-step-meeting-list.php
@@ -5,7 +5,7 @@
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Description: Manage a list of recovery meetings
- * Version: 3.19.18
+ * Version: 3.19.19
  * Requires PHP: 5.6
  * Author: Code for Recovery
  * Author URI: https://github.com/code4recovery/12-step-meeting-list
@@ -34,7 +34,7 @@ define('TSML_MEETING_GUIDE_APP_NOTIFY', 'appsupport@aa.org');
 define('TSML_MEETINGS_PERMISSION', 'edit_posts');
 define('TSML_PATH', plugin_dir_path(__FILE__));
 define('TSML_SETTINGS_PERMISSION', 'manage_options');
-define('TSML_VERSION', '3.19.18');
+define('TSML_VERSION', '3.19.19');
 
 // include these files first
 include TSML_PATH . '/includes/filter_meetings.php';

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://code4recovery.org/contribute
 Requires at least: 3.2
 Requires PHP: 7.2
 Tested up to: 7.0
-Stable tag: 3.19.18
+Stable tag: 3.19.19
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -280,6 +280,9 @@ Yes, you will need to know the key name of the field. Then include an array in y
 1. Edit location
 
 == Changelog ==
+
+= 3.19.19 =
+* Don't let an unreachable data source block the auto-import queue [more info](https://github.com/code4recovery/12-step-meeting-list/pull/1990)
 
 = 3.19.18 =
 * Switch default map tiles from Carto to OpenStreetMap, as Carto now requires an API key [more info](https://github.com/code4recovery/12-step-meeting-list/pull/1994)


### PR DESCRIPTION
= 3.19.19 =
* Don't let an unreachable data source block the auto-import queue [more info](https://github.com/code4recovery/12-step-meeting-list/pull/1990)

= 3.19.18 =
* Switch default map tiles from Carto to OpenStreetMap, as Carto now requires an API key [more info](https://github.com/code4recovery/12-step-meeting-list/pull/1994)
